### PR TITLE
fix: improve error handling in bare catch blocks

### DIFF
--- a/packages/core/src/llm/llm-service.ts
+++ b/packages/core/src/llm/llm-service.ts
@@ -274,7 +274,7 @@ export class LLMService {
         }
 
         return result.object;
-      } catch (error: any) {
+      } catch (error: unknown) {
         const isLastAttempt = attempt === maxRetries;
 
         this.debugLog(

--- a/packages/core/src/llm/object-repair.ts
+++ b/packages/core/src/llm/object-repair.ts
@@ -14,11 +14,12 @@ const STRATEGY_NAMES = {
 } as const;
 
 export function tryFixGeneratedObject<T>(
-  error: any,
+  error: unknown,
   schema: z.ZodType<T>,
   deps: ObjectRepairDeps,
 ): T | null {
-  const errorToCheck = error.cause || error;
+  const err = error as Record<string, unknown>;
+  const errorToCheck = (err.cause || err) as Record<string, unknown>;
 
   if (!errorToCheck.value || typeof errorToCheck.value !== 'object') {
     deps.debugLog('[LLMService] No value to fix');
@@ -28,20 +29,26 @@ export function tryFixGeneratedObject<T>(
   deps.debugLog('[LLMService] ========================================');
   deps.debugLog('[LLMService] Schema Validation Error Detected');
   deps.debugLog('[LLMService] ========================================');
-  deps.debugLog('[LLMService] Error name:', error.name);
-  deps.debugLog('[LLMService] Error type:', error.constructor.name);
-  deps.debugLog('[LLMService] Has cause:', !!error.cause);
+  deps.debugLog('[LLMService] Error name:', err.name);
+  deps.debugLog(
+    '[LLMService] Error type:',
+    (error as { constructor?: { name?: string } })?.constructor?.name,
+  );
+  deps.debugLog('[LLMService] Has cause:', !!err.cause);
   deps.debugLog('[LLMService] Original value keys:', Object.keys(errorToCheck.value));
   deps.debugLog(
     '[LLMService] Original value structure:',
     `${JSON.stringify(errorToCheck.value, null, 2).substring(0, 500)}...`,
   );
 
-  if (errorToCheck.cause?.issues) {
+  if ((errorToCheck.cause as Record<string, unknown>)?.issues) {
     deps.debugLog('[LLMService] Zod validation issues:');
-    errorToCheck.cause.issues.forEach((issue: any, index: number) => {
+    const issues = (errorToCheck.cause as Record<string, unknown>).issues as Array<
+      Record<string, unknown>
+    >;
+    issues.forEach((issue, index: number) => {
       deps.debugLog(`[LLMService]   Issue ${index + 1}:`, {
-        path: issue.path.join('.'),
+        path: (issue.path as string[])?.join('.'),
         message: issue.message,
         expected: issue.expected,
         received: issue.received,
@@ -110,7 +117,7 @@ export function tryFixGeneratedObject<T>(
   return null;
 }
 
-export function unwrapDollarKeys(obj: any, deps: ObjectRepairDeps): any {
+export function unwrapDollarKeys(obj: unknown, deps: ObjectRepairDeps): unknown {
   if (typeof obj !== 'object' || obj === null) {
     return obj;
   }
@@ -119,15 +126,16 @@ export function unwrapDollarKeys(obj: any, deps: ObjectRepairDeps): any {
     return obj.map((item) => unwrapDollarKeys(item, deps));
   }
 
-  const dollarKeys = Object.keys(obj).filter((key) => key.startsWith('$'));
+  const record = obj as Record<string, unknown>;
+  const dollarKeys = Object.keys(record).filter((key) => key.startsWith('$'));
 
-  if (dollarKeys.length === 1 && Object.keys(obj).length === 1) {
+  if (dollarKeys.length === 1 && Object.keys(record).length === 1) {
     deps.debugLog(`[LLMService] Unwrapping ${dollarKeys[0]}`);
-    return unwrapDollarKeys(obj[dollarKeys[0]], deps);
+    return unwrapDollarKeys(record[dollarKeys[0]], deps);
   }
 
-  const result: any = {};
-  for (const [key, value] of Object.entries(obj)) {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
     if (!key.startsWith('$')) {
       result[key] = unwrapDollarKeys(value, deps);
     }
@@ -136,7 +144,7 @@ export function unwrapDollarKeys(obj: any, deps: ObjectRepairDeps): any {
   return result;
 }
 
-export function deepParseStringifiedFields(obj: any, deps: ObjectRepairDeps): any {
+export function deepParseStringifiedFields(obj: unknown, deps: ObjectRepairDeps): unknown {
   if (typeof obj !== 'object' || obj === null) {
     return obj;
   }
@@ -145,9 +153,10 @@ export function deepParseStringifiedFields(obj: any, deps: ObjectRepairDeps): an
     return obj.map((item) => deepParseStringifiedFields(item, deps));
   }
 
-  const result: any = {};
+  const record = obj as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
 
-  for (const [key, value] of Object.entries(obj)) {
+  for (const [key, value] of Object.entries(record)) {
     if (typeof value === 'string' && value.trim().length > 0) {
       if (value.trim().startsWith('[') || value.trim().startsWith('{')) {
         try {

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -76,6 +76,7 @@ export class MemoryStore {
       const raw = readFileSync(indexPath, 'utf-8');
       return this.parseIndex(raw);
     } catch {
+      // Corrupted index file — caller will recreate
       return null;
     }
   }
@@ -164,6 +165,7 @@ export class MemoryStore {
       this.topicCache.set(topicId, topic);
       return topic;
     } catch {
+      // Corrupted topic file — treat as missing
       return null;
     }
   }
@@ -261,6 +263,7 @@ export class MemoryStore {
       const raw = readFileSync(snapshotPath, 'utf-8');
       return JSON.parse(raw) as ProjectFactsSnapshot;
     } catch {
+      // Corrupted snapshot — caller will regenerate
       return null;
     }
   }

--- a/packages/mcp-file/src/tools/search-code.ts
+++ b/packages/mcp-file/src/tools/search-code.ts
@@ -148,7 +148,9 @@ export async function searchCode(
             }
           }
         }
-      } catch {}
+      } catch {
+        // File read failed (e.g. binary file, permission denied) — skip silently
+      }
     }
 
     return {


### PR DESCRIPTION
## Summary

Improve error handling patterns across the codebase by eliminating unsafe `any` types and documenting intentional catch-and-ignore patterns.

## Changes

- **packages/mcp-file/src/tools/search-code.ts**: Add comment explaining why file read errors are skipped (binary files, permission denied)
- **packages/core/src/memory/store.ts**: Add comments to 3 catch blocks explaining the corrupted-file recovery pattern
- **packages/core/src/llm/llm-service.ts**: Change `catch (error: any)` to `catch (error: unknown)`
- **packages/core/src/llm/object-repair.ts**: Full rewrite from `any` to `unknown` with proper `Record<string, unknown>` narrowing — eliminates 8 `any` usages

## Verification

- Typecheck: pass
- Lint: clean
- Tests: all pass

Closes #52