### PR TITLE
fix(shared): remove TechStackConfig index signature type escape

### DIFF
--- a/packages/shared/src/types/sdd.ts
+++ b/packages/shared/src/types/sdd.ts
@@ -27,7 +27,6 @@ export interface TechStackConfig {
   uiLibraryVersion?: string;
   routing?: string;
   buildTool?: string;
-  [key: string]: any;
 }
 
 export interface DirectoryStructureConfig {


### PR DESCRIPTION
## Summary
Remove `[key: string]: any` from `TechStackConfig` interface.

## Rationale
The index signature was inconsistent with the SDD schema validator which sets `additionalProperties: false` for techStack. All known extension fields (uiLibrary, routing, buildTool, etc.) are already declared as typed optional properties. The `any` escape defeated TypeScript's type checking for the entire interface.

## Verification
- `pnpm typecheck` passes (no consumers relied on arbitrary property access)
- `pnpm test` passes

Closes #25