### PR TITLE
test(hallucination-guard, sdd): add unit tests for untested packages

### DIFF
--- a/packages/hallucination-guard/package.json
+++ b/packages/hallucination-guard/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },

--- a/packages/hallucination-guard/src/guard.test.ts
+++ b/packages/hallucination-guard/src/guard.test.ts
@@ -1,0 +1,214 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import { checkFileExistence } from './checks/file-existence.js';
+import { checkSyntaxValidity } from './checks/syntax-validity.js';
+import { checkAllImports, extractImports } from './checks/import-validity.js';
+import { HallucinationGuard } from './guard.js';
+
+const TEST_ROOT = join(tmpdir(), 'frontagent-guard-test-' + Date.now());
+
+beforeAll(() => {
+  mkdirSync(TEST_ROOT, { recursive: true });
+  writeFileSync(join(TEST_ROOT, 'existing.ts'), 'export const x = 1;\n');
+  mkdirSync(join(TEST_ROOT, 'src'), { recursive: true });
+  writeFileSync(join(TEST_ROOT, 'src', 'utils.ts'), 'export function add(a: number, b: number) { return a + b; }\n');
+  writeFileSync(join(TEST_ROOT, 'package.json'), JSON.stringify({ dependencies: { zod: '^3.0.0' } }));
+});
+
+afterAll(() => {
+  rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe('checkFileExistence', () => {
+  it('passes when file exists and shouldExist is true', async () => {
+    const result = await checkFileExistence({
+      path: 'existing.ts',
+      projectRoot: TEST_ROOT,
+      shouldExist: true,
+    });
+    expect(result.pass).toBe(true);
+    expect(result.type).toBe('file_existence');
+  });
+
+  it('fails when file does not exist and shouldExist is true', async () => {
+    const result = await checkFileExistence({
+      path: 'nonexistent.ts',
+      projectRoot: TEST_ROOT,
+      shouldExist: true,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.severity).toBe('block');
+    expect(result.message).toContain('does not exist');
+  });
+
+  it('warns when file exists and shouldExist is false', async () => {
+    const result = await checkFileExistence({
+      path: 'existing.ts',
+      projectRoot: TEST_ROOT,
+      shouldExist: false,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.severity).toBe('warn');
+  });
+
+  it('blocks path traversal outside project root', async () => {
+    const result = await checkFileExistence({
+      path: '../../etc/passwd',
+      projectRoot: TEST_ROOT,
+      shouldExist: true,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.severity).toBe('block');
+    expect(result.message).toContain('outside project root');
+  });
+});
+
+describe('checkSyntaxValidity', () => {
+  it('passes valid TypeScript code', async () => {
+    const result = await checkSyntaxValidity({
+      code: 'const x: number = 1;\nfunction add(a: number, b: number) { return a + b; }',
+      language: 'typescript',
+    });
+    expect(result.pass).toBe(true);
+  });
+
+  it('detects unmatched brackets', async () => {
+    const result = await checkSyntaxValidity({
+      code: 'function foo() {\n  if (true) {\n    return 1;\n  }\n',
+      language: 'typescript',
+    });
+    expect(result.pass).toBe(false);
+    expect(result.severity).toBe('block');
+  });
+
+  it('passes valid JSON', async () => {
+    const result = await checkSyntaxValidity({
+      code: '{"name": "test", "version": "1.0.0"}',
+      language: 'json',
+    });
+    expect(result.pass).toBe(true);
+  });
+
+  it('detects invalid JSON', async () => {
+    const result = await checkSyntaxValidity({
+      code: '{"name": "test",}',
+      language: 'json',
+    });
+    expect(result.pass).toBe(false);
+    expect(result.severity).toBe('block');
+  });
+});
+
+describe('extractImports', () => {
+  it('extracts ES6 imports', () => {
+    const code = `
+import { foo } from './foo.js';
+import bar from 'bar';
+import type { Baz } from '@scope/baz';
+`;
+    const imports = extractImports(code);
+    expect(imports).toContain('./foo.js');
+    expect(imports).toContain('bar');
+    expect(imports).toContain('@scope/baz');
+  });
+
+  it('extracts dynamic imports', () => {
+    const code = `const mod = await import('./dynamic.js');`;
+    const imports = extractImports(code);
+    expect(imports).toContain('./dynamic.js');
+  });
+
+  it('extracts require calls', () => {
+    const code = `const fs = require('node:fs');`;
+    const imports = extractImports(code);
+    expect(imports).toContain('node:fs');
+  });
+
+  it('deduplicates imports', () => {
+    const code = `
+import { a } from './shared.js';
+import { b } from './shared.js';
+`;
+    const imports = extractImports(code);
+    expect(imports.filter((i) => i === './shared.js')).toHaveLength(1);
+  });
+});
+
+describe('checkAllImports', () => {
+  it('passes node: built-in imports', async () => {
+    const code = `import { readFileSync } from 'node:fs';`;
+    const results = await checkAllImports(code, 'src/index.ts', TEST_ROOT);
+    expect(results.every((r) => r.pass)).toBe(true);
+  });
+
+  it('passes valid relative imports', async () => {
+    const code = `import { add } from './utils';`;
+    const results = await checkAllImports(code, 'src/index.ts', TEST_ROOT);
+    expect(results.every((r) => r.pass)).toBe(true);
+  });
+
+  it('fails for non-existent relative imports', async () => {
+    const code = `import { foo } from './nonexistent.js';`;
+    const results = await checkAllImports(code, 'src/index.ts', TEST_ROOT);
+    expect(results.some((r) => !r.pass)).toBe(true);
+  });
+});
+
+describe('HallucinationGuard', () => {
+  it('validates a valid create_file action', async () => {
+    const guard = new HallucinationGuard({
+      projectRoot: TEST_ROOT,
+      enabledChecks: {
+        fileExistence: true,
+        syntaxValidity: true,
+        importValidity: false,
+        sddCompliance: false,
+      },
+    });
+
+    const result = await guard.validate({
+      action: 'create_file',
+      targetPath: 'new-file.ts',
+      content: 'export const y = 2;',
+      language: 'typescript',
+    });
+    expect(result.pass).toBe(true);
+  });
+
+  it('blocks reading a non-existent file', async () => {
+    const guard = new HallucinationGuard({
+      projectRoot: TEST_ROOT,
+      enabledChecks: {
+        fileExistence: true,
+        syntaxValidity: false,
+        importValidity: false,
+        sddCompliance: false,
+      },
+    });
+
+    const result = await guard.validate({
+      action: 'read_file',
+      targetPath: 'ghost.ts',
+    });
+    expect(result.pass).toBe(false);
+    expect(result.blockedBy).toBeDefined();
+    expect(result.blockedBy!.length).toBeGreaterThan(0);
+  });
+
+  it('validates code syntax when content is provided', async () => {
+    const guard = new HallucinationGuard({
+      projectRoot: TEST_ROOT,
+      enabledChecks: {
+        fileExistence: false,
+        syntaxValidity: true,
+        importValidity: false,
+        sddCompliance: false,
+      },
+    });
+
+    const result = await guard.validateCode('{ invalid json', 'json');
+    expect(result.pass).toBe(false);
+  });
+});

--- a/packages/sdd/package.json
+++ b/packages/sdd/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },

--- a/packages/sdd/src/sdd.test.ts
+++ b/packages/sdd/src/sdd.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest';
+import { SDDParser } from './parser.js';
+import { SDDPromptGenerator } from './prompt-generator.js';
+import { SDDValidator } from './validator.js';
+import { defaultSDDConfig } from './schema.js';
+
+const VALID_YAML = `
+version: "1.0"
+project:
+  name: test-app
+  type: spa
+techStack:
+  framework: react
+  version: "^18.0.0"
+  language: typescript
+  forbiddenPackages:
+    - jquery
+    - lodash
+directoryStructure:
+  components:
+    maxLines: 200
+moduleBoundaries:
+  - from: "src/utils/**"
+    canImport:
+      - "src/utils/**"
+    cannotImport:
+      - "src/components/**"
+namingConventions:
+  components: PascalCase
+  hooks: "camelCase with use prefix"
+  utils: camelCase
+  constants: SCREAMING_SNAKE_CASE
+  types: PascalCase
+codeQuality:
+  maxFunctionLines: 50
+  maxFileLines: 300
+  maxParameters: 4
+  requireJsdoc: false
+  forbiddenPatterns:
+    - "console\\\\.log"
+modificationRules:
+  protectedFiles:
+    - "package-lock.json"
+  protectedDirectories:
+    - node_modules
+    - .git
+  requireApproval:
+    - pattern: "src/core/**"
+      reason: "Core module changes require review"
+`;
+
+describe('SDDParser', () => {
+  const parser = new SDDParser();
+
+  it('parses valid YAML config', () => {
+    const result = parser.parseContent(VALID_YAML);
+    expect(result.success).toBe(true);
+    expect(result.config).toBeDefined();
+    expect(result.config!.project.name).toBe('test-app');
+    expect(result.config!.techStack.framework).toBe('react');
+    expect(result.config!.techStack.forbiddenPackages).toContain('jquery');
+  });
+
+  it('parses valid JSON config', () => {
+    const json = JSON.stringify({
+      version: '1.0',
+      project: { name: 'json-app', type: 'spa' },
+      techStack: {
+        framework: 'vue',
+        version: '^3.0.0',
+        language: 'typescript',
+        forbiddenPackages: [],
+      },
+      directoryStructure: {},
+      moduleBoundaries: [],
+      namingConventions: {
+        components: 'PascalCase',
+        hooks: 'camelCase with use prefix',
+        utils: 'camelCase',
+        constants: 'SCREAMING_SNAKE_CASE',
+        types: 'PascalCase',
+      },
+      codeQuality: {
+        maxFunctionLines: 50,
+        maxFileLines: 300,
+        maxParameters: 4,
+        requireJsdoc: false,
+        forbiddenPatterns: [],
+      },
+      modificationRules: {
+        protectedFiles: [],
+        protectedDirectories: [],
+        requireApproval: [],
+      },
+    });
+    const result = parser.parseContent(json);
+    expect(result.success).toBe(true);
+    expect(result.config!.project.name).toBe('json-app');
+  });
+
+  it('returns errors for invalid content', () => {
+    const result = parser.parseContent('not: valid: yaml: [[[');
+    expect(result.success).toBe(false);
+    expect(result.errors).toBeDefined();
+    expect(result.errors!.length).toBeGreaterThan(0);
+  });
+
+  it('returns error for non-existent file', () => {
+    const result = parser.parseFile('/nonexistent/path/sdd.yaml');
+    expect(result.success).toBe(false);
+    expect(result.errors![0]).toContain('not found');
+  });
+
+  it('merges with default config for partial input', () => {
+    const result = parser.parseContent(VALID_YAML);
+    expect(result.success).toBe(true);
+    expect(result.config!.codeQuality.maxParameters).toBe(4);
+  });
+});
+
+describe('SDDValidator', () => {
+  it('passes valid action with no violations', () => {
+    const validator = new SDDValidator(defaultSDDConfig);
+    const result = validator.validate({
+      type: 'create_file',
+      targetPath: 'src/components/Button.tsx',
+      content: 'export function Button() { return <button />; }',
+    });
+    expect(result.valid).toBe(true);
+    expect(result.violations.filter((v) => v.type === 'error')).toHaveLength(0);
+  });
+
+  it('blocks modification of protected directories', () => {
+    const validator = new SDDValidator(defaultSDDConfig);
+    const result = validator.validate({
+      type: 'create_file',
+      targetPath: 'node_modules/foo/index.js',
+      content: 'module.exports = {};',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v) => v.rule === 'protected_directory')).toBe(true);
+  });
+
+  it('detects forbidden packages', () => {
+    const config = {
+      ...defaultSDDConfig,
+      techStack: { ...defaultSDDConfig.techStack, forbiddenPackages: ['jquery', 'moment'] },
+    };
+    const validator = new SDDValidator(config);
+    const result = validator.validate({
+      type: 'create_file',
+      targetPath: 'src/index.ts',
+      dependencies: ['jquery'],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v) => v.rule === 'forbidden_package')).toBe(true);
+  });
+
+  it('detects module boundary violations', () => {
+    const config = {
+      ...defaultSDDConfig,
+      moduleBoundaries: [
+        { from: 'src/utils/**', canImport: ['src/utils/**'], cannotImport: ['src/components/**'] },
+      ],
+    };
+    const validator = new SDDValidator(config);
+    const result = validator.validate({
+      type: 'create_file',
+      targetPath: 'src/utils/helper.ts',
+      imports: ['src/components/Button'],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v) => v.rule === 'module_boundary')).toBe(true);
+  });
+
+  it('warns on file exceeding maxFileLines', () => {
+    const config = { ...defaultSDDConfig, codeQuality: { ...defaultSDDConfig.codeQuality, maxFileLines: 10 } };
+    const validator = new SDDValidator(config);
+    const result = validator.validate({
+      type: 'create_file',
+      targetPath: 'src/big.ts',
+      content: Array(20).fill('const x = 1;').join('\n'),
+    });
+    expect(result.violations.some((v) => v.rule === 'max_file_lines')).toBe(true);
+  });
+
+  it('detects forbidden patterns in code', () => {
+    const config = {
+      ...defaultSDDConfig,
+      codeQuality: { ...defaultSDDConfig.codeQuality, forbiddenPatterns: ['console\\.log'] },
+    };
+    const validator = new SDDValidator(config);
+    const result = validator.validate({
+      type: 'create_file',
+      targetPath: 'src/index.ts',
+      content: 'console.log("debug");',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v) => v.rule === 'forbidden_pattern')).toBe(true);
+  });
+
+  it('flags protected files for approval', () => {
+    const config = {
+      ...defaultSDDConfig,
+      modificationRules: {
+        ...defaultSDDConfig.modificationRules,
+        protectedFiles: ['package-lock.json'],
+        requireApproval: [{ pattern: 'src/core/**', reason: 'Core changes need review' }],
+      },
+    };
+    const validator = new SDDValidator(config);
+    const result = validator.validate({
+      type: 'apply_patch',
+      targetPath: 'src/core/engine.ts',
+    });
+    expect(result.requiresApproval).toBe(true);
+    expect(result.approvalReasons.length).toBeGreaterThan(0);
+  });
+
+  it('warns on non-PascalCase component names', () => {
+    const validator = new SDDValidator(defaultSDDConfig);
+    const result = validator.validate({
+      type: 'create_file',
+      targetPath: 'src/components/my-button.tsx',
+      content: 'export function MyButton() {}',
+    });
+    expect(result.violations.some((v) => v.rule === 'naming_convention')).toBe(true);
+  });
+});
+
+describe('SDDPromptGenerator', () => {
+  it('generates a non-empty prompt from config', () => {
+    const generator = new SDDPromptGenerator(defaultSDDConfig);
+    const prompt = generator.generate();
+    expect(prompt.length).toBeGreaterThan(0);
+    expect(prompt).toContain('SDD');
+  });
+
+  it('includes project name in prompt', () => {
+    const config = { ...defaultSDDConfig, project: { name: 'my-app', type: 'spa' } };
+    const generator = new SDDPromptGenerator(config);
+    const prompt = generator.generate();
+    expect(prompt).toContain('my-app');
+  });
+
+  it('includes forbidden packages in prompt', () => {
+    const config = {
+      ...defaultSDDConfig,
+      techStack: { ...defaultSDDConfig.techStack, forbiddenPackages: ['jquery'] },
+    };
+    const generator = new SDDPromptGenerator(config);
+    const prompt = generator.generate();
+    expect(prompt).toContain('jquery');
+  });
+
+  it('respects language option', () => {
+    const generator = new SDDPromptGenerator(defaultSDDConfig, { language: 'en' });
+    const prompt = generator.generate();
+    expect(prompt).toContain('Project Constraints');
+  });
+});


### PR DESCRIPTION
## Summary

Add unit test suites for the two packages that previously had zero test coverage:

- **hallucination-guard** (18 tests): file existence checks, syntax validity, import extraction/validation, HallucinationGuard integration
- **sdd** (17 tests): SDDParser (YAML/JSON), SDDValidator (protected dirs, forbidden packages, module boundaries, naming conventions, code quality), SDDPromptGenerator

Also adds missing `"test": "vitest run"` scripts to both package.json files.

## Verification

- All 35 tests pass
- Typecheck passes for both packages
- No new lint errors introduced

Closes #29