### PR TITLE
fix(mcp-file): handle non-existent paths in path-safety helpers

### DIFF
--- a/packages/mcp-file/src/path-safety.ts
+++ b/packages/mcp-file/src/path-safety.ts
@@ -176,11 +176,13 @@ export function assertWritableByPolicy(input: {
 }
 
 export function isRegularFile(path: string): boolean {
-  return statSync(path).isFile();
+  const stat = statSync(path, { throwIfNoEntry: false });
+  return stat?.isFile() ?? false;
 }
 
 export function isDirectory(path: string): boolean {
-  return statSync(path).isDirectory();
+  const stat = statSync(path, { throwIfNoEntry: false });
+  return stat?.isDirectory() ?? false;
 }
 
 export function isUnsafeGlobPattern(pattern: string): boolean {


### PR DESCRIPTION
## Summary

`isRegularFile` and `isDirectory` used `statSync(path)` which throws `ENOENT` on non-existent paths. These are exported utilities that may be called without prior existence checks.

## Fix

Use `statSync(path, { throwIfNoEntry: false })` (Node 15.3+) and return `false` when stat is `undefined`.

## Testing
- All existing tests pass (6/6)
- Typecheck passes

Closes #14