### PR TITLE
fix(shared): skip undefined values in deepMerge

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -747,6 +747,7 @@ export function deepMerge<T extends Record<string, unknown>>(target: T, source: 
   for (const key in source) {
     if (Object.prototype.hasOwnProperty.call(source, key)) {
       const sourceValue = source[key];
+      if (sourceValue === undefined) continue;
       const targetValue = result[key];
       if (
         sourceValue !== null &&


### PR DESCRIPTION
## Summary

`deepMerge` was overwriting existing target values with `undefined` when the source object had undefined properties. This is incorrect for a merge operation where `Partial<T>` semantics mean "not specified" rather than "set to undefined".

## Impact Note

This function has HIGH upstream impact (8 symbols, 4 processes including SDD config parsing and CLI commands). However, the fix is strictly corrective — callers already expect `undefined` to mean "keep the existing value", so this aligns behavior with intent.

## Fix

Added `if (sourceValue === undefined) continue;` before processing each key. Explicit `null` still overwrites as intended.

## Testing
- Typecheck passes
- Verified: undefined skipped, null overwrites, nested merge preserved

Closes #13