### PR TITLE
refactor(shared): extract escapeRegex utility

### DIFF
--- a/packages/mcp-file/src/tools/search-code.ts
+++ b/packages/mcp-file/src/tools/search-code.ts
@@ -5,6 +5,7 @@
 
 import { readFileSync, statSync } from 'node:fs';
 import { relative, resolve } from 'node:path';
+import { escapeRegex } from '@frontagent/shared';
 import { glob } from 'glob';
 import { getRealProjectRoot, isInsidePath, isUnsafeGlobPattern } from '../path-safety.js';
 
@@ -165,13 +166,6 @@ export async function searchCode(
       error: `Search failed: ${error instanceof Error ? error.message : String(error)}`,
     };
   }
-}
-
-/**
- * 转义正则特殊字符
- */
-function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**

--- a/packages/sdd/src/workflow/checklist/validator.ts
+++ b/packages/sdd/src/workflow/checklist/validator.ts
@@ -2,6 +2,7 @@
  * Checklist 评估引擎
  */
 
+import { escapeRegex } from '@frontagent/shared';
 import type {
   ChecklistEvaluator,
   ChecklistItem,
@@ -62,10 +63,7 @@ export class ChecklistValidator {
       }
 
       case 'section_exists': {
-        const headingPattern = new RegExp(
-          `^#{1,4}\\s+.*${this.escapeRegex(evaluator.heading)}`,
-          'im',
-        );
+        const headingPattern = new RegExp(`^#{1,4}\\s+.*${escapeRegex(evaluator.heading)}`, 'im');
         return headingPattern.test(content);
       }
 
@@ -95,10 +93,6 @@ export class ChecklistValidator {
       default:
         return 'Review and address this checklist item';
     }
-  }
-
-  private escapeRegex(str: string): string {
-    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -84,4 +84,5 @@ export {
   deepMerge,
   normalizePath,
   matchGlob,
+  escapeRegex,
 } from './utils.js';

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -62,3 +62,7 @@ export function matchGlob(path: string, pattern: string): boolean {
   const regex = new RegExp(`^${regexPattern}$`);
   return regex.test(normalizePath(path));
 }
+
+export function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
## Summary

Extract `escapeRegex` into `@frontagent/shared` and replace the two local reimplementations:

- `packages/mcp-file/src/tools/search-code.ts` — removed local function, imported from shared
- `packages/sdd/src/workflow/checklist/validator.ts` — removed private method, imported from shared

Net: -7 lines, single source of truth for regex escaping.

## Verification

- All affected packages typecheck clean
- All tests pass (shared: 54, mcp-file: 6, sdd: 17)

Closes #66