### PR TITLE
refactor(shared): centralize default LLM temperature and maxTokens

### DIFF
--- a/apps/cli/src/bootstrap.ts
+++ b/apps/cli/src/bootstrap.ts
@@ -8,6 +8,7 @@
 import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { DEFAULT_LLM_MAX_TOKENS, DEFAULT_LLM_TEMPERATURE } from '@frontagent/shared';
 
 const currentModuleDir = dirname(fileURLToPath(import.meta.url));
 
@@ -95,8 +96,8 @@ export function resolveLLMConfigFromOptions(options: {
     model,
     baseURL: resolveProviderBaseURL(provider, options.baseUrl),
     apiKey: resolveProviderApiKey(provider, options.apiKey),
-    maxTokens: parseOptionalInt(options.maxTokens) ?? 4096,
-    temperature: parseOptionalFloat(options.temperature) ?? 0.2,
+    maxTokens: parseOptionalInt(options.maxTokens) ?? DEFAULT_LLM_MAX_TOKENS,
+    temperature: parseOptionalFloat(options.temperature) ?? DEFAULT_LLM_TEMPERATURE,
     topP: parseOptionalFloat(options.topP) ?? parseOptionalFloat(process.env.TOP_P),
     topK: parseOptionalInt(options.topK) ?? parseOptionalInt(process.env.TOP_K),
   } as const;

--- a/packages/runtime-node/src/config.ts
+++ b/packages/runtime-node/src/config.ts
@@ -3,6 +3,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { AgentConfig, FilesenseConfig, RagConfig } from '@frontagent/core';
 import type { SecurityMode, TaskType } from '@frontagent/shared';
+import { DEFAULT_LLM_MAX_TOKENS, DEFAULT_LLM_TEMPERATURE } from '@frontagent/shared';
 
 export type LLMProvider = 'openai' | 'anthropic';
 
@@ -347,8 +348,8 @@ export function resolveRuntimeConfig(
       model,
       baseURL: resolvedLlmBaseURL,
       apiKey: resolvedLlmApiKey,
-      maxTokens: parseOptionalInt(input.maxTokens) ?? 4096,
-      temperature: parseOptionalFloat(input.temperature) ?? 0.7,
+      maxTokens: parseOptionalInt(input.maxTokens) ?? DEFAULT_LLM_MAX_TOKENS,
+      temperature: parseOptionalFloat(input.temperature) ?? DEFAULT_LLM_TEMPERATURE,
       topP: parseOptionalFloat(input.topP) ?? parseOptionalFloat(process.env.TOP_P),
       topK: parseOptionalInt(input.topK) ?? parseOptionalInt(process.env.TOP_K),
     },

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -712,6 +712,9 @@ export interface ValidationResult {
 // 工具函数
 // ============================================================================
 
+export const DEFAULT_LLM_TEMPERATURE = 0.2;
+export const DEFAULT_LLM_MAX_TOKENS = 4096;
+
 /**
  * 生成唯一 ID
  */


### PR DESCRIPTION
## Summary

CLI bootstrap used temperature 0.2 while runtime-node config used 0.7 as the default. This caused the same model to behave differently depending on which code path resolved the config.

## Fix

Extracted shared constants in `@frontagent/shared`:
- `DEFAULT_LLM_TEMPERATURE = 0.2` (appropriate for code-generation agents)
- `DEFAULT_LLM_MAX_TOKENS = 4096`

Both `apps/cli/src/bootstrap.ts` and `packages/runtime-node/src/config.ts` now import and use these constants.

## Testing
- All typechecks pass (shared, runtime-node, cli)
- runtime-node tests pass (10/10)

Closes #16