### PR TITLE
test(mcp-memory): add unit tests for RAG modules

### DIFF
--- a/packages/mcp-memory/src/rag/bm25.test.ts
+++ b/packages/mcp-memory/src/rag/bm25.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aggregateChunkCandidates,
+  buildSnippet,
+  matchesMetadataFilter,
+  searchBm25,
+  tokenize,
+} from './bm25.js';
+import type { RepositoryChunk, RepositoryDocument, RepositoryIndex } from './types.js';
+import { INDEX_VERSION } from './types.js';
+
+function makeChunk(overrides: Partial<RepositoryChunk> = {}): RepositoryChunk {
+  return {
+    id: 'chunk:test:0',
+    documentId: 'doc:test',
+    path: 'src/index.ts',
+    sourceUrl: 'https://example.com/blob/main/src/index.ts',
+    title: 'index.ts',
+    text: 'function hello() { return "world"; }',
+    keywordText: 'src/index.ts\nfunction hello() { return "world"; }',
+    contentHash: 'abc123',
+    tokenCount: 5,
+    termFrequency: { hello: 1, function: 1, world: 1, return: 1, 'src/index.ts': 1 },
+    metadata: {
+      extension: '.ts',
+      topLevelDir: 'src',
+      chunkIndex: 0,
+      totalChunks: 1,
+      lineStart: 1,
+      lineEnd: 1,
+    },
+    ...overrides,
+  };
+}
+
+function makeDocument(overrides: Partial<RepositoryDocument> = {}): RepositoryDocument {
+  return {
+    id: 'doc:test',
+    path: 'src/index.ts',
+    title: 'index.ts',
+    sourceUrl: 'https://example.com/blob/main/src/index.ts',
+    extension: '.ts',
+    topLevelDir: 'src',
+    sizeBytes: 100,
+    contentHash: 'abc123',
+    chunkIds: ['chunk:test:0'],
+    ...overrides,
+  };
+}
+
+function makeIndex(chunks: RepositoryChunk[], documents: RepositoryDocument[]): RepositoryIndex {
+  const documentFrequency: Record<string, number> = {};
+  let totalLength = 0;
+  for (const chunk of chunks) {
+    for (const token of Object.keys(chunk.termFrequency)) {
+      documentFrequency[token] = (documentFrequency[token] ?? 0) + 1;
+    }
+    totalLength += chunk.tokenCount;
+  }
+  return {
+    version: INDEX_VERSION,
+    source: {
+      repoUrl: 'https://example.com/repo.git',
+      branch: 'main',
+      syncedAt: '2024-01-01T00:00:00Z',
+      revision: 'abc123',
+      repoDir: '/tmp/repo',
+      indexedFiles: documents.length,
+      indexedChunks: chunks.length,
+      excludedPathPrefixes: [],
+      excludedSubmodulePaths: [],
+    },
+    build: {
+      chunkSize: 1200,
+      chunkOverlap: 200,
+      maxFileSizeBytes: 256 * 1024,
+      chunkingStrategy: 'semantic-v2',
+      chunkSignature: 'sig',
+    },
+    bm25: {
+      documentCount: chunks.length,
+      averageDocumentLength: chunks.length > 0 ? totalLength / chunks.length : 0,
+      documentFrequency,
+    },
+    documents,
+    chunks,
+  };
+}
+
+describe('tokenize', () => {
+  it('lowercases and splits on word boundaries', () => {
+    const tokens = tokenize('Hello World');
+    expect(tokens).toContain('hello');
+    expect(tokens).toContain('world');
+  });
+
+  it('splits camelCase identifiers', () => {
+    const tokens = tokenize('getUserName');
+    expect(tokens).toContain('get');
+    expect(tokens).toContain('user');
+    expect(tokens).toContain('name');
+  });
+
+  it('splits snake_case identifiers', () => {
+    const tokens = tokenize('get_user_name');
+    expect(tokens).toContain('get');
+    expect(tokens).toContain('user');
+    expect(tokens).toContain('name');
+  });
+
+  it('deduplicates tokens', () => {
+    const tokens = tokenize('hello hello hello');
+    expect(tokens.filter((t) => t === 'hello')).toHaveLength(1);
+  });
+
+  it('skips single-character tokens', () => {
+    const tokens = tokenize('a b c de fg');
+    expect(tokens).not.toContain('a');
+    expect(tokens).not.toContain('b');
+    expect(tokens).toContain('de');
+    expect(tokens).toContain('fg');
+  });
+
+  it('handles CJK bigrams', () => {
+    const tokens = tokenize('知识库');
+    expect(tokens).toContain('知识');
+    expect(tokens).toContain('识库');
+  });
+
+  it('returns empty for empty input', () => {
+    expect(tokenize('')).toEqual([]);
+  });
+});
+
+describe('searchBm25', () => {
+  it('returns matching chunks ranked by score', () => {
+    const chunk1 = makeChunk({
+      id: 'chunk:a:0',
+      termFrequency: { hello: 3, world: 1 },
+      tokenCount: 10,
+    });
+    const chunk2 = makeChunk({
+      id: 'chunk:b:0',
+      termFrequency: { hello: 1, foo: 2 },
+      tokenCount: 10,
+    });
+    const doc = makeDocument();
+    const index = makeIndex([chunk1, chunk2], [doc]);
+
+    const results = searchBm25(index, 'hello', 10);
+    expect(results.length).toBe(2);
+    expect(results[0].chunk.id).toBe('chunk:a:0');
+    expect(results[0].score).toBeGreaterThan(results[1].score);
+  });
+
+  it('returns empty for no matches', () => {
+    const chunk = makeChunk({ termFrequency: { foo: 1 } });
+    const doc = makeDocument();
+    const index = makeIndex([chunk], [doc]);
+
+    const results = searchBm25(index, 'nonexistent', 10);
+    expect(results).toHaveLength(0);
+  });
+
+  it('returns empty for empty query', () => {
+    const chunk = makeChunk();
+    const doc = makeDocument();
+    const index = makeIndex([chunk], [doc]);
+
+    const results = searchBm25(index, '', 10);
+    expect(results).toHaveLength(0);
+  });
+
+  it('respects limit', () => {
+    const chunks = Array.from({ length: 5 }, (_, i) =>
+      makeChunk({
+        id: `chunk:${i}:0`,
+        termFrequency: { hello: i + 1 },
+        tokenCount: 10,
+      }),
+    );
+    const doc = makeDocument();
+    const index = makeIndex(chunks, [doc]);
+
+    const results = searchBm25(index, 'hello', 2);
+    expect(results).toHaveLength(2);
+  });
+});
+
+describe('matchesMetadataFilter', () => {
+  const chunk = makeChunk({
+    path: 'src/utils/helper.ts',
+    metadata: {
+      extension: '.ts',
+      topLevelDir: 'src',
+      chunkIndex: 0,
+      totalChunks: 1,
+      lineStart: 1,
+      lineEnd: 10,
+    },
+  });
+
+  it('returns true when no filters', () => {
+    expect(matchesMetadataFilter(chunk, undefined)).toBe(true);
+    expect(matchesMetadataFilter(chunk, {})).toBe(true);
+  });
+
+  it('filters by topLevelDirs', () => {
+    expect(matchesMetadataFilter(chunk, { topLevelDirs: ['src'] })).toBe(true);
+    expect(matchesMetadataFilter(chunk, { topLevelDirs: ['docs'] })).toBe(false);
+  });
+
+  it('filters by extensions', () => {
+    expect(matchesMetadataFilter(chunk, { extensions: ['.ts', '.js'] })).toBe(true);
+    expect(matchesMetadataFilter(chunk, { extensions: ['.py'] })).toBe(false);
+  });
+
+  it('filters by pathPrefixes', () => {
+    expect(matchesMetadataFilter(chunk, { pathPrefixes: ['src/utils'] })).toBe(true);
+    expect(matchesMetadataFilter(chunk, { pathPrefixes: ['docs/'] })).toBe(false);
+  });
+
+  it('filters by excludePathPrefixes', () => {
+    expect(matchesMetadataFilter(chunk, { excludePathPrefixes: ['src/utils'] })).toBe(false);
+    expect(matchesMetadataFilter(chunk, { excludePathPrefixes: ['docs/'] })).toBe(true);
+  });
+});
+
+describe('aggregateChunkCandidates', () => {
+  it('picks best chunk per document', () => {
+    const doc = makeDocument({ id: 'doc:file' });
+    const chunk1 = makeChunk({ id: 'chunk:file:0', documentId: 'doc:file' });
+    const chunk2 = makeChunk({ id: 'chunk:file:1', documentId: 'doc:file' });
+    const index = makeIndex([chunk1, chunk2], [doc]);
+
+    const candidates = aggregateChunkCandidates(
+      [
+        { chunk: chunk1, score: 5 },
+        { chunk: chunk2, score: 10 },
+      ],
+      index,
+    );
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].chunk.id).toBe('chunk:file:1');
+    expect(candidates[0].score).toBe(10);
+  });
+
+  it('applies metadata filters', () => {
+    const doc = makeDocument({ id: 'doc:file' });
+    const chunk = makeChunk({
+      id: 'chunk:file:0',
+      documentId: 'doc:file',
+      metadata: {
+        extension: '.ts',
+        topLevelDir: 'src',
+        chunkIndex: 0,
+        totalChunks: 1,
+        lineStart: 1,
+        lineEnd: 5,
+      },
+    });
+    const index = makeIndex([chunk], [doc]);
+
+    const withMatch = aggregateChunkCandidates([{ chunk, score: 5 }], index, {
+      topLevelDirs: ['src'],
+    });
+    expect(withMatch).toHaveLength(1);
+
+    const withoutMatch = aggregateChunkCandidates([{ chunk, score: 5 }], index, {
+      topLevelDirs: ['docs'],
+    });
+    expect(withoutMatch).toHaveLength(0);
+  });
+});
+
+describe('buildSnippet', () => {
+  it('returns text around the first matching token', () => {
+    const text = `${'a'.repeat(200)}targetWord${'b'.repeat(200)}`;
+    const snippet = buildSnippet(text, 'targetWord');
+    expect(snippet).toContain('targetWord');
+    expect(snippet.length).toBeLessThan(text.length);
+  });
+
+  it('falls back to first 320 chars when no match', () => {
+    const text = 'x'.repeat(500);
+    const snippet = buildSnippet(text, 'nonexistent_query_xyz');
+    expect(snippet).toHaveLength(320);
+  });
+
+  it('handles short text', () => {
+    const text = 'short text';
+    const snippet = buildSnippet(text, 'short');
+    expect(snippet).toBe('short text');
+  });
+});

