### PR TITLE
fix(mcp-shell): enforce timeout and add output size limit

### DIFF
--- a/packages/mcp-shell/src/index.ts
+++ b/packages/mcp-shell/src/index.ts
@@ -101,6 +101,7 @@ export class ShellMCPClient {
     const {
       command,
       workingDirectory,
+      timeout = 60_000,
       __frontagentSecurityApproved = false,
     } = params;
     const analysis = analyzeShellCommand(command);
@@ -139,7 +140,9 @@ export class ShellMCPClient {
       };
     }
 
-    return new Promise((resolve) => {
+    const MAX_OUTPUT_BYTES = 10 * 1024 * 1024; // 10MB
+
+    return new Promise((resolvePromise) => {
       const child = analysis.structurallyTrusted
         ? spawn(analysis.argv[0], analysis.argv.slice(1), {
           cwd,
@@ -152,10 +155,30 @@ export class ShellMCPClient {
           stdio: ['ignore', 'pipe', 'pipe']
         });
 
+      let killed = false;
+      let totalBytes = 0;
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
 
+      const timer = setTimeout(() => {
+        killed = true;
+        child.kill('SIGTERM');
+        setTimeout(() => { if (!child.killed) child.kill('SIGKILL'); }, 2000);
+      }, timeout);
+
+      const killForOutputOverflow = () => {
+        if (!killed) {
+          killed = true;
+          child.kill('SIGTERM');
+        }
+      };
+
       child.stdout?.on('data', (chunk: Buffer) => {
+        totalBytes += chunk.length;
+        if (totalBytes > MAX_OUTPUT_BYTES) {
+          killForOutputOverflow();
+          return;
+        }
         stdoutChunks.push(chunk);
         if (this.streamOutput) {
           process.stdout.write(chunk);
@@ -163,6 +186,11 @@ export class ShellMCPClient {
       });
 
       child.stderr?.on('data', (chunk: Buffer) => {
+        totalBytes += chunk.length;
+        if (totalBytes > MAX_OUTPUT_BYTES) {
+          killForOutputOverflow();
+          return;
+        }
         stderrChunks.push(chunk);
         if (this.streamOutput) {
           process.stderr.write(chunk);
@@ -170,7 +198,8 @@ export class ShellMCPClient {
       });
 
       child.on('error', (error) => {
-        resolve({
+        clearTimeout(timer);
+        resolvePromise({
           success: false,
           stdout: Buffer.concat(stdoutChunks).toString(),
           stderr: Buffer.concat(stderrChunks).toString(),
@@ -180,8 +209,32 @@ export class ShellMCPClient {
       });
 
       child.on('close', (exitCode) => {
+        clearTimeout(timer);
         const stdout = Buffer.concat(stdoutChunks).toString();
         const stderr = Buffer.concat(stderrChunks).toString();
+
+        if (killed && totalBytes > MAX_OUTPUT_BYTES) {
+          resolvePromise({
+            success: false,
+            stdout,
+            stderr,
+            exitCode: 1,
+            error: `Command killed: output exceeded ${MAX_OUTPUT_BYTES} bytes limit`
+          });
+          return;
+        }
+
+        if (killed) {
+          resolvePromise({
+            success: false,
+            stdout,
+            stderr,
+            exitCode: 1,
+            error: `Command timed out after ${timeout}ms: ${command}`
+          });
+          return;
+        }
+
         const code = exitCode ?? 0;
         const success = code === 0;
 
@@ -194,7 +247,7 @@ export class ShellMCPClient {
           errorMessage = parts.join('\n');
         }
 
-        resolve({
+        resolvePromise({
           success,
           stdout,
           stderr,


### PR DESCRIPTION
## Summary

Fixes two related issues in the shell MCP client:

1. **Timeout enforcement** (#11): The `timeout` parameter was accepted in the tool schema but never actually used. Commands could hang indefinitely. Now properly kills the child process after the specified timeout (default 60s).

2. **Output size limit** (#15): `stdout`/`stderr` chunks accumulated without bound. A command producing excessive output could OOM the process. Now caps total output at 10MB and kills the process if exceeded.

## Changes
- `packages/mcp-shell/src/index.ts`: Added timeout timer with SIGTERM/SIGKILL escalation, output byte tracking with 10MB cap

## Testing
- All existing tests pass
- Typecheck passes

Closes #11, closes #15