### PR TITLE
ci: decouple test task from self-build in turbo pipeline

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,7 @@
       "dependsOn": ["^build"]
     },
     "test": {
-      "dependsOn": ["build"]
+      "dependsOn": ["^build"]
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
## Summary

Change `test.dependsOn` from `["build"]` to `["^build"]` in turbo.json.

Previously, each package had to build itself before running tests. Since vitest transforms TypeScript via esbuild at runtime, the self-build is unnecessary — only upstream workspace dependencies need their dist output.

This reduces the critical path for `pnpm test` by removing redundant build steps for leaf packages.

## Verification

- `pnpm test` — all 22 tasks pass

Closes #62