--- a/packages/mcp-memory/src/rag/chunking.test.ts
+++ b/packages/mcp-memory/src/rag/chunking.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { chunkText } from './chunking.js';
+
+describe('chunkText', () => {
+  it('returns empty for empty/whitespace content', () => {
+    expect(chunkText('', 'test.ts', 1200, 200)).toEqual([]);
+    expect(chunkText('   \n  \n  ', 'test.ts', 1200, 200)).toEqual([]);
+  });
+
+  it('returns a single chunk for short content', () => {
+    const content = 'const x = 1;\nconst y = 2;';
+    const chunks = chunkText(content, 'test.ts', 1200, 200);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].text).toContain('const x = 1;');
+    expect(chunks[0].lineStart).toBe(1);
+    expect(chunks[0].lineEnd).toBe(2);
+  });
+
+  it('splits large content into multiple chunks', () => {
+    const lines = Array.from({ length: 100 }, (_, i) => `const var${i} = ${i};`);
+    const content = lines.join('\n\n');
+    const chunks = chunkText(content, 'test.ts', 200, 50);
+    expect(chunks.length).toBeGreaterThan(1);
+  });
+
+  it('preserves line numbers across chunks', () => {
+    const lines = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`);
+    const content = lines.join('\n\n');
+    const chunks = chunkText(content, 'test.md', 100, 20);
+    expect(chunks[0].lineStart).toBe(1);
+    for (let i = 1; i < chunks.length; i++) {
+      expect(chunks[i].lineStart).toBeGreaterThanOrEqual(chunks[i - 1].lineStart);
+    }
+  });
+
+  it('handles markdown headers as semantic boundaries', () => {
+    const content =
+      '# Title\n\nSome intro text.\n\n## Section A\n\nContent A.\n\n## Section B\n\nContent B.';
+    const chunks = chunkText(content, 'readme.md', 50, 10);
+    expect(chunks.length).toBeGreaterThan(1);
+  });
+
+  it('handles code fences as blocks', () => {
+    const content = 'Some text\n\n```ts\nconst x = 1;\nconst y = 2;\n```\n\nMore text';
+    const chunks = chunkText(content, 'doc.md', 1200, 200);
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+    const allText = chunks.map((c) => c.text).join('\n');
+    expect(allText).toContain('```ts');
+    expect(allText).toContain('const x = 1;');
+  });
+
+  it('recognizes TypeScript function boundaries', () => {
+    const content = [
+      'export function foo() {',
+      '  return 1;',
+      '}',
+      '',
+      'export function bar() {',
+      '  return 2;',
+      '}',
+    ].join('\n');
+    const chunks = chunkText(content, 'module.ts', 60, 10);
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('handles overlap between chunks', () => {
+    const blocks = Array.from({ length: 20 }, (_, i) => `Block ${i}: ${'x'.repeat(40)}`);
+    const content = blocks.join('\n\n');
+    const chunks = chunkText(content, 'test.txt', 150, 60);
+    if (chunks.length >= 2) {
+      const firstEnd = chunks[0].lineEnd;
+      const secondStart = chunks[1].lineStart;
+      expect(secondStart).toBeLessThanOrEqual(firstEnd + 1);
+    }
+  });
+});

