### PR TITLE
fix: eliminate `as any` in CLI package

### DIFF
--- a/apps/cli/src/commands/run.tsx
+++ b/apps/cli/src/commands/run.tsx
@@ -109,7 +109,9 @@ export default async function runCommand(task: string, options: Record<string, a
         taskId: '',
         executedSteps: [],
         error: errorMessage,
-      } as any,
+        duration: 0,
+        validations: [],
+      },
     });
   } finally {
     store.recordActivity('收尾完成', null);

--- a/apps/cli/src/mcp-client.ts
+++ b/apps/cli/src/mcp-client.ts
@@ -5,6 +5,12 @@
 
 import type { MCPClient } from '@frontagent/core';
 import {
+  type ApplyPatchParams,
+  type CreateFileParams,
+  type GetASTParams,
+  type ListDirectoryParams,
+  type ReadFileParams,
+  type SearchCodeParams,
   SnapshotManager,
   applyPatch,
   createFile,
@@ -13,7 +19,7 @@ import {
   readFile,
   searchCode,
 } from '@frontagent/mcp-file';
-import { type KnowledgeBaseConfig, ragQuery } from '@frontagent/mcp-memory';
+import { type KnowledgeBaseConfig, type RagQueryParams, ragQuery } from '@frontagent/mcp-memory';
 import { type BrowserManager, createBrowserManager } from '@frontagent/mcp-web';
 
 /**
@@ -31,28 +37,36 @@ export class FileMCPClient implements MCPClient {
   async callTool(name: string, args: Record<string, unknown>): Promise<unknown> {
     switch (name) {
       case 'read_file':
-        return readFile(args as any, this.projectRoot);
+        return readFile(args as unknown as ReadFileParams, this.projectRoot);
 
       case 'apply_patch':
-        return applyPatch(args as any, this.projectRoot, this.snapshotManager);
+        return applyPatch(
+          args as unknown as ApplyPatchParams,
+          this.projectRoot,
+          this.snapshotManager,
+        );
 
       case 'create_file':
-        return createFile(args as any, this.projectRoot, this.snapshotManager);
+        return createFile(
+          args as unknown as CreateFileParams,
+          this.projectRoot,
+          this.snapshotManager,
+        );
 
       case 'search_code':
-        return searchCode(args as any, this.projectRoot);
+        return searchCode(args as unknown as SearchCodeParams, this.projectRoot);
 
       case 'list_directory':
-        return listDirectory(args as any, this.projectRoot);
+        return listDirectory(args as unknown as ListDirectoryParams, this.projectRoot);
 
       case 'get_ast':
-        return getAST(args as any, this.projectRoot);
+        return getAST(args as unknown as GetASTParams, this.projectRoot);
 
       case 'rollback':
-        return this.snapshotManager.rollback((args as any).snapshotId);
+        return this.snapshotManager.rollback((args as { snapshotId: string }).snapshotId);
 
       case 'get_snapshots': {
-        const filePath = (args as any).filePath;
+        const filePath = (args as { filePath?: string }).filePath;
         if (filePath) {
           return { snapshots: this.snapshotManager.getFileSnapshots(filePath) };
         }
@@ -186,7 +200,7 @@ export class MemoryMCPClient implements MCPClient {
   async callTool(name: string, args: Record<string, unknown>): Promise<unknown> {
     switch (name) {
       case 'rag_query':
-        return ragQuery(args as any, this.knowledgeBaseConfig);
+        return ragQuery(args as unknown as RagQueryParams, this.knowledgeBaseConfig);
       default:
         throw new Error(`Unknown memory tool: ${name}`);
     }


### PR DESCRIPTION
## Summary

Remove all 10 `as any` type assertions from the CLI package.

## Changes

- **apps/cli/src/mcp-client.ts**: Import specific param types (`ReadFileParams`, `ApplyPatchParams`, `CreateFileParams`, `SearchCodeParams`, `ListDirectoryParams`, `GetASTParams`, `RagQueryParams`) and use `as unknown as T` pattern
- **apps/cli/src/commands/run.tsx**: Provide all required `AgentExecutionResult` fields (`duration: 0`, `validations: []`) instead of casting incomplete object

## Verification

- Typecheck: pass
- Lint: clean
- Tests: all pass

Closes #53