### PR TITLE
refactor(core): split executor.ts into focused modules

### DIFF
--- a/packages/core/src/executor/executor.ts
+++ b/packages/core/src/executor/executor.ts
@@ -1,0 +1,1434 @@
+import { existsSync, statSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import type {
+  AgentTask,
+  ExecutionStep,
+  SecurityDecision,
+  StepResult,
+  ValidationResult,
+} from '@frontagent/shared';
+import { Annotation, END, MemorySaver, START, StateGraph } from '@langchain/langgraph';
+import { SecurityManager, toApprovalRequest } from '../security.js';
+import {
+  type ExecutorActionSkill,
+  type ExecutorSkillsLayerSnapshot,
+  createDefaultExecutorSkillRegistry,
+} from '../skills/index.js';
+import type { ExecutorOutput } from '../types.js';
+import { buildOrderedPhaseGroups, detectLanguage } from './phase-ordering.js';
+import type {
+  ExecutorCollectedContext,
+  ExecutorConfig,
+  ExecutorSubStage,
+  ExecutorTraceStage,
+  LangGraphRuntimeState,
+  MCPClient,
+  PhaseExecutionGroup,
+  SerializablePhaseExecutionGroup,
+} from './types.js';
+
+export class Executor {
+  private config: ExecutorConfig;
+  private mcpClients: Map<string, MCPClient> = new Map();
+  private toolToClient: Map<string, string> = new Map();
+  private actionSkills: ReturnType<typeof createDefaultExecutorSkillRegistry>;
+  private securityManager: SecurityManager;
+  private currentBrowserUrl?: string;
+
+  constructor(config: ExecutorConfig) {
+    this.config = config;
+    this.securityManager = new SecurityManager();
+    this.actionSkills = createDefaultExecutorSkillRegistry({
+      llmService: this.config.llmService,
+      debug: this.config.debug,
+      getCreatedModules: this.config.getCreatedModules,
+      getSddConstraints: this.config.getSddConstraints,
+      getSkillContext: this.config.getSkillContext,
+      getMemoryRecall: this.config.getMemoryRecall,
+      onStreamToken: this.config.onStreamToken,
+      buildContextString: (collectedContext) => this.buildContextString(collectedContext),
+      detectLanguage: (path) => detectLanguage(path),
+    });
+  }
+
+  private debugLog(...args: unknown[]): void {
+    if (this.config.debug) {
+      console.log(...args);
+    }
+  }
+
+  private debugWarn(...args: unknown[]): void {
+    if (this.config.debug) {
+      console.warn(...args);
+    }
+  }
+
+  private debugError(...args: unknown[]): void {
+    if (this.config.debug) {
+      console.error(...args);
+    }
+  }
+
+  private nowMs(): number {
+    return Number(process.hrtime.bigint()) / 1_000_000;
+  }
+
+  private isTraceEnabled(): boolean {
+    return Boolean(this.config.trace?.enabled || this.config.trace?.onStepTrace);
+  }
+
+  private createTraceStage(
+    name: ExecutorTraceStage['name'],
+    startedAtMs: number,
+    success: boolean,
+    error?: string,
+  ): ExecutorTraceStage {
+    return {
+      name,
+      durationMs: this.nowMs() - startedAtMs,
+      success,
+      error,
+    };
+  }
+
+  registerMCPClient(name: string, client: MCPClient): void {
+    this.mcpClients.set(name, client);
+  }
+
+  registerToolMapping(toolName: string, clientName: string): void {
+    this.toolToClient.set(toolName, clientName);
+  }
+
+  registerActionSkill(skill: ExecutorActionSkill): void {
+    this.actionSkills.registerActionSkill(skill);
+  }
+
+  getActionSkillSnapshot(): ExecutorSkillsLayerSnapshot {
+    return this.actionSkills.snapshot();
+  }
+
+  async executeStep(
+    step: ExecutionStep,
+    context: {
+      task: AgentTask;
+      collectedContext: ExecutorCollectedContext;
+    },
+  ): Promise<ExecutorOutput> {
+    const startTime = Date.now();
+    const traceEnabled = this.isTraceEnabled();
+    const traceStartedAt = traceEnabled ? this.nowMs() : 0;
+    const traceStages: ExecutorTraceStage[] = [];
+    const subStages: ExecutorSubStage[] = [];
+
+    const finish = (output: ExecutorOutput): ExecutorOutput => {
+      if (traceEnabled) {
+        const stepResult = output.stepResult;
+        const toolResult = stepResult.output as any;
+        this.config.trace?.onStepTrace?.({
+          taskId: context.task.id,
+          stepId: step.stepId,
+          action: step.action,
+          tool: step.tool,
+          totalMs: this.nowMs() - traceStartedAt,
+          success: stepResult.success,
+          skipped:
+            typeof stepResult.output === 'object' &&
+            stepResult.output !== null &&
+            Boolean((stepResult.output as { skipped?: boolean }).skipped),
+          error: stepResult.error,
+          stages: traceStages,
+          toolDurationMs: toolResult?.__toolDurationMs,
+          subStages: subStages.length > 0 ? subStages : undefined,
+        });
+      }
+      return output;
+    };
+
+    const withStage = async <T>(
+      name: ExecutorTraceStage['name'],
+      fn: () => Promise<T> | T,
+    ): Promise<T> => {
+      if (!traceEnabled) {
+        return fn();
+      }
+      const stageStartedAt = this.nowMs();
+      try {
+        const result = await fn();
+        traceStages.push(this.createTraceStage(name, stageStartedAt, true));
+        return result;
+      } catch (error) {
+        traceStages.push(
+          this.createTraceStage(
+            name,
+            stageStartedAt,
+            false,
+            error instanceof Error ? error.message : String(error),
+          ),
+        );
+        throw error;
+      }
+    };
+
+    try {
+      const paramValidation = await withStage('validate_params', () =>
+        this.validateStepParams(step),
+      );
+      if (!paramValidation.valid) {
+        if (this.config.debug) {
+          console.log(`[Executor] Skipping step due to invalid params: ${paramValidation.reason}`);
+        }
+        return finish({
+          stepResult: {
+            success: true,
+            output: { skipped: true, reason: paramValidation.reason },
+            duration: Date.now() - startTime,
+          },
+          validation: { pass: true, results: [] },
+          needsRollback: false,
+        });
+      }
+
+      const preValidation = await withStage('validate_before', () =>
+        this.validateBeforeExecution(step, context),
+      );
+      if (!preValidation.pass) {
+        const errorMsg = preValidation.blockedBy?.join('; ') || '';
+        const isDirectoryError =
+          errorMsg.includes('is not a file') || errorMsg.includes('Not a file');
+        const isFileNotExist = errorMsg.includes('does not exist') && step.action === 'read_file';
+
+        if (isDirectoryError || isFileNotExist) {
+          if (this.config.debug) {
+            console.log(`[Executor] Skipping step due to validation: ${errorMsg}`);
+          }
+          return finish({
+            stepResult: {
+              success: true,
+              output: { skipped: true, reason: errorMsg, exists: false },
+              duration: Date.now() - startTime,
+            },
+            validation: { pass: true, results: [] },
+            needsRollback: false,
+          });
+        }
+
+        return finish({
+          stepResult: {
+            success: false,
+            error: `Pre-execution validation failed: ${errorMsg}`,
+            duration: Date.now() - startTime,
+          },
+          validation: preValidation,
+          needsRollback: false,
+        });
+      }
+
+      let toolParams = { ...step.params };
+
+      if (this.config.debug) {
+        const stepAny = step as { needsCodeGeneration?: boolean };
+        console.log(
+          `[Executor] Step action: ${step.action}, needsCodeGeneration: ${Boolean(stepAny.needsCodeGeneration)}`,
+        );
+        console.log('[Executor] Step params:', toolParams);
+      }
+
+      toolParams = await withStage('prepare_tool_params', () =>
+        this.actionSkills.prepareToolParams({
+          step,
+          params: toolParams,
+          context,
+          onSubStageTiming: (name, durationMs) => {
+            subStages.push({ name, durationMs, success: true });
+          },
+        }),
+      );
+
+      const toolResult = await withStage('call_tool', () => this.callTool(step.tool, toolParams));
+
+      if (typeof toolResult === 'object' && toolResult !== null) {
+        const resultObj = toolResult as { success?: boolean; error?: string };
+        if (resultObj.success === false && resultObj.error) {
+          const isSkippableError = this.isSkippableError(resultObj.error, step, toolParams);
+          if (isSkippableError) {
+            if (this.config.debug) {
+              console.log(`[Executor] Skipping step due to tool error: ${resultObj.error}`);
+            }
+            return finish({
+              stepResult: {
+                success: true,
+                output: { skipped: true, reason: resultObj.error },
+                duration: Date.now() - startTime,
+              },
+              validation: { pass: true, results: [] },
+              needsRollback: false,
+            });
+          }
+        }
+      }
+
+      const postValidation = await withStage('validate_after', () =>
+        this.validateAfterExecution(step, toolResult, toolParams),
+      );
+
+      const stepResult: StepResult = {
+        success: postValidation.pass,
+        output: toolResult,
+        error: postValidation.pass ? undefined : postValidation.blockedBy?.join('; '),
+        duration: Date.now() - startTime,
+        snapshotId: (toolResult as { snapshotId?: string })?.snapshotId,
+      };
+
+      return finish({
+        stepResult,
+        validation: postValidation,
+        needsRollback: !postValidation.pass && step.validation.some((v) => v.required),
+      });
+    } catch (error) {
+      if (traceEnabled && traceStages.length === 0) {
+        traceStages.push(
+          this.createTraceStage(
+            'catch',
+            traceStartedAt,
+            false,
+            error instanceof Error ? error.message : String(error),
+          ),
+        );
+      }
+      return finish({
+        stepResult: {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+          duration: Date.now() - startTime,
+        },
+        validation: {
+          pass: false,
+          results: [],
+          blockedBy: [error instanceof Error ? error.message : String(error)],
+        },
+        needsRollback: true,
+      });
+    }
+  }
+
+  private validateStepParams(step: ExecutionStep): { valid: boolean; reason?: string } {
+    const params = step.params as Record<string, unknown>;
+    const customValidation = this.actionSkills.validateStepParams(step, params);
+    if (customValidation && !customValidation.valid) {
+      return customValidation;
+    }
+
+    const requiredParams = this.actionSkills.resolveRequiredParams(step.action);
+
+    for (const paramName of requiredParams) {
+      const value = params[paramName];
+      const missing =
+        value === undefined || value === null || (typeof value === 'string' && value.trim() === '');
+
+      if (missing) {
+        return {
+          valid: false,
+          reason: `${step.action} requires non-empty ${paramName} parameter`,
+        };
+      }
+    }
+
+    return { valid: true };
+  }
+
+  private isSkippableError(
+    errorMsg: string,
+    step: ExecutionStep,
+    params?: Record<string, unknown>,
+  ): boolean {
+    const skillDecision = this.actionSkills.shouldSkipToolError({
+      errorMsg,
+      step,
+      params: params ?? {},
+    });
+    if (typeof skillDecision === 'boolean') {
+      return skillDecision;
+    }
+
+    if (
+      errorMsg.includes('Not a directory') ||
+      errorMsg.includes('is not a file') ||
+      errorMsg.includes('Not a file')
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private buildContextString(collectedContext: ExecutorCollectedContext): string {
+    const parts: string[] = [];
+
+    if (collectedContext.files.size > 0) {
+      parts.push('相关文件:');
+      for (const [path, content] of collectedContext.files) {
+        const truncatedContent =
+          content.length > 1000 ? `${content.substring(0, 1000)}\n... (内容已截断)` : content;
+        parts.push(`\n--- ${path} ---\n${truncatedContent}`);
+      }
+    }
+
+    if (collectedContext.ragResults && collectedContext.ragResults.length > 0) {
+      parts.push('\n知识库参考:');
+      for (const result of collectedContext.ragResults) {
+        parts.push(`- ${result}`);
+      }
+    }
+
+    if (collectedContext.matchedSkillNames && collectedContext.matchedSkillNames.length > 0) {
+      parts.push(`\n已激活内容技能: ${collectedContext.matchedSkillNames.join(', ')}`);
+    }
+
+    return parts.join('\n');
+  }
+
+  private async validateBeforeExecution(
+    step: ExecutionStep,
+    context: { task: AgentTask; collectedContext: ExecutorCollectedContext },
+  ): Promise<ValidationResult> {
+    const results: ValidationResult['results'] = [];
+
+    if (step.action === 'apply_patch' && step.params.path) {
+      const path = step.params.path as string;
+      const facts = this.config.getFileSystemFacts?.();
+
+      if (facts?.nonExistentPaths.has(path)) {
+        if (this.config.debug) {
+          console.log(
+            `[Executor] ⚠️  File ${path} is known to not exist. Suggest using create_file instead.`,
+          );
+        }
+        return {
+          pass: false,
+          results: [
+            {
+              pass: false,
+              type: 'file_not_found',
+              severity: 'block',
+              message: `Cannot apply patch: file ${path} does not exist (confirmed by previous directory listing). Please use create_file instead.`,
+            },
+          ],
+          blockedBy: [`File ${path} does not exist. Use create_file instead of apply_patch.`],
+        };
+      }
+
+      if (!context.collectedContext.files.has(path)) {
+        this.debugLog(
+          `[Executor] 📖 File ${path} not in context, auto-reading before apply_patch...`,
+        );
+
+        try {
+          const readResult = (await this.callTool('read_file', { path })) as {
+            success: boolean;
+            content?: string;
+            error?: string;
+          };
+
+          if (readResult.success && readResult.content !== undefined) {
+            context.collectedContext.files.set(path, readResult.content);
+            this.debugLog(
+              `[Executor] ✅ Auto-read file ${path} (${readResult.content.length} chars) into context`,
+            );
+          } else {
+            const errorMsg = readResult.error || 'Failed to read file';
+            if (this.config.debug) {
+              console.log(`[Executor] ❌ Auto-read failed: ${errorMsg}`);
+            }
+            return {
+              pass: false,
+              results: [
+                {
+                  pass: false,
+                  type: 'file_read_failed',
+                  severity: 'block',
+                  message: `Cannot apply patch: failed to auto-read file ${path}. Error: ${errorMsg}`,
+                },
+              ],
+              blockedBy: [`Failed to auto-read file ${path}: ${errorMsg}`],
+            };
+          }
+        } catch (error) {
+          const errorMsg = error instanceof Error ? error.message : String(error);
+          this.debugLog(`[Executor] ❌ Auto-read exception: ${errorMsg}`);
+          return {
+            pass: false,
+            results: [
+              {
+                pass: false,
+                type: 'file_read_error',
+                severity: 'block',
+                message: `Cannot apply patch: error reading file ${path}. Error: ${errorMsg}`,
+              },
+            ],
+            blockedBy: [`Error auto-reading file ${path}: ${errorMsg}`],
+          };
+        }
+      }
+    }
+
+    if (step.action === 'read_file' && step.params.path) {
+      const fileCheck = await this.config.hallucinationGuard.validateFilePath(
+        step.params.path as string,
+        true,
+      );
+      results.push(fileCheck);
+    }
+
+    if (step.action === 'create_file' && step.params.path && !step.params.overwrite) {
+      const path = step.params.path as string;
+      const facts = this.config.getFileSystemFacts?.();
+
+      if (facts?.existingFiles.has(path)) {
+        return {
+          pass: false,
+          results: [
+            {
+              pass: false,
+              type: 'file_existence',
+              severity: 'block',
+              message: `Cannot create file: ${path} already exists. Use apply_patch after reading the file instead.`,
+            },
+          ],
+          blockedBy: [`File ${path} already exists. Use apply_patch instead of create_file.`],
+        };
+      }
+
+      const parentDir = dirname(path);
+      const parentKnown =
+        parentDir === '.' ||
+        facts?.existingDirectories.has(parentDir) ||
+        Array.from(facts?.directoryContents.keys() ?? []).some((dir) => dir === parentDir);
+
+      if (!parentKnown) {
+        if (facts?.nonExistentPaths.has(parentDir)) {
+          return {
+            pass: false,
+            results: [
+              {
+                pass: false,
+                type: 'parent_directory_not_found',
+                severity: 'block',
+                message: `Cannot create file: parent directory ${parentDir} is known to not exist.`,
+              },
+            ],
+            blockedBy: [`Parent directory ${parentDir} is known to not exist.`],
+          };
+        }
+
+        try {
+          const absoluteParent = resolve(this.config.projectRoot, parentDir);
+          const absoluteTarget = resolve(this.config.projectRoot, path);
+          const parentExists = existsSync(absoluteParent) && statSync(absoluteParent).isDirectory();
+          const targetExists = existsSync(absoluteTarget);
+
+          if (!parentExists || targetExists) {
+            const reason = !parentExists
+              ? `parent directory ${parentDir} does not exist`
+              : `target ${path} already exists`;
+            return {
+              pass: false,
+              results: [
+                {
+                  pass: false,
+                  type: 'progressive_exploration_required',
+                  severity: 'block',
+                  message: `Cannot create file until the target path is precisely confirmed. ${reason}.`,
+                },
+              ],
+              blockedBy: [
+                `Create_file requires progressive exploration: use search_code globOnly/list_directory to narrow candidates before writing ${path}.`,
+              ],
+            };
+          }
+        } catch (error) {
+          return {
+            pass: false,
+            results: [
+              {
+                pass: false,
+                type: 'progressive_exploration_required',
+                severity: 'block',
+                message: `Cannot create file before precise Bash confirmation for ${path}: ${error instanceof Error ? error.message : String(error)}`,
+              },
+            ],
+            blockedBy: [`Create_file requires precise confirmation before writing ${path}.`],
+          };
+        }
+      }
+
+      const fileCheck = await this.config.hallucinationGuard.validateFilePath(path, false);
+      results.push(fileCheck);
+    }
+
+    const blockedBy = results
+      .filter((r) => !r.pass && r.severity === 'block')
+      .map((r) => r.message ?? r.type);
+
+    return {
+      pass: blockedBy.length === 0,
+      results,
+      blockedBy: blockedBy.length > 0 ? blockedBy : undefined,
+    };
+  }
+
+  private async validateAfterExecution(
+    step: ExecutionStep,
+    result: unknown,
+    toolParams?: Record<string, unknown>,
+  ): Promise<ValidationResult> {
+    if (typeof result === 'object' && result !== null) {
+      const resultObj = result as { success?: boolean; error?: string };
+      if (resultObj.success === false) {
+        return {
+          pass: false,
+          results: [],
+          blockedBy: [resultObj.error ?? 'Tool execution failed'],
+        };
+      }
+    }
+
+    if (['apply_patch', 'create_file'].includes(step.action)) {
+      const content =
+        (result as { content?: string })?.content ??
+        (toolParams?.content as string | undefined) ??
+        (step.params.content as string | undefined);
+      const path = step.params.path as string;
+
+      if (content && path) {
+        const language = detectLanguage(path);
+        if (language) {
+          const codeValidation = await this.config.hallucinationGuard.validateCode(
+            content,
+            language,
+            path,
+          );
+          return codeValidation;
+        }
+      }
+    }
+
+    return {
+      pass: true,
+      results: [],
+    };
+  }
+
+  async callTool(toolName: string, args: Record<string, unknown>): Promise<unknown> {
+    const clientName = this.toolToClient.get(toolName);
+    if (!clientName) {
+      throw new Error(`No MCP client registered for tool: ${toolName}`);
+    }
+
+    const client = this.mcpClients.get(clientName);
+    if (!client) {
+      throw new Error(`MCP client not found: ${clientName}`);
+    }
+
+    if (this.config.debug) {
+      console.log(`[Executor] Calling tool: ${toolName}`, args);
+    }
+
+    const security = await this.enforceSecurity(toolName, args);
+    if (!security.allowed) {
+      return {
+        success: false,
+        error: security.error,
+      };
+    }
+
+    const mcpStart = this.nowMs();
+    const result = await client.callTool(toolName, security.args);
+    const mcpDurationMs = this.nowMs() - mcpStart;
+    if (typeof result === 'object' && result !== null) {
+      (result as any).__toolDurationMs = mcpDurationMs;
+    }
+
+    if (toolName === 'browser_navigate' || toolName === 'navigate') {
+      if (typeof args.url === 'string' && this.isSuccessfulToolResult(result)) {
+        this.currentBrowserUrl = args.url;
+      }
+    }
+
+    if (this.config.debug) {
+      console.log('[Executor] Tool result:', result);
+    }
+
+    return result;
+  }
+
+  private async enforceSecurity(
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<{ allowed: true; args: Record<string, unknown> } | { allowed: false; error: string }> {
+    const decision = this.securityManager.evaluate({
+      toolName,
+      args,
+      projectRoot: this.config.projectRoot,
+      sddConfig: this.config.sddConfig,
+      security: this.config.security,
+      currentBrowserUrl: this.currentBrowserUrl,
+    });
+
+    this.emitSecurityDecision(decision);
+
+    if (decision.decision === 'deny') {
+      return { allowed: false, error: `Security policy denied ${toolName}: ${decision.message}` };
+    }
+
+    if (decision.decision === 'allow') {
+      return { allowed: true, args };
+    }
+
+    const approvalRequest = toApprovalRequest(decision);
+    const interactive = this.config.security?.interactive ?? false;
+    if (!interactive || !this.config.approvalHandler) {
+      const deniedDecision: SecurityDecision = {
+        ...decision,
+        decision: 'deny',
+        reasonCode: 'security_approval_unavailable',
+        message: 'Approval is required but no interactive approval channel is available.',
+      };
+      this.emitSecurityDecision(deniedDecision);
+      return { allowed: false, error: deniedDecision.message };
+    }
+
+    const approved = await this.config.approvalHandler(approvalRequest);
+    const finalDecision: SecurityDecision = approved
+      ? {
+          ...decision,
+          decision: 'allow',
+          reasonCode: 'approved_by_user',
+          message: `User approved: ${decision.message}`,
+          approvalId: approvalRequest.approvalId,
+        }
+      : {
+          ...decision,
+          decision: 'deny',
+          reasonCode: 'rejected_by_user',
+          message: `User rejected: ${decision.message}`,
+          approvalId: approvalRequest.approvalId,
+        };
+    this.emitSecurityDecision(finalDecision);
+
+    if (!approved) {
+      return {
+        allowed: false,
+        error: `Security approval rejected for ${toolName}: ${decision.message}`,
+      };
+    }
+
+    return {
+      allowed: true,
+      args: {
+        ...args,
+        __frontagentSecurityApproved: true,
+      },
+    };
+  }
+
+  private emitSecurityDecision(decision: SecurityDecision): void {
+    if (this.config.security?.auditEnabled === false) {
+      return;
+    }
+    this.config.onSecurityDecision?.(decision);
+  }
+
+  private isSuccessfulToolResult(result: unknown): boolean {
+    if (typeof result !== 'object' || result === null) {
+      return true;
+    }
+    const resultObj = result as { success?: boolean };
+    return resultObj.success !== false;
+  }
+
+  async executeSteps(
+    steps: ExecutionStep[],
+    context: {
+      task: AgentTask;
+      collectedContext: ExecutorCollectedContext;
+    },
+    onStepComplete?: (step: ExecutionStep, output: ExecutorOutput) => void,
+  ): Promise<ExecutorOutput[]> {
+    const results: ExecutorOutput[] = [];
+    const completedSteps = new Set<string>();
+
+    const pendingSteps = [...steps];
+
+    while (pendingSteps.length > 0) {
+      const executableIndex = pendingSteps.findIndex((step) =>
+        step.dependencies.every((dep) => completedSteps.has(dep)),
+      );
+
+      if (executableIndex === -1) {
+        throw new Error('Circular dependency detected or missing dependency');
+      }
+
+      const step = pendingSteps.splice(executableIndex, 1)[0];
+      step.status = 'running';
+
+      const output = await this.executeStep(step, context);
+      step.result = output.stepResult;
+      step.status = output.stepResult.success ? 'completed' : 'failed';
+
+      results.push(output);
+      completedSteps.add(step.stepId);
+
+      if (onStepComplete) {
+        onStepComplete(step, output);
+      }
+
+      if (!output.stepResult.success && output.needsRollback) {
+        for (const pending of pendingSteps) {
+          pending.status = 'skipped';
+        }
+        break;
+      }
+    }
+
+    return results;
+  }
+
+  private shouldUseLangGraphEngine(): boolean {
+    if (this.config.executionEngine === 'langgraph') {
+      return true;
+    }
+    return this.config.langGraph?.enabled ?? false;
+  }
+
+  private getMaxRecoveryAttempts(): number {
+    return this.config.maxRecoveryAttempts ?? this.config.langGraph?.maxRecoveryAttempts ?? 2;
+  }
+
+  private createRecoveryFingerprint(errors: Array<{ step: ExecutionStep; error: string }>): string {
+    return errors
+      .map(({ step, error }) => {
+        const target =
+          typeof step.params.path === 'string'
+            ? step.params.path
+            : typeof step.params.command === 'string'
+              ? step.params.command
+              : '';
+        const normalizedError = error
+          .replace(/:\d+:\d+/g, '')
+          .replace(/\bline\s+\d+\b/gi, 'line')
+          .replace(/\s+/g, ' ')
+          .trim();
+        return `${step.action}|${step.tool}|${target}|${normalizedError}`;
+      })
+      .sort()
+      .join('\n');
+  }
+
+  private throwIfAborted(signal?: AbortSignal): void {
+    if (!signal?.aborted) return;
+    const reason = signal.reason;
+    if (reason instanceof Error) {
+      throw reason;
+    }
+    throw new Error(typeof reason === 'string' ? reason : 'FrontAgent run cancelled');
+  }
+
+  private async executeSinglePhaseWithRecovery(
+    phaseGroup: PhaseExecutionGroup,
+    context: {
+      task: AgentTask;
+      collectedContext: ExecutorCollectedContext;
+    },
+    completedStepIds: Set<string>,
+    allResults: ExecutorOutput[],
+    onStepStart?: (step: ExecutionStep) => void,
+    onStepComplete?: (step: ExecutionStep, output: ExecutorOutput) => void,
+    onPhaseStart?: (phase: string, stepCount: number) => void,
+    onPhaseError?: (
+      phase: string,
+      errors: Array<{ step: ExecutionStep; error: string }>,
+    ) => Promise<ExecutionStep[]>,
+    onPhaseComplete?: (
+      phase: string,
+      results: ExecutorOutput[],
+    ) => Promise<Array<{ step: ExecutionStep; error: string }>>,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const phase = phaseGroup.phase;
+    const phaseSteps = phaseGroup.steps;
+
+    this.debugLog('[Executor] ========================================');
+    this.debugLog(`[Executor] Starting phase: ${phase} (${phaseSteps.length} steps)`);
+
+    onPhaseStart?.(phase, phaseSteps.length);
+    this.debugLog(
+      `[Executor] 🔗 Phase dependencies: [${Array.from(phaseGroup.dependencies).join(', ') || 'none'}]`,
+    );
+    this.debugLog('[Executor] 📋 Steps in this phase:');
+    for (const s of phaseSteps) {
+      this.debugLog(
+        `[Executor]    - ${s.stepId}: ${s.description} (deps: [${s.dependencies.join(', ') || 'none'}])`,
+      );
+    }
+    this.debugLog(
+      `[Executor] 📊 Already completed steps: [${Array.from(completedStepIds).join(', ') || 'none'}]`,
+    );
+    this.debugLog('[Executor] ----------------------------------------');
+
+    const phaseResults: ExecutorOutput[] = [];
+    const phaseErrors: Array<{ step: ExecutionStep; error: string }> = [];
+
+    if (this.config.parallelExecution) {
+      await this.executePhaseParallel(
+        phaseSteps,
+        context,
+        completedStepIds,
+        allResults,
+        phaseResults,
+        phaseErrors,
+        onStepStart,
+        onStepComplete,
+        signal,
+      );
+    } else {
+      await this.executePhaseSequential(
+        phaseSteps,
+        context,
+        completedStepIds,
+        allResults,
+        phaseResults,
+        phaseErrors,
+        onStepStart,
+        onStepComplete,
+        signal,
+      );
+    }
+
+    if (onPhaseComplete) {
+      try {
+        this.throwIfAborted(signal);
+        const additionalErrors = await onPhaseComplete(phase, phaseResults);
+        if (additionalErrors.length > 0) {
+          this.debugLog(
+            `[Executor] Phase ${phase} validation found ${additionalErrors.length} additional issues`,
+          );
+          phaseErrors.push(...additionalErrors);
+        }
+      } catch (error) {
+        this.debugError('[Executor] Phase complete validation failed:', error);
+      }
+    }
+
+    await this.runPhaseRecovery(
+      phase,
+      phaseSteps,
+      phaseErrors,
+      context,
+      completedStepIds,
+      allResults,
+      onStepStart,
+      onStepComplete,
+      onPhaseError,
+      onPhaseComplete,
+      signal,
+    );
+
+    const phaseStats = {
+      total: phaseSteps.length,
+      completed: phaseSteps.filter((s) => s.status === 'completed').length,
+      failed: phaseSteps.filter((s) => s.status === 'failed').length,
+      skipped: phaseSteps.filter((s) => s.status === 'skipped').length,
+    };
+    this.debugLog('[Executor] ----------------------------------------');
+    this.debugLog(`[Executor] Phase ${phase} completed`);
+    this.debugLog(
+      `[Executor] 📊 Phase stats: ${phaseStats.completed}/${phaseStats.total} completed, ${phaseStats.failed} failed, ${phaseStats.skipped} skipped`,
+    );
+    this.debugLog('[Executor] ========================================');
+  }
+
+  private async executePhaseParallel(
+    phaseSteps: ExecutionStep[],
+    context: { task: AgentTask; collectedContext: ExecutorCollectedContext },
+    completedStepIds: Set<string>,
+    allResults: ExecutorOutput[],
+    phaseResults: ExecutorOutput[],
+    phaseErrors: Array<{ step: ExecutionStep; error: string }>,
+    onStepStart?: (step: ExecutionStep) => void,
+    onStepComplete?: (step: ExecutionStep, output: ExecutorOutput) => void,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const pending = [...phaseSteps];
+
+    while (pending.length > 0) {
+      this.throwIfAborted(signal);
+
+      const ready = pending.filter((step) =>
+        step.dependencies.every((dep) => completedStepIds.has(dep)),
+      );
+
+      if (ready.length === 0) {
+        const skippable = pending.filter((step) =>
+          step.dependencies.some((dep) => !completedStepIds.has(dep)),
+        );
+        for (const s of skippable) {
+          this.debugWarn(`[Executor] ⏭️  Skipping step ${s.stepId}: dependencies not met`);
+          s.status = 'skipped';
+          pending.splice(pending.indexOf(s), 1);
+        }
+        if (pending.length > 0 && skippable.length === 0) {
+          this.debugError(
+            `[Executor] Circular dependency detected within phase ${phaseSteps[0]?.phase}`,
+          );
+          break;
+        }
+        continue;
+      }
+
+      for (const s of ready) pending.splice(pending.indexOf(s), 1);
+
+      const results = await Promise.allSettled(
+        ready.map(async (step) => {
+          step.status = 'running';
+          onStepStart?.(step);
+          const output = await this.executeStep(step, context);
+          return { step, output };
+        }),
+      );
+
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          const { step, output } = result.value;
+          step.result = output.stepResult;
+          step.status = output.stepResult.success ? 'completed' : 'failed';
+          phaseResults.push(output);
+          allResults.push(output);
+          if (output.stepResult.success) {
+            completedStepIds.add(step.stepId);
+          } else {
+            phaseErrors.push({ step, error: output.stepResult.error || 'Unknown error' });
+          }
+          onStepComplete?.(step, output);
+        }
+      }
+    }
+  }
+
+  private async executePhaseSequential(
+    phaseSteps: ExecutionStep[],
+    context: { task: AgentTask; collectedContext: ExecutorCollectedContext },
+    completedStepIds: Set<string>,
+    allResults: ExecutorOutput[],
+    phaseResults: ExecutorOutput[],
+    phaseErrors: Array<{ step: ExecutionStep; error: string }>,
+    onStepStart?: (step: ExecutionStep) => void,
+    onStepComplete?: (step: ExecutionStep, output: ExecutorOutput) => void,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    for (const step of phaseSteps) {
+      this.throwIfAborted(signal);
+      const dependenciesMet = step.dependencies.every((dep) => completedStepIds.has(dep));
+      if (!dependenciesMet) {
+        const missingDeps = step.dependencies.filter((dep) => !completedStepIds.has(dep));
+        this.debugWarn(`[Executor] ⏭️  Skipping step ${step.stepId}: dependencies not met`);
+        this.debugWarn(`[Executor]    Step description: ${step.description}`);
+        this.debugWarn(`[Executor]    Required dependencies: [${step.dependencies.join(', ')}]`);
+        this.debugWarn(`[Executor]    Missing dependencies: [${missingDeps.join(', ')}]`);
+        this.debugWarn(
+          `[Executor]    Completed steps: [${Array.from(completedStepIds).join(', ')}]`,
+        );
+        step.status = 'skipped';
+        continue;
+      }
+
+      step.status = 'running';
+      onStepStart?.(step);
+      const output = await this.executeStep(step, context);
+      step.result = output.stepResult;
+      step.status = output.stepResult.success ? 'completed' : 'failed';
+
+      phaseResults.push(output);
+      allResults.push(output);
+
+      if (output.stepResult.success) {
+        completedStepIds.add(step.stepId);
+      } else {
+        phaseErrors.push({
+          step,
+          error: output.stepResult.error || 'Unknown error',
+        });
+      }
+
+      if (onStepComplete) {
+        onStepComplete(step, output);
+      }
+    }
+  }
+
+  private async runPhaseRecovery(
+    phase: string,
+    phaseSteps: ExecutionStep[],
+    phaseErrors: Array<{ step: ExecutionStep; error: string }>,
+    context: { task: AgentTask; collectedContext: ExecutorCollectedContext },
+    completedStepIds: Set<string>,
+    allResults: ExecutorOutput[],
+    onStepStart?: (step: ExecutionStep) => void,
+    onStepComplete?: (step: ExecutionStep, output: ExecutorOutput) => void,
+    onPhaseError?: (
+      phase: string,
+      errors: Array<{ step: ExecutionStep; error: string }>,
+    ) => Promise<ExecutionStep[]>,
+    onPhaseComplete?: (
+      phase: string,
+      results: ExecutorOutput[],
+    ) => Promise<Array<{ step: ExecutionStep; error: string }>>,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const maxRecoveryAttempts = this.getMaxRecoveryAttempts();
+    const seenRecoveryFingerprints = new Set<string>();
+    let recoveryAttempt = 0;
+
+    while (phaseErrors.length > 0 && onPhaseError && recoveryAttempt < maxRecoveryAttempts) {
+      this.throwIfAborted(signal);
+      const recoveryFingerprint = this.createRecoveryFingerprint(phaseErrors);
+      if (seenRecoveryFingerprints.has(recoveryFingerprint)) {
+        this.debugWarn(
+          '[Executor] Repeated recovery error fingerprint detected, stopping recovery attempts',
+        );
+        break;
+      }
+      seenRecoveryFingerprints.add(recoveryFingerprint);
+
+      recoveryAttempt++;
+      this.debugLog(
+        `[Executor] Phase ${phase} has ${phaseErrors.length} errors, recovery attempt ${recoveryAttempt}/${maxRecoveryAttempts}...`,
+      );
+
+      try {
+        const recoverySteps = await onPhaseError(phase, phaseErrors);
+        if (recoverySteps.length === 0) {
+          this.debugLog('[Executor] No recovery steps generated, stopping recovery attempts');
+          break;
+        }
+
+        this.debugLog(
+          `[Executor] Inserting ${recoverySteps.length} recovery steps for phase ${phase}`,
+        );
+
+        for (const recoveryStep of recoverySteps) {
+          recoveryStep.phase = phase;
+          phaseSteps.push(recoveryStep);
+        }
+
+        for (const recoveryStep of recoverySteps) {
+          this.throwIfAborted(signal);
+          recoveryStep.status = 'running';
+          onStepStart?.(recoveryStep);
+          const output = await this.executeStep(recoveryStep, context);
+          recoveryStep.result = output.stepResult;
+          recoveryStep.status = output.stepResult.success ? 'completed' : 'failed';
+
+          allResults.push(output);
+
+          if (output.stepResult.success) {
+            completedStepIds.add(recoveryStep.stepId);
+          }
+
+          if (onStepComplete) {
+            onStepComplete(recoveryStep, output);
+          }
+        }
+
+        if (onPhaseComplete) {
+          this.debugLog(
+            `[Executor] Re-running phase completion checks after recovery attempt ${recoveryAttempt}...`,
+          );
+          const previousPhaseErrors = phaseErrors;
+          phaseErrors = [];
+
+          try {
+            this.throwIfAborted(signal);
+            const verificationErrors = await onPhaseComplete(phase, allResults);
+            phaseErrors = verificationErrors;
+
+            if (phaseErrors.length === 0) {
+              this.debugLog('[Executor] ✅ Recovery successful! All errors fixed.');
+
+              for (const errorInfo of previousPhaseErrors) {
+                if (errorInfo.step.status === 'failed') {
+                  this.debugLog(
+                    `[Executor] Marking step ${errorInfo.step.stepId} as completed (fixed by recovery)`,
+                  );
+                  errorInfo.step.status = 'completed';
+                  completedStepIds.add(errorInfo.step.stepId);
+                }
+              }
+
+              const skippedSteps = phaseSteps.filter((s) => s.status === 'skipped');
+              if (skippedSteps.length > 0) {
+                this.debugLog(
+                  `[Executor] 🔄 Re-checking ${skippedSteps.length} skipped steps after recovery...`,
+                );
+
+                for (const skippedStep of skippedSteps) {
+                  this.throwIfAborted(signal);
+                  const dependenciesMet = skippedStep.dependencies.every((dep) =>
+                    completedStepIds.has(dep),
+                  );
+
+                  if (dependenciesMet) {
+                    this.debugLog(
+                      `[Executor] 🔄 Re-executing previously skipped step: ${skippedStep.stepId}`,
+                    );
+
+                    skippedStep.status = 'running';
+                    onStepStart?.(skippedStep);
+                    const output = await this.executeStep(skippedStep, context);
+                    skippedStep.result = output.stepResult;
+                    skippedStep.status = output.stepResult.success ? 'completed' : 'failed';
+
+                    allResults.push(output);
+
+                    if (output.stepResult.success) {
+                      completedStepIds.add(skippedStep.stepId);
+                    } else {
+                      phaseErrors.push({
+                        step: skippedStep,
+                        error: output.stepResult.error || 'Unknown error',
+                      });
+                    }
+
+                    if (onStepComplete) {
+                      onStepComplete(skippedStep, output);
+                    }
+                  }
+                }
+              }
+
+              if (phaseErrors.length === 0) {
+                break;
+              }
+              this.debugLog(
+                `[Executor] ⚠️  ${phaseErrors.length} error(s) after re-execution, continuing recovery...`,
+              );
+            } else {
+              this.debugLog(
+                `[Executor] ⚠️  Still have ${phaseErrors.length} error(s) after recovery attempt ${recoveryAttempt}`,
+              );
+              if (recoveryAttempt >= maxRecoveryAttempts) {
+                this.debugWarn(
+                  `[Executor] ❌ Max recovery attempts (${maxRecoveryAttempts}) reached. Stopping recovery.`,
+                );
+              }
+            }
+          } catch (error) {
+            this.debugError('[Executor] Verification check failed:', error);
+            break;
+          }
+        } else {
+          break;
+        }
+      } catch (error) {
+        this.debugError('[Executor] Failed to generate/execute recovery plan:', error);
+        break;
+      }
+    }
+  }
+
+  private async executeStepsWithErrorFeedbackViaLangGraph(
+    steps: ExecutionStep[],
+    context: {
+      task: AgentTask;
+      collectedContext: ExecutorCollectedContext;
+    },
+    onStepStart?: (step: ExecutionStep) => void,
+    onStepComplete?: (step: ExecutionStep, output: ExecutorOutput) => void,
+    onPhaseStart?: (phase: string, stepCount: number) => void,
+    onPhaseError?: (
+      phase: string,
+      errors: Array<{ step: ExecutionStep; error: string }>,
+    ) => Promise<ExecutionStep[]>,
+    onPhaseComplete?: (
+      phase: string,
+      results: ExecutorOutput[],
+    ) => Promise<Array<{ step: ExecutionStep; error: string }>>,
+    signal?: AbortSignal,
+  ): Promise<ExecutorOutput[]> {
+    const orderedPhaseGroups = buildOrderedPhaseGroups(steps, this.debugWarn.bind(this));
+    const serializablePhaseGroups: SerializablePhaseExecutionGroup[] = orderedPhaseGroups.map(
+      (group) => ({
+        phase: group.phase,
+        steps: group.steps,
+        dependencies: Array.from(group.dependencies),
+        firstSeenIndex: group.firstSeenIndex,
+        priority: group.priority,
+      }),
+    );
+
+    const RuntimeStateAnnotation = Annotation.Root({
+      runtime: Annotation<LangGraphRuntimeState>({
+        reducer: (_left, right) => right,
+        default: () => ({
+          phaseGroups: [],
+          phaseIndex: 0,
+          completedStepIds: [],
+          allResults: [],
+        }),
+      }),
+    });
+
+    const graph = new StateGraph(RuntimeStateAnnotation)
+      .addNode('select_phase', () => ({}))
+      .addNode('execute_phase', async (state) => {
+        const runtime = state.runtime as LangGraphRuntimeState;
+        if (runtime.phaseIndex >= runtime.phaseGroups.length) {
+          return {};
+        }
+
+        const phaseGroupData = runtime.phaseGroups[runtime.phaseIndex];
+        const phaseGroup: PhaseExecutionGroup = {
+          ...phaseGroupData,
+          dependencies: new Set(phaseGroupData.dependencies),
+        };
+        const completedStepIds = new Set(runtime.completedStepIds);
+        const allResults = [...runtime.allResults];
+
+        await this.executeSinglePhaseWithRecovery(
+          phaseGroup,
+          context,
+          completedStepIds,
+          allResults,
+          onStepStart,
+          onStepComplete,
+          onPhaseStart,
+          onPhaseError,
+          onPhaseComplete,
+          signal,
+        );
+
+        return {
+          runtime: {
+            ...runtime,
+            completedStepIds: Array.from(completedStepIds),
+            allResults,
+          },
+        };
+      })
+      .addNode('advance_phase', (state) => {
+        const runtime = state.runtime as LangGraphRuntimeState;
+        return {
+          runtime: {
+            ...runtime,
+            phaseIndex: runtime.phaseIndex + 1,
+          },
+        };
+      })
+      .addEdge(START, 'select_phase')
+      .addConditionalEdges('select_phase', (state) => {
+        const runtime = state.runtime as LangGraphRuntimeState;
+        return runtime.phaseIndex >= runtime.phaseGroups.length ? END : 'execute_phase';
+      })
+      .addEdge('execute_phase', 'advance_phase')
+      .addEdge('advance_phase', 'select_phase')
+      .compile({
+        checkpointer: this.config.langGraph?.useCheckpoint ? new MemorySaver() : undefined,
+        name: 'frontagent.phase.flow',
+      });
+
+    const initialState: LangGraphRuntimeState = {
+      phaseGroups: serializablePhaseGroups,
+      phaseIndex: 0,
+      completedStepIds: [],
+      allResults: [],
+    };
+
+    const runnableConfig = this.config.langGraph?.useCheckpoint
+      ? {
+          configurable: {
+            thread_id: `${this.config.langGraph?.threadIdPrefix ?? 'frontagent'}-${Date.now()}`,
+          },
+        }
+      : undefined;
+
+    const finalState = (await graph.invoke({ runtime: initialState }, runnableConfig as any)) as {
+      runtime?: LangGraphRuntimeState;
+    };
+
+    return finalState.runtime?.allResults ?? [];
+  }
+
+  async executeStepsWithErrorFeedback(
+    steps: ExecutionStep[],
+    context: {
+      task: AgentTask;
+      collectedContext: ExecutorCollectedContext;
+    },
+    onStepStart?: (step: ExecutionStep) => void,
+    onStepComplete?: (step: ExecutionStep, output: ExecutorOutput) => void,
+    onPhaseStart?: (phase: string, stepCount: number) => void,
+    onPhaseError?: (
+      phase: string,
+      errors: Array<{ step: ExecutionStep; error: string }>,
+    ) => Promise<ExecutionStep[]>,
+    onPhaseComplete?: (
+      phase: string,
+      results: ExecutorOutput[],
+    ) => Promise<Array<{ step: ExecutionStep; error: string }>>,
+    signal?: AbortSignal,
+  ): Promise<ExecutorOutput[]> {
+    if (this.shouldUseLangGraphEngine()) {
+      if (this.config.debug) {
+        console.log('[Executor] Using LangGraph execution engine');
+      }
+      return this.executeStepsWithErrorFeedbackViaLangGraph(
+        steps,
+        context,
+        onStepStart,
+        onStepComplete,
+        onPhaseStart,
+        onPhaseError,
+        onPhaseComplete,
+        signal,
+      );
+    }
+
+    const orderedPhaseGroups = buildOrderedPhaseGroups(steps, this.debugWarn.bind(this));
+
+    const allResults: ExecutorOutput[] = [];
+    const completedStepIds = new Set<string>();
+
+    for (const phaseGroup of orderedPhaseGroups) {
+      this.throwIfAborted(signal);
+      await this.executeSinglePhaseWithRecovery(
+        phaseGroup,
+        context,
+        completedStepIds,
+        allResults,
+        onStepStart,
+        onStepComplete,
+        onPhaseStart,
+        onPhaseError,
+        onPhaseComplete,
+        signal,
+      );
+    }
+
+    return allResults;
+  }
+
+  async rollback(snapshotId: string): Promise<{ success: boolean; message: string }> {
+    try {
+      const result = await this.callTool('rollback', { snapshotId });
+      return result as { success: boolean; message: string };
+    } catch (error) {
+      return {
+        success: false,
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+}
+
+export function createExecutor(config: ExecutorConfig): Executor {
+  return new Executor(config);
+}

--- a/packages/core/src/executor/index.ts
+++ b/packages/core/src/executor/index.ts
@@ -1,6 +1,6 @@
-export { Executor, createExecutor } from './executor/index.js';
-export { createTraceCollector } from './executor/index.js';
-export { buildOrderedPhaseGroups, detectLanguage, getPhasePriority } from './executor/index.js';
+export { Executor, createExecutor } from './executor.js';
+export { createTraceCollector } from './trace.js';
+export { buildOrderedPhaseGroups, detectLanguage, getPhasePriority } from './phase-ordering.js';
 export type {
   ExecutorCollectedContext,
   ExecutorConfig,
@@ -14,4 +14,4 @@ export type {
   MCPClient,
   PhaseExecutionGroup,
   SerializablePhaseExecutionGroup,
-} from './executor/index.js';
+} from './types.js';

--- a/packages/core/src/executor/phase-ordering.ts
+++ b/packages/core/src/executor/phase-ordering.ts
@@ -1,0 +1,163 @@
+import type { ExecutionStep } from '@frontagent/shared';
+import type { PhaseExecutionGroup } from './types.js';
+
+export function getPhasePriority(phase: string): number {
+  const normalized = phase.toLowerCase();
+
+  if (normalized.includes('分析') || normalized.includes('analy')) return 10;
+  if (
+    normalized.includes('创建') ||
+    normalized.includes('实现') ||
+    normalized.includes('create') ||
+    normalized.includes('implement')
+  )
+    return 20;
+  if (normalized.includes('安装') || normalized.includes('install')) return 30;
+  if (
+    normalized.includes('验证') ||
+    normalized.includes('验收') ||
+    normalized.includes('valid') ||
+    normalized.includes('accept')
+  )
+    return 40;
+  if (normalized.includes('启动') || normalized.includes('start') || normalized.includes('serve'))
+    return 50;
+  if (normalized.includes('浏览器') || normalized.includes('browser')) return 60;
+  if (
+    normalized.includes('仓库') ||
+    normalized.includes('repo') ||
+    normalized.includes('repository')
+  )
+    return 70;
+  if (normalized.includes('未分组') || normalized.includes('ungroup')) return 90;
+
+  return 80;
+}
+
+function comparePhaseGroup(a: PhaseExecutionGroup, b: PhaseExecutionGroup): number {
+  if (a.priority !== b.priority) {
+    return a.priority - b.priority;
+  }
+  if (a.firstSeenIndex !== b.firstSeenIndex) {
+    return a.firstSeenIndex - b.firstSeenIndex;
+  }
+  return a.phase.localeCompare(b.phase);
+}
+
+function topologicalSortPhaseGroups(
+  groups: PhaseExecutionGroup[],
+  debugWarn?: (...args: unknown[]) => void,
+): PhaseExecutionGroup[] {
+  if (groups.length <= 1) {
+    return groups;
+  }
+
+  const groupMap = new Map(groups.map((group) => [group.phase, group]));
+  const indegree = new Map<string, number>();
+  const outgoing = new Map<string, Set<string>>();
+
+  for (const group of groups) {
+    indegree.set(group.phase, 0);
+    outgoing.set(group.phase, new Set<string>());
+  }
+
+  for (const group of groups) {
+    for (const dep of group.dependencies) {
+      if (!groupMap.has(dep)) continue;
+      indegree.set(group.phase, (indegree.get(group.phase) ?? 0) + 1);
+      outgoing.get(dep)!.add(group.phase);
+    }
+  }
+
+  const ready = groups.filter((group) => (indegree.get(group.phase) ?? 0) === 0);
+  ready.sort((a, b) => comparePhaseGroup(a, b));
+
+  const ordered: PhaseExecutionGroup[] = [];
+
+  while (ready.length > 0) {
+    const current = ready.shift()!;
+    ordered.push(current);
+
+    for (const nextPhase of outgoing.get(current.phase) ?? []) {
+      const nextDegree = (indegree.get(nextPhase) ?? 0) - 1;
+      indegree.set(nextPhase, nextDegree);
+
+      if (nextDegree === 0) {
+        const nextGroup = groupMap.get(nextPhase);
+        if (nextGroup) {
+          ready.push(nextGroup);
+        }
+      }
+    }
+
+    ready.sort((a, b) => comparePhaseGroup(a, b));
+  }
+
+  if (ordered.length !== groups.length) {
+    debugWarn?.('[Executor] Detected phase dependency cycle, fallback to priority ordering');
+    return [...groups].sort((a, b) => comparePhaseGroup(a, b));
+  }
+
+  return ordered;
+}
+
+export function buildOrderedPhaseGroups(
+  steps: ExecutionStep[],
+  debugWarn?: (...args: unknown[]) => void,
+): PhaseExecutionGroup[] {
+  const phaseGroups = new Map<string, PhaseExecutionGroup>();
+  const stepToPhase = new Map<string, string>();
+
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    const phase = step.phase || '未分组';
+    stepToPhase.set(step.stepId, phase);
+
+    if (!phaseGroups.has(phase)) {
+      phaseGroups.set(phase, {
+        phase,
+        steps: [],
+        dependencies: new Set<string>(),
+        firstSeenIndex: i,
+        priority: getPhasePriority(phase),
+      });
+    }
+
+    phaseGroups.get(phase)!.steps.push(step);
+  }
+
+  for (const step of steps) {
+    const phase = step.phase || '未分组';
+    const group = phaseGroups.get(phase);
+    if (!group) continue;
+
+    for (const dep of step.dependencies) {
+      const depPhase = stepToPhase.get(dep);
+      if (!depPhase || depPhase === phase) continue;
+      group.dependencies.add(depPhase);
+    }
+  }
+
+  return topologicalSortPhaseGroups(Array.from(phaseGroups.values()), debugWarn);
+}
+
+export function detectLanguage(path: string): 'typescript' | 'javascript' | 'json' | 'yaml' | null {
+  const ext = path.split('.').pop()?.toLowerCase();
+  switch (ext) {
+    case 'ts':
+    case 'tsx':
+      return 'typescript';
+    case 'js':
+    case 'jsx':
+    case 'mjs':
+    case 'cjs':
+      return 'javascript';
+    case 'json':
+      return 'json';
+    case 'yaml':
+    case 'yml':
+      return 'yaml';
+    default:
+      return null;
+  }
+}

--- a/packages/core/src/executor/trace.ts
+++ b/packages/core/src/executor/trace.ts
@@ -1,0 +1,72 @@
+import type {
+  ExecutorStepTrace,
+  ExecutorTraceCollector,
+  ExecutorTraceConfig,
+  ExecutorTraceSummary,
+} from './types.js';
+
+function calcStats(values: number[]): { avg: number; min: number; median: number; max: number } {
+  if (values.length === 0) return { avg: 0, min: 0, median: 0, max: 0 };
+  const sorted = [...values].sort((a, b) => a - b);
+  const avg = values.reduce((a, b) => a + b, 0) / values.length;
+  return {
+    avg,
+    min: sorted[0],
+    median: sorted[Math.floor(sorted.length / 2)],
+    max: sorted[sorted.length - 1],
+  };
+}
+
+function summarizeTraces(traces: ExecutorStepTrace[]): Record<string, ExecutorTraceSummary> {
+  const byTool: Record<string, ExecutorStepTrace[]> = {};
+  for (const t of traces) {
+    (byTool[t.tool] ??= []).push(t);
+  }
+
+  const result: Record<string, ExecutorTraceSummary> = {};
+  for (const [tool, group] of Object.entries(byTool)) {
+    const stageMap: Record<string, number[]> = {};
+    const subStageMap: Record<string, number[]> = {};
+    const toolDurations: number[] = [];
+
+    for (const t of group) {
+      if (t.toolDurationMs != null) toolDurations.push(t.toolDurationMs);
+      for (const s of t.stages) {
+        (stageMap[s.name] ??= []).push(s.durationMs);
+      }
+      if (t.subStages) {
+        for (const s of t.subStages) {
+          (subStageMap[s.name] ??= []).push(s.durationMs);
+        }
+      }
+    }
+
+    const stages: Record<string, { avg: number; min: number; median: number; max: number }> = {};
+    for (const [name, vals] of Object.entries(stageMap)) stages[name] = calcStats(vals);
+    const subStages: Record<string, { avg: number; min: number; median: number; max: number }> = {};
+    for (const [name, vals] of Object.entries(subStageMap)) subStages[name] = calcStats(vals);
+
+    result[tool] = {
+      count: group.length,
+      totalMs: calcStats(group.map((t) => t.totalMs)),
+      toolDurationMs: calcStats(toolDurations),
+      stages,
+      subStages,
+    };
+  }
+  return result;
+}
+
+export function createTraceCollector(): ExecutorTraceCollector {
+  const traces: ExecutorStepTrace[] = [];
+  return {
+    traces,
+    config: {
+      enabled: true,
+      onStepTrace: (trace) => traces.push(trace),
+    } satisfies ExecutorTraceConfig,
+    summary() {
+      return summarizeTraces(traces);
+    },
+  };
+}

--- a/packages/core/src/executor/types.ts
+++ b/packages/core/src/executor/types.ts
@@ -1,0 +1,133 @@
+import type { HallucinationGuard } from '@frontagent/hallucination-guard';
+import type {
+  ApprovalRequest,
+  ExecutionStep,
+  SDDConfig,
+  SecurityConfig,
+  SecurityDecision,
+} from '@frontagent/shared';
+import type { LLMService } from '../llm.js';
+
+export interface MCPClient {
+  callTool(name: string, args: Record<string, unknown>): Promise<unknown>;
+  listTools(): Promise<Array<{ name: string; description: string }>>;
+}
+
+export interface ExecutorConfig {
+  projectRoot: string;
+  hallucinationGuard: HallucinationGuard;
+  llmService: LLMService;
+  debug?: boolean;
+  getCreatedModules?: () => string[];
+  getSddConstraints?: () => string | undefined;
+  getSkillContext?: () => string | undefined;
+  getFileSystemFacts?: () =>
+    | {
+        existingFiles: Set<string>;
+        existingDirectories: Set<string>;
+        nonExistentPaths: Set<string>;
+        directoryContents: Map<string, string[]>;
+      }
+    | undefined;
+  getMemoryRecall?: (filePath: string, action: string) => string | undefined;
+  onStreamToken?: (token: string, stepId: string) => void;
+  security?: SecurityConfig;
+  sddConfig?: SDDConfig;
+  approvalHandler?: (request: ApprovalRequest) => Promise<boolean>;
+  onSecurityDecision?: (decision: SecurityDecision) => void;
+  trace?: ExecutorTraceConfig;
+  executionEngine?: 'native' | 'langgraph';
+  langGraph?: {
+    enabled?: boolean;
+    useCheckpoint?: boolean;
+    maxRecoveryAttempts?: number;
+    threadIdPrefix?: string;
+  };
+  maxRecoveryAttempts?: number;
+  parallelExecution?: boolean;
+}
+
+export interface PhaseExecutionGroup {
+  phase: string;
+  steps: ExecutionStep[];
+  dependencies: Set<string>;
+  firstSeenIndex: number;
+  priority: number;
+}
+
+export interface ExecutorTraceStage {
+  name:
+    | 'validate_params'
+    | 'validate_before'
+    | 'prepare_tool_params'
+    | 'call_tool'
+    | 'validate_after'
+    | 'handle_tool_result'
+    | 'catch';
+  durationMs: number;
+  success: boolean;
+  error?: string;
+}
+
+export interface ExecutorSubStage {
+  name: string;
+  durationMs: number;
+  success: boolean;
+  error?: string;
+}
+
+export interface ExecutorStepTrace {
+  taskId?: string;
+  stepId: string;
+  action: string;
+  tool: string;
+  totalMs: number;
+  success: boolean;
+  skipped?: boolean;
+  error?: string;
+  stages: ExecutorTraceStage[];
+  toolDurationMs?: number;
+  subStages?: ExecutorSubStage[];
+}
+
+export interface ExecutorTraceConfig {
+  enabled?: boolean;
+  onStepTrace?: (trace: ExecutorStepTrace) => void;
+}
+
+export interface ExecutorTraceSummary {
+  count: number;
+  totalMs: { avg: number; min: number; median: number; max: number };
+  toolDurationMs: { avg: number; min: number; median: number; max: number };
+  stages: Record<string, { avg: number; min: number; median: number; max: number }>;
+  subStages: Record<string, { avg: number; min: number; median: number; max: number }>;
+}
+
+export interface ExecutorTraceCollector {
+  traces: ExecutorStepTrace[];
+  config: ExecutorTraceConfig;
+  summary(): Record<string, ExecutorTraceSummary>;
+}
+
+export interface SerializablePhaseExecutionGroup {
+  phase: string;
+  steps: ExecutionStep[];
+  dependencies: string[];
+  firstSeenIndex: number;
+  priority: number;
+}
+
+export interface LangGraphRuntimeState {
+  phaseGroups: SerializablePhaseExecutionGroup[];
+  phaseIndex: number;
+  completedStepIds: string[];
+  allResults: import('../types.js').ExecutorOutput[];
+}
+
+export interface ExecutorCollectedContext {
+  files: Map<string, string>;
+  ragResults?: string[];
+  matchedSkillNames?: string[];
+  skillContext?: string;
+  filesenseContext?: string;
+}

--- a/packages/hallucination-guard/src/guard.test.ts
+++ b/packages/hallucination-guard/src/guard.test.ts
@@ -1,20 +1,26 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { checkFileExistence } from './checks/file-existence.js';
-import { checkSyntaxValidity } from './checks/syntax-validity.js';
 import { checkAllImports, extractImports } from './checks/import-validity.js';
+import { checkSyntaxValidity } from './checks/syntax-validity.js';
 import { HallucinationGuard } from './guard.js';
 
-const TEST_ROOT = join(tmpdir(), 'frontagent-guard-test-' + Date.now());
+const TEST_ROOT = join(tmpdir(), `frontagent-guard-test-${Date.now()}`);
 
 beforeAll(() => {
   mkdirSync(TEST_ROOT, { recursive: true });
   writeFileSync(join(TEST_ROOT, 'existing.ts'), 'export const x = 1;\n');
   mkdirSync(join(TEST_ROOT, 'src'), { recursive: true });
-  writeFileSync(join(TEST_ROOT, 'src', 'utils.ts'), 'export function add(a: number, b: number) { return a + b; }\n');
-  writeFileSync(join(TEST_ROOT, 'package.json'), JSON.stringify({ dependencies: { zod: '^3.0.0' } }));
+  writeFileSync(
+    join(TEST_ROOT, 'src', 'utils.ts'),
+    'export function add(a: number, b: number) { return a + b; }\n',
+  );
+  writeFileSync(
+    join(TEST_ROOT, 'package.json'),
+    JSON.stringify({ dependencies: { zod: '^3.0.0' } }),
+  );
 });
 
 afterAll(() => {


### PR DESCRIPTION
Closes #42

## Changes

Split the monolithic `packages/core/src/executor.ts` (1864 lines) into 4 focused modules:

- **executor/types.ts** (~130 lines): All interfaces and type definitions (MCPClient, ExecutorConfig, trace types, phase types)
- **executor/trace.ts** (~70 lines): Trace collection utilities (createTraceCollector, summarizeTraces)
- **executor/phase-ordering.ts** (~140 lines): Phase dependency sorting (topological sort, priority), language detection
- **executor/executor.ts** (~1400 lines): Core Executor class with step execution, validation, security, and recovery

The original `executor.ts` becomes a thin re-export shim for backward compatibility.

## Motivation

The single-file structure mixed unrelated concerns (type definitions, utility functions, core orchestration logic). The extracted modules have clear boundaries and can be understood independently.

## Verification

- `pnpm turbo typecheck` passes (22/22 tasks)
- `pnpm lint` passes (467 files checked)
- `pnpm vitest run` passes (161 tests)