--- a/packages/mcp-memory/src/rag/normalize-config.test.ts
+++ b/packages/mcp-memory/src/rag/normalize-config.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeConfig, normalizeFiltersForCache, validateMetadataFilters } from './config.js';
+import type { KnowledgeBaseConfig } from './types.js';
+
+function baseConfig(overrides: Partial<KnowledgeBaseConfig> = {}): KnowledgeBaseConfig {
+  return {
+    repoUrl: 'https://github.com/user/repo.git',
+    branch: 'main',
+    cacheDir: '/tmp/rag-cache',
+    ...overrides,
+  };
+}
+
+describe('normalizeConfig', () => {
+  it('fills all defaults from minimal config', () => {
+    const result = normalizeConfig(baseConfig());
+    expect(result.repoUrl).toBe('https://github.com/user/repo.git');
+    expect(result.branch).toBe('main');
+    expect(result.syncOnQuery).toBe(false);
+    expect(result.maxResults).toBe(5);
+    expect(result.chunkSize).toBe(1200);
+    expect(result.chunkOverlap).toBe(200);
+    expect(result.keywordWeight).toBe(0.45);
+    expect(result.semanticWeight).toBe(0.55);
+    expect(result.embedding.enabled).toBe(true);
+    expect(result.embedding.provider).toBe('openai-compatible');
+    expect(result.reranker.enabled).toBe(false);
+    expect(result.vectorStore.provider).toBe('local');
+  });
+
+  it('respects explicit overrides', () => {
+    const result = normalizeConfig(
+      baseConfig({
+        maxResults: 20,
+        chunkSize: 800,
+        syncOnQuery: true,
+        keywordWeight: 0.6,
+        semanticWeight: 0.4,
+      }),
+    );
+    expect(result.maxResults).toBe(20);
+    expect(result.chunkSize).toBe(800);
+    expect(result.syncOnQuery).toBe(true);
+    expect(result.keywordWeight).toBe(0.6);
+    expect(result.semanticWeight).toBe(0.4);
+  });
+
+  it('resolves cacheDir to absolute path', () => {
+    const result = normalizeConfig(baseConfig({ cacheDir: './relative/path' }));
+    expect(result.cacheDir).toMatch(/^\//);
+  });
+
+  it('normalizes embedding baseURL with /embeddings suffix', () => {
+    const result = normalizeConfig(
+      baseConfig({
+        embedding: { baseURL: 'https://api.openai.com/v1' },
+      }),
+    );
+    expect(result.embedding.baseURL).toBe('https://api.openai.com/v1/embeddings');
+  });
+});
+
+describe('normalizeFiltersForCache', () => {
+  it('returns undefined for no filters', () => {
+    expect(normalizeFiltersForCache(undefined)).toBeUndefined();
+  });
+
+  it('sorts arrays for stable cache keys', () => {
+    const result = normalizeFiltersForCache({
+      topLevelDirs: ['docs', 'src', 'apps'],
+      extensions: ['.tsx', '.ts'],
+    });
+    expect(result?.topLevelDirs).toEqual(['apps', 'docs', 'src']);
+    expect(result?.extensions).toEqual(['.ts', '.tsx']);
+  });
+
+  it('preserves undefined fields', () => {
+    const result = normalizeFiltersForCache({ topLevelDirs: ['src'] });
+    expect(result?.extensions).toBeUndefined();
+    expect(result?.pathPrefixes).toBeUndefined();
+  });
+});
+
+describe('validateMetadataFilters', () => {
+  it('returns undefined for no filters', () => {
+    expect(validateMetadataFilters(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for safe paths', () => {
+    expect(validateMetadataFilters({ pathPrefixes: ['src/utils'] })).toBeUndefined();
+    expect(validateMetadataFilters({ topLevelDirs: ['packages'] })).toBeUndefined();
+  });
+
+  it('rejects absolute paths', () => {
+    const error = validateMetadataFilters({ pathPrefixes: ['/etc/passwd'] });
+    expect(error).toContain('Unsafe');
+  });
+
+  it('rejects path traversal', () => {
+    const error = validateMetadataFilters({ pathPrefixes: ['src/../../../etc'] });
+    expect(error).toContain('Unsafe');
+  });
+
+  it('rejects traversal in excludePathPrefixes', () => {
+    const error = validateMetadataFilters({ excludePathPrefixes: ['../secret'] });
+    expect(error).toContain('Unsafe');
+  });
+
+  it('rejects traversal in topLevelDirs', () => {
+    const error = validateMetadataFilters({ topLevelDirs: ['/root'] });
+    expect(error).toContain('Unsafe');
+  });
+});

--- a/packages/mcp-memory/src/rag/repository.test.ts
+++ b/packages/mcp-memory/src/rag/repository.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { canReuseIndex } from './repository.js';
+import type { RepositoryIndex } from './types.js';
+import { INDEX_VERSION } from './types.js';
+
+function makeIndex(overrides: Partial<RepositoryIndex> = {}): RepositoryIndex {
+  return {
+    version: INDEX_VERSION,
+    source: {
+      repoUrl: 'https://github.com/user/repo.git',
+      branch: 'main',
+      syncedAt: '2024-01-01T00:00:00Z',
+      revision: 'abc123',
+      repoDir: '/tmp/cache/repo',
+      indexedFiles: 10,
+      indexedChunks: 50,
+      excludedPathPrefixes: ['vendor'],
+      excludedSubmodulePaths: ['lib/external'],
+    },
+    build: {
+      chunkSize: 1200,
+      chunkOverlap: 200,
+      maxFileSizeBytes: 256 * 1024,
+      chunkingStrategy: 'semantic-v2',
+      chunkSignature: 'sig123',
+    },
+    bm25: {
+      documentCount: 50,
+      averageDocumentLength: 100,
+      documentFrequency: {},
+    },
+    documents: [],
+    chunks: [],
+    ...overrides,
+  };
+}
+
+const baseExpected = {
+  repoUrl: 'https://github.com/user/repo.git',
+  branch: 'main',
+  revision: 'abc123',
+  repoDir: '/tmp/cache/repo',
+  excludedPathPrefixes: ['vendor'],
+  excludedSubmodulePaths: ['lib/external'],
+  chunkSize: 1200,
+  chunkOverlap: 200,
+  maxFileSizeBytes: 256 * 1024,
+};
+
+describe('canReuseIndex', () => {
+  it('returns true when all fields match', () => {
+    expect(canReuseIndex(makeIndex(), baseExpected)).toBe(true);
+  });
+
+  it('returns false when version differs', () => {
+    const index = makeIndex();
+    (index as { version: number }).version = INDEX_VERSION - 1;
+    expect(canReuseIndex(index, baseExpected)).toBe(false);
+  });
+
+  it('returns false when repoUrl differs', () => {
+    expect(
+      canReuseIndex(makeIndex(), { ...baseExpected, repoUrl: 'https://other.com/repo.git' }),
+    ).toBe(false);
+  });
+
+  it('returns false when branch differs', () => {
+    expect(canReuseIndex(makeIndex(), { ...baseExpected, branch: 'develop' })).toBe(false);
+  });
+
+  it('returns false when revision differs', () => {
+    expect(canReuseIndex(makeIndex(), { ...baseExpected, revision: 'def456' })).toBe(false);
+  });
+
+  it('returns false when repoDir differs', () => {
+    expect(canReuseIndex(makeIndex(), { ...baseExpected, repoDir: '/other/path' })).toBe(false);
+  });
+
+  it('returns false when excludedPathPrefixes differ', () => {
+    expect(
+      canReuseIndex(makeIndex(), { ...baseExpected, excludedPathPrefixes: ['vendor', 'extra'] }),
+    ).toBe(false);
+  });
+
+  it('returns false when chunkSize differs', () => {
+    expect(canReuseIndex(makeIndex(), { ...baseExpected, chunkSize: 800 })).toBe(false);
+  });
+
+  it('returns false when chunkOverlap differs', () => {
+    expect(canReuseIndex(makeIndex(), { ...baseExpected, chunkOverlap: 100 })).toBe(false);
+  });
+
+  it('returns false when maxFileSizeBytes differs', () => {
+    expect(canReuseIndex(makeIndex(), { ...baseExpected, maxFileSizeBytes: 512 * 1024 })).toBe(
+      false,
+    );
+  });
+
+  it('returns false when chunkingStrategy is not semantic-v2', () => {
+    const index = makeIndex();
+    index.build.chunkingStrategy = 'naive';
+    expect(canReuseIndex(index, baseExpected)).toBe(false);
+  });
+});

--- a/packages/mcp-memory/src/rag/utils.test.ts
+++ b/packages/mcp-memory/src/rag/utils.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getNumber,
+  getString,
+  hashText,
+  normalizeBaseUrl,
+  normalizeEmbeddingBaseUrl,
+  normalizeOptionalBaseUrl,
+  normalizeRepoPath,
+  normalizeRerankerBaseUrl,
+  parseOptionalBoolean,
+  parseOptionalInt,
+  parseStringList,
+  sameStringSet,
+  toBlobUrl,
+} from './utils.js';
+
+describe('normalizeRepoPath', () => {
+  it('converts backslashes to forward slashes', () => {
+    expect(normalizeRepoPath('src\\utils\\index.ts')).toBe('src/utils/index.ts');
+  });
+
+  it('strips leading ./', () => {
+    expect(normalizeRepoPath('./src/index.ts')).toBe('src/index.ts');
+  });
+
+  it('strips leading /', () => {
+    expect(normalizeRepoPath('/src/index.ts')).toBe('src/index.ts');
+  });
+
+  it('strips multiple leading slashes', () => {
+    expect(normalizeRepoPath('///src/index.ts')).toBe('src/index.ts');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(normalizeRepoPath('')).toBe('');
+  });
+});
+
+describe('normalizeBaseUrl', () => {
+  it('strips trailing slashes', () => {
+    expect(normalizeBaseUrl('https://api.example.com/')).toBe('https://api.example.com');
+    expect(normalizeBaseUrl('https://api.example.com///')).toBe('https://api.example.com');
+  });
+
+  it('leaves clean URLs unchanged', () => {
+    expect(normalizeBaseUrl('https://api.example.com')).toBe('https://api.example.com');
+  });
+});
+
+describe('normalizeOptionalBaseUrl', () => {
+  it('returns undefined for empty/whitespace', () => {
+    expect(normalizeOptionalBaseUrl('')).toBeUndefined();
+    expect(normalizeOptionalBaseUrl('   ')).toBeUndefined();
+    expect(normalizeOptionalBaseUrl(undefined)).toBeUndefined();
+  });
+
+  it('trims and normalizes', () => {
+    expect(normalizeOptionalBaseUrl('  https://api.example.com/  ')).toBe(
+      'https://api.example.com',
+    );
+  });
+});
+
+describe('normalizeEmbeddingBaseUrl', () => {
+  it('appends /embeddings if missing', () => {
+    expect(normalizeEmbeddingBaseUrl('https://api.openai.com/v1')).toBe(
+      'https://api.openai.com/v1/embeddings',
+    );
+  });
+
+  it('does not double-append /embeddings', () => {
+    expect(normalizeEmbeddingBaseUrl('https://api.openai.com/v1/embeddings')).toBe(
+      'https://api.openai.com/v1/embeddings',
+    );
+  });
+
+  it('strips trailing slash before appending', () => {
+    expect(normalizeEmbeddingBaseUrl('https://api.openai.com/v1/')).toBe(
+      'https://api.openai.com/v1/embeddings',
+    );
+  });
+});
+
+describe('normalizeRerankerBaseUrl', () => {
+  it('appends /rerank if missing', () => {
+    expect(normalizeRerankerBaseUrl('https://api.jina.ai/v1')).toBe(
+      'https://api.jina.ai/v1/rerank',
+    );
+  });
+
+  it('does not double-append /rerank', () => {
+    expect(normalizeRerankerBaseUrl('https://api.jina.ai/v1/rerank')).toBe(
+      'https://api.jina.ai/v1/rerank',
+    );
+  });
+});
+
+describe('toBlobUrl', () => {
+  it('builds a GitHub blob URL', () => {
+    expect(toBlobUrl('https://github.com/user/repo.git', 'main', 'src/index.ts')).toBe(
+      'https://github.com/user/repo/blob/main/src/index.ts',
+    );
+  });
+
+  it('encodes branch and path segments', () => {
+    expect(toBlobUrl('https://github.com/user/repo', 'feat/new thing', 'dir/file name.ts')).toBe(
+      'https://github.com/user/repo/blob/feat%2Fnew%20thing/dir/file%20name.ts',
+    );
+  });
+});
+
+describe('hashText', () => {
+  it('returns a sha256 hex digest', () => {
+    const hash = hashText('hello');
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('is deterministic', () => {
+    expect(hashText('test')).toBe(hashText('test'));
+  });
+
+  it('differs for different inputs', () => {
+    expect(hashText('a')).not.toBe(hashText('b'));
+  });
+});
+
+describe('parseOptionalInt', () => {
+  it('returns undefined for empty/undefined', () => {
+    expect(parseOptionalInt(undefined)).toBeUndefined();
+    expect(parseOptionalInt('')).toBeUndefined();
+  });
+
+  it('parses valid integers', () => {
+    expect(parseOptionalInt('42')).toBe(42);
+    expect(parseOptionalInt('0')).toBe(0);
+  });
+
+  it('returns undefined for non-numeric', () => {
+    expect(parseOptionalInt('abc')).toBeUndefined();
+  });
+});
+
+describe('parseOptionalBoolean', () => {
+  it('returns undefined for empty/undefined', () => {
+    expect(parseOptionalBoolean(undefined)).toBeUndefined();
+    expect(parseOptionalBoolean('')).toBeUndefined();
+  });
+
+  it('parses truthy values', () => {
+    expect(parseOptionalBoolean('true')).toBe(true);
+    expect(parseOptionalBoolean('1')).toBe(true);
+    expect(parseOptionalBoolean('yes')).toBe(true);
+    expect(parseOptionalBoolean('on')).toBe(true);
+    expect(parseOptionalBoolean('TRUE')).toBe(true);
+  });
+
+  it('parses falsy values', () => {
+    expect(parseOptionalBoolean('false')).toBe(false);
+    expect(parseOptionalBoolean('0')).toBe(false);
+    expect(parseOptionalBoolean('no')).toBe(false);
+    expect(parseOptionalBoolean('off')).toBe(false);
+  });
+
+  it('returns undefined for unrecognized values', () => {
+    expect(parseOptionalBoolean('maybe')).toBeUndefined();
+  });
+});
+
+describe('parseStringList', () => {
+  it('returns undefined for empty/undefined', () => {
+    expect(parseStringList(undefined)).toBeUndefined();
+    expect(parseStringList('')).toBeUndefined();
+    expect(parseStringList('   ')).toBeUndefined();
+  });
+
+  it('splits by comma and normalizes paths', () => {
+    expect(parseStringList('src/a, docs/b')).toEqual(['src/a', 'docs/b']);
+  });
+
+  it('strips leading ./ from items', () => {
+    expect(parseStringList('./vendor,./dist')).toEqual(['vendor', 'dist']);
+  });
+});
+
+describe('sameStringSet', () => {
+  it('returns true for identical arrays', () => {
+    expect(sameStringSet(['a', 'b'], ['a', 'b'])).toBe(true);
+  });
+
+  it('returns true regardless of order', () => {
+    expect(sameStringSet(['b', 'a'], ['a', 'b'])).toBe(true);
+  });
+
+  it('returns false for different lengths', () => {
+    expect(sameStringSet(['a'], ['a', 'b'])).toBe(false);
+  });
+
+  it('returns false for different content', () => {
+    expect(sameStringSet(['a', 'b'], ['a', 'c'])).toBe(false);
+  });
+
+  it('returns true for empty arrays', () => {
+    expect(sameStringSet([], [])).toBe(true);
+  });
+});
+
+describe('getString', () => {
+  it('returns string for non-empty strings', () => {
+    expect(getString('hello')).toBe('hello');
+  });
+
+  it('returns undefined for empty/whitespace strings', () => {
+    expect(getString('')).toBeUndefined();
+    expect(getString('   ')).toBeUndefined();
+  });
+
+  it('returns undefined for non-string values', () => {
+    expect(getString(42)).toBeUndefined();
+    expect(getString(null)).toBeUndefined();
+    expect(getString(undefined)).toBeUndefined();
+  });
+});
+
+describe('getNumber', () => {
+  it('returns number for finite numbers', () => {
+    expect(getNumber(42)).toBe(42);
+    expect(getNumber(0)).toBe(0);
+    expect(getNumber(-1.5)).toBe(-1.5);
+  });
+
+  it('returns undefined for non-finite/non-number', () => {
+    expect(getNumber(Number.NaN)).toBeUndefined();
+    expect(getNumber(Number.POSITIVE_INFINITY)).toBeUndefined();
+    expect(getNumber('42')).toBeUndefined();
+    expect(getNumber(null)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Add 92 unit tests covering the pure-logic portions of the mcp-memory RAG subsystem:

- **utils.test.ts** (39 tests): normalizeRepoPath, toBlobUrl, hashText, parseOptionalInt/Boolean, parseStringList, sameStringSet, getString, getNumber
- **bm25.test.ts** (21 tests): tokenize (camelCase/snake_case/CJK), searchBm25 ranking & limits, matchesMetadataFilter, aggregateChunkCandidates, buildSnippet
- **chunking.test.ts** (8 tests): empty input, single chunk, multi-chunk splitting, line numbers, semantic boundaries, code fences, overlap
- **repository.test.ts** (11 tests): canReuseIndex field-by-field validation
- **normalize-config.test.ts** (13 tests): normalizeConfig defaults & overrides, normalizeFiltersForCache sorting, validateMetadataFilters path safety

All tests run in ~30ms with no mocks or network calls.

Closes #55