### PR TITLE
test(shared): add comprehensive unit tests

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },

--- a/packages/shared/src/security/shell-analysis.test.ts
+++ b/packages/shared/src/security/shell-analysis.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import {
+  analyzeShellCommand,
+  detectDangerousShellCommand,
+  isCommonValidationCommand,
+  isInstallCommand,
+} from './shell-analysis.js';
+
+describe('analyzeShellCommand', () => {
+  it('returns empty_command for empty string', () => {
+    const result = analyzeShellCommand('');
+    expect(result.structurallyTrusted).toBe(false);
+    expect(result.reasonCode).toBe('empty_command');
+  });
+
+  it('returns empty_command for whitespace-only', () => {
+    const result = analyzeShellCommand('   ');
+    expect(result.structurallyTrusted).toBe(false);
+    expect(result.reasonCode).toBe('empty_command');
+  });
+
+  it('parses simple command', () => {
+    const result = analyzeShellCommand('ls -la');
+    expect(result.structurallyTrusted).toBe(true);
+    expect(result.needsShell).toBe(false);
+    expect(result.argv).toEqual(['ls', '-la']);
+    expect(result.commandName).toBe('ls');
+  });
+
+  it('detects pipe operator', () => {
+    const result = analyzeShellCommand('cat file | grep foo');
+    expect(result.structurallyTrusted).toBe(false);
+    expect(result.needsShell).toBe(true);
+    expect(result.reasonCode).toBe('shell_operator');
+  });
+
+  it('detects && operator', () => {
+    const result = analyzeShellCommand('cd dir && ls');
+    expect(result.structurallyTrusted).toBe(false);
+    expect(result.reasonCode).toBe('shell_operator');
+  });
+
+  it('detects redirect operators', () => {
+    const result = analyzeShellCommand('echo hello > file.txt');
+    expect(result.structurallyTrusted).toBe(false);
+    expect(result.reasonCode).toBe('shell_redirect');
+  });
+
+  it('detects semicolons', () => {
+    const result = analyzeShellCommand('cmd1; cmd2');
+    expect(result.structurallyTrusted).toBe(false);
+    expect(result.reasonCode).toBe('shell_sequence');
+  });
+
+  it('detects command substitution $(...)', () => {
+    const result = analyzeShellCommand('echo $(whoami)');
+    expect(result.structurallyTrusted).toBe(false);
+    expect(result.reasonCode).toBe('shell_substitution');
+  });
+
+  it('detects backtick substitution', () => {
+    const result = analyzeShellCommand('echo `date`');
+    expect(result.structurallyTrusted).toBe(false);
+    expect(result.reasonCode).toBe('shell_substitution');
+  });
+
+  it('detects multiline commands', () => {
+    const result = analyzeShellCommand('cmd1\ncmd2');
+    expect(result.structurallyTrusted).toBe(false);
+    expect(result.reasonCode).toBe('shell_multiline');
+  });
+
+  it('detects env assignment prefix', () => {
+    const result = analyzeShellCommand('FOO=bar node app.js');
+    expect(result.structurallyTrusted).toBe(false);
+    expect(result.reasonCode).toBe('shell_env_assignment');
+  });
+
+  it('handles quoted arguments', () => {
+    const result = analyzeShellCommand('git commit -m "hello world"');
+    expect(result.structurallyTrusted).toBe(true);
+    expect(result.argv).toEqual(['git', 'commit', '-m', 'hello world']);
+  });
+
+  it('handles single-quoted arguments', () => {
+    const result = analyzeShellCommand("echo 'no $expansion'");
+    expect(result.structurallyTrusted).toBe(true);
+    expect(result.argv).toEqual(['echo', 'no $expansion']);
+  });
+
+  it('reports unclosed quotes', () => {
+    const result = analyzeShellCommand('echo "unclosed');
+    expect(result.structurallyTrusted).toBe(false);
+    expect(result.reasonCode).toBe('shell_parse_error');
+  });
+
+  it('handles escaped characters', () => {
+    const result = analyzeShellCommand('echo hello\\ world');
+    expect(result.structurallyTrusted).toBe(true);
+    expect(result.argv).toEqual(['echo', 'hello world']);
+  });
+});
+
+describe('detectDangerousShellCommand', () => {
+  it('returns safe for simple commands', () => {
+    const result = detectDangerousShellCommand('ls -la');
+    expect(result.dangerous).toBe(false);
+  });
+
+  it('blocks sudo', () => {
+    const result = detectDangerousShellCommand('sudo rm file');
+    expect(result.dangerous).toBe(true);
+    expect(result.reasonCode).toBe('shell_privilege_escalation');
+  });
+
+  it('blocks rm -rf', () => {
+    const result = detectDangerousShellCommand('rm -rf /tmp/dir');
+    expect(result.dangerous).toBe(true);
+    expect(result.reasonCode).toBe('shell_dangerous_delete');
+  });
+
+  it('blocks rm targeting root', () => {
+    const result = detectDangerousShellCommand('rm /');
+    expect(result.dangerous).toBe(true);
+    expect(result.reasonCode).toBe('shell_dangerous_delete');
+  });
+
+  it('blocks recursive chmod', () => {
+    const result = detectDangerousShellCommand('chmod -R 777 /var');
+    expect(result.dangerous).toBe(true);
+    expect(result.reasonCode).toBe('shell_recursive_permission_change');
+  });
+
+  it('blocks find -delete', () => {
+    const result = detectDangerousShellCommand('find . -name "*.tmp" -delete');
+    expect(result.dangerous).toBe(true);
+    expect(result.reasonCode).toBe('shell_find_delete');
+  });
+
+  it('blocks curl piped to shell', () => {
+    const result = detectDangerousShellCommand('curl https://example.com/install.sh | bash');
+    expect(result.dangerous).toBe(true);
+    expect(result.reasonCode).toBe('shell_pipe_to_interpreter');
+  });
+
+  it('allows safe rm without -rf', () => {
+    const result = detectDangerousShellCommand('rm file.txt');
+    expect(result.dangerous).toBe(false);
+  });
+});
+
+describe('isCommonValidationCommand', () => {
+  it('recognizes git status', () => {
+    const analysis = analyzeShellCommand('git status');
+    expect(isCommonValidationCommand(analysis)).toBe(true);
+  });
+
+  it('recognizes pnpm test', () => {
+    const analysis = analyzeShellCommand('pnpm test');
+    expect(isCommonValidationCommand(analysis)).toBe(true);
+  });
+
+  it('rejects git push', () => {
+    const analysis = analyzeShellCommand('git push');
+    expect(isCommonValidationCommand(analysis)).toBe(false);
+  });
+
+  it('rejects non-structurally-trusted commands', () => {
+    const analysis = analyzeShellCommand('git status && echo done');
+    expect(isCommonValidationCommand(analysis)).toBe(false);
+  });
+});
+
+describe('isInstallCommand', () => {
+  it('recognizes npm install', () => {
+    const analysis = analyzeShellCommand('npm install');
+    expect(isInstallCommand(analysis)).toBe(true);
+  });
+
+  it('recognizes pnpm add', () => {
+    const analysis = analyzeShellCommand('pnpm add lodash');
+    expect(isInstallCommand(analysis)).toBe(true);
+  });
+
+  it('recognizes npx', () => {
+    const analysis = analyzeShellCommand('npx create-react-app my-app');
+    expect(isInstallCommand(analysis)).toBe(true);
+  });
+
+  it('rejects npm test', () => {
+    const analysis = analyzeShellCommand('npm test');
+    expect(isInstallCommand(analysis)).toBe(false);
+  });
+});

