### PR TITLE
perf(mcp-file): lazy-load ts-morph in get_ast tool

### DIFF
--- a/packages/mcp-file/src/server.ts
+++ b/packages/mcp-file/src/server.ts
@@ -136,7 +136,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'get_ast': {
-        const result = getAST(args as unknown as Parameters<typeof getAST>[0], projectRoot);
+        const result = await getAST(args as unknown as Parameters<typeof getAST>[0], projectRoot);
         return {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };

--- a/packages/mcp-file/src/tools/get-ast.ts
+++ b/packages/mcp-file/src/tools/get-ast.ts
@@ -4,8 +4,10 @@
  */
 
 import { extname } from 'node:path';
-import { Project, SyntaxKind } from 'ts-morph';
 import { resolveReadPath } from '../path-safety.js';
+
+type TsMorph = typeof import('ts-morph');
+let cachedTsMorph: TsMorph | undefined;
 
 export interface GetASTParams {
   path: string;
@@ -51,7 +53,7 @@ export interface ASTResult {
 /**
  * 获取文件的 AST 分析
  */
-export function getAST(params: GetASTParams, projectRoot: string): ASTResult {
+export async function getAST(params: GetASTParams, projectRoot: string): Promise<ASTResult> {
   const { path: filePath } = params;
 
   const safePath = resolveReadPath(filePath, projectRoot);
@@ -72,6 +74,11 @@ export function getAST(params: GetASTParams, projectRoot: string): ASTResult {
   }
 
   try {
+    if (!cachedTsMorph) {
+      cachedTsMorph = await import('ts-morph');
+    }
+    const { Project, SyntaxKind } = cachedTsMorph;
+
     const project = new Project({
       compilerOptions: {
         allowJs: true,


### PR DESCRIPTION
## Summary

Convert the top-level `import { Project, SyntaxKind } from 'ts-morph'` to a dynamic `await import('ts-morph')` inside the `getAST` function, with a module-level cache for subsequent calls.

ts-morph (~12MB with bundled TypeScript compiler) was loaded at startup even when `get_ast` is never invoked. This change defers that cost to first use.

## Changes

- `packages/mcp-file/src/tools/get-ast.ts`: Replace static import with cached dynamic import; make `getAST` async
- `packages/mcp-file/src/server.ts`: Add `await` to `getAST` call (already in async handler)

## Verification

- Full monorepo typecheck passes (22/22 packages)
- Biome lint clean

Closes #60