### PR TITLE
fix(shared): escape regex metacharacters in matchGlob

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -780,10 +780,13 @@ export function normalizePath(path: string): string {
  */
 export function matchGlob(path: string, pattern: string): boolean {
   const regexPattern = pattern
-    .replace(/\*\*/g, '{{GLOBSTAR}}')
-    .replace(/\*/g, '[^/]*')
-    .replace(/\?/g, '[^/]')
-    .replace(/{{GLOBSTAR}}/g, '.*');
+    .replace(/\*\*/g, '\0GLOBSTAR\0')
+    .replace(/\*/g, '\0STAR\0')
+    .replace(/\?/g, '\0QUESTION\0')
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\0GLOBSTAR\0/g, '.*')
+    .replace(/\0STAR\0/g, '[^/]*')
+    .replace(/\0QUESTION\0/g, '[^/]');
   const regex = new RegExp(`^${regexPattern}$`);
   return regex.test(normalizePath(path));
 }


### PR DESCRIPTION
## Summary

The `matchGlob` function converted glob patterns to regex but did not escape regex metacharacters like `.`, `(`, `)`, `[`, `]`, `+`, `{`, `}`. This caused patterns like `src/utils.ts` to incorrectly match `src/utilsXts` because `.` became regex any-char.

## Fix

Escape all regex metacharacters before performing glob-to-regex conversion, using null-byte placeholders to preserve glob tokens (`**`, `*`, `?`) through the escaping step.

## Testing
- Typecheck passes
- Verified: exact match, dot escaping, globstar, star, question mark, parentheses in paths

Closes #12