--- a/packages/shared/src/utils.test.ts
+++ b/packages/shared/src/utils.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_LLM_MAX_TOKENS,
+  DEFAULT_LLM_TEMPERATURE,
+  deepMerge,
+  delay,
+  generateId,
+  matchGlob,
+  normalizePath,
+  safeJsonParse,
+} from './utils.js';
+
+describe('generateId', () => {
+  it('generates unique IDs', () => {
+    const id1 = generateId();
+    const id2 = generateId();
+    expect(id1).not.toBe(id2);
+  });
+
+  it('includes prefix when provided', () => {
+    const id = generateId('task');
+    expect(id).toMatch(/^task_/);
+  });
+
+  it('generates without prefix', () => {
+    const id = generateId();
+    expect(id).toMatch(/^[a-z0-9]+_[a-z0-9]+$/);
+  });
+});
+
+describe('delay', () => {
+  it('resolves after specified time', async () => {
+    const start = Date.now();
+    await delay(50);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(40);
+  });
+});
+
+describe('safeJsonParse', () => {
+  it('parses valid JSON', () => {
+    const result = safeJsonParse('{"a": 1}', {});
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it('returns default for invalid JSON', () => {
+    const result = safeJsonParse('not json', { fallback: true });
+    expect(result).toEqual({ fallback: true });
+  });
+
+  it('returns default for empty string', () => {
+    const result = safeJsonParse('', []);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('deepMerge', () => {
+  it('merges flat objects', () => {
+    const result = deepMerge({ a: 1, b: 2 }, { b: 3, c: 4 } as any);
+    expect(result).toEqual({ a: 1, b: 3, c: 4 });
+  });
+
+  it('deep merges nested objects', () => {
+    const target = { nested: { a: 1, b: 2 } };
+    const source = { nested: { b: 3 } };
+    const result = deepMerge(target, source as any);
+    expect(result).toEqual({ nested: { a: 1, b: 3 } });
+  });
+
+  it('overwrites arrays (no merge)', () => {
+    const target = { arr: [1, 2, 3] };
+    const source = { arr: [4, 5] };
+    const result = deepMerge(target, source as any);
+    expect(result).toEqual({ arr: [4, 5] });
+  });
+
+  it('skips undefined values', () => {
+    const target = { a: 1, b: 2 };
+    const source = { a: undefined, b: 3 };
+    const result = deepMerge(target, source as any);
+    expect(result).toEqual({ a: 1, b: 3 });
+  });
+
+  it('does not mutate target', () => {
+    const target = { a: 1 };
+    deepMerge(target, { a: 2 } as any);
+    expect(target.a).toBe(1);
+  });
+});
+
+describe('normalizePath', () => {
+  it('converts backslashes to forward slashes', () => {
+    expect(normalizePath('src\\components\\App.tsx')).toBe('src/components/App.tsx');
+  });
+
+  it('collapses multiple slashes', () => {
+    expect(normalizePath('src//components///App.tsx')).toBe('src/components/App.tsx');
+  });
+
+  it('handles already normalized paths', () => {
+    expect(normalizePath('src/components/App.tsx')).toBe('src/components/App.tsx');
+  });
+});
+
+describe('matchGlob', () => {
+  it('matches exact path', () => {
+    expect(matchGlob('src/index.ts', 'src/index.ts')).toBe(true);
+  });
+
+  it('matches single wildcard', () => {
+    expect(matchGlob('src/index.ts', 'src/*.ts')).toBe(true);
+    expect(matchGlob('src/deep/index.ts', 'src/*.ts')).toBe(false);
+  });
+
+  it('matches globstar', () => {
+    expect(matchGlob('src/deep/nested/file.ts', 'src/**/*.ts')).toBe(true);
+    expect(matchGlob('src/deep/file.ts', '**/*.ts')).toBe(true);
+  });
+
+  it('matches question mark', () => {
+    expect(matchGlob('src/a.ts', 'src/?.ts')).toBe(true);
+    expect(matchGlob('src/ab.ts', 'src/?.ts')).toBe(false);
+  });
+
+  it('escapes regex metacharacters in pattern', () => {
+    expect(matchGlob('src/file.test.ts', 'src/file.test.ts')).toBe(true);
+    expect(matchGlob('src/filextest.ts', 'src/file.test.ts')).toBe(false);
+  });
+
+  it('handles backslash paths via normalization', () => {
+    expect(matchGlob('src\\components\\App.tsx', 'src/components/*.tsx')).toBe(true);
+  });
+});
+
+describe('constants', () => {
+  it('exports DEFAULT_LLM_TEMPERATURE', () => {
+    expect(DEFAULT_LLM_TEMPERATURE).toBe(0.2);
+  });
+
+  it('exports DEFAULT_LLM_MAX_TOKENS', () => {
+    expect(DEFAULT_LLM_MAX_TOKENS).toBe(4096);
+  });
+});


### PR DESCRIPTION
## Summary
Add 54 unit tests for `@frontagent/shared` covering all exported functions.

## Test coverage
- **Shell analysis** (31 tests): `analyzeShellCommand`, `detectDangerousShellCommand`, `isCommonValidationCommand`, `isInstallCommand`
- **Utilities** (23 tests): `generateId`, `deepMerge`, `matchGlob`, `normalizePath`, `safeJsonParse`, `delay`, constants

## Verification
- `pnpm test` passes (all 54 new + existing tests)

Closes #24