### PR TITLE
perf(build): externalize ts-morph from CLI bundle

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -14,6 +14,7 @@ await build({
   outfile: resolve(__dirname, 'dist/index.mjs'),
   external: [
     'playwright',
+    'ts-morph',
   ],
   jsx: 'automatic',
   plugins: [{

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
   },
   "homepage": "https://github.com/ceilf6/FrontAgent#readme",
   "dependencies": {
-    "playwright": "^1.40.0"
+    "playwright": "^1.40.0",
+    "ts-morph": "^21.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       playwright:
         specifier: ^1.40.0
         version: 1.57.0
+      ts-morph:
+        specifier: ^21.0.0
+        version: 21.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: 1.9.4


### PR DESCRIPTION
## Summary

Externalize `ts-morph` from the esbuild CLI bundle. It was being inlined (~12MB with the bundled TypeScript compiler) despite the dynamic import added in #67.

## Changes

- Add `ts-morph` to `external` array in `build.mjs`
- Add `ts-morph` to root `package.json` dependencies (resolves from `node_modules` at runtime)

## Results

| Metric | Before | After |
|--------|--------|-------|
| Bundle size | 18 MB | 5.8 MB |
| Reduction | — | **67%** |

## Verification

- `node dist/index.mjs --help` works correctly
- All typecheck passes (22/22)
- mcp-file tests pass (6/6)

Closes #68