### PR TITLE
test(sdd): add unit tests for quality module

### DIFF
--- a/packages/sdd/src/quality/consistency-analyzer.test.ts
+++ b/packages/sdd/src/quality/consistency-analyzer.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { ConsistencyAnalyzer } from './consistency-analyzer.js';
+
+describe('ConsistencyAnalyzer', () => {
+  const analyzer = new ConsistencyAnalyzer();
+
+  describe('missing artifact detection', () => {
+    it('warns when plan exists without spec', () => {
+      const result = analyzer.analyze({ planContent: '## Step 1\n- Do something' });
+      expect(result.issues.some((i) => i.type === 'missing_artifact' && i.source === 'spec')).toBe(
+        true,
+      );
+    });
+
+    it('warns when tasks exist without spec', () => {
+      const result = analyzer.analyze({ tasksContent: '- [ ] Task 1' });
+      expect(result.issues.some((i) => i.type === 'missing_artifact' && i.source === 'spec')).toBe(
+        true,
+      );
+    });
+
+    it('warns when tasks exist without plan but with spec', () => {
+      const result = analyzer.analyze({
+        specContent: '- MUST: support authentication',
+        tasksContent: '- [ ] Implement auth',
+      });
+      expect(result.issues.some((i) => i.type === 'missing_artifact' && i.source === 'plan')).toBe(
+        true,
+      );
+    });
+
+    it('no missing artifact warning when all present', () => {
+      const result = analyzer.analyze({
+        specContent: '- MUST: support auth',
+        planContent: '## Auth\n- Implement login',
+        tasksContent: '- [ ] Login page',
+      });
+      expect(result.issues.filter((i) => i.type === 'missing_artifact')).toHaveLength(0);
+    });
+
+    it('no issues when only spec is provided', () => {
+      const result = analyzer.analyze({ specContent: '- MUST: do something' });
+      expect(result.issues.filter((i) => i.type === 'missing_artifact')).toHaveLength(0);
+    });
+  });
+
+  describe('requirement extraction', () => {
+    it('extracts checkbox items as requirements', () => {
+      const result = analyzer.analyze({
+        specContent: '- [ ] User can login\n- [x] User can logout',
+        planContent: '## Login\n- Implement login flow\n## Logout\n- Implement logout flow',
+      });
+      expect(result.coverage.specRequirements).toBe(2);
+    });
+
+    it('extracts MUST/SHALL/SHOULD items', () => {
+      const result = analyzer.analyze({
+        specContent: '- MUST: validate input\n- SHOULD: log errors',
+        planContent: '## Validation\n- Add input validation and error logging',
+      });
+      expect(result.coverage.specRequirements).toBe(2);
+    });
+
+    it('extracts AC/REQ numbered items', () => {
+      const result = analyzer.analyze({
+        specContent: 'AC-1 Login works\nREQ-2 Logout works',
+        planContent: '## Auth\n- Login and logout implementation',
+      });
+      expect(result.coverage.specRequirements).toBe(2);
+    });
+  });
+
+  describe('coverage matching', () => {
+    it('detects covered requirements', () => {
+      const result = analyzer.analyze({
+        specContent: '- MUST: implement user authentication',
+        planContent: '## Authentication\n- Implement user authentication flow',
+      });
+      expect(result.coverage.coveredByPlan).toBeGreaterThan(0);
+      expect(result.coverage.ratio).toBeGreaterThan(0);
+    });
+
+    it('detects uncovered requirements', () => {
+      const result = analyzer.analyze({
+        specContent: '- MUST: implement payment processing\n- MUST: implement user login',
+        planContent: '## Login\n- Implement user login flow',
+      });
+      const uncovered = result.issues.filter((i) => i.type === 'uncovered_requirement');
+      expect(uncovered.length).toBeGreaterThan(0);
+      expect(uncovered[0].message).toContain('payment');
+    });
+
+    it('returns ratio 1 when no requirements exist', () => {
+      const result = analyzer.analyze({
+        specContent: 'Just some notes without formal requirements',
+        planContent: '## Notes\n- Some plan items',
+      });
+      expect(result.coverage.ratio).toBe(1);
+    });
+
+    it('counts task coverage separately from plan coverage', () => {
+      const result = analyzer.analyze({
+        specContent: '- MUST: implement caching',
+        planContent: '## Unrelated\n- Something else',
+        tasksContent: '- Implement caching layer with Redis',
+      });
+      expect(result.coverage.coveredByTasks).toBeGreaterThanOrEqual(result.coverage.coveredByPlan);
+    });
+  });
+
+  describe('overall consistency', () => {
+    it('returns consistent true when no errors', () => {
+      const result = analyzer.analyze({
+        specContent: '- MUST: implement login',
+        planContent: '## Login\n- Implement login flow',
+        tasksContent: '- [ ] Build login page',
+      });
+      expect(result.consistent).toBe(true);
+    });
+
+    it('returns consistent true even with warnings', () => {
+      const result = analyzer.analyze({
+        planContent: '## Something\n- A plan without spec',
+      });
+      expect(result.consistent).toBe(true);
+      expect(result.issues.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/sdd/src/quality/plan-quality.test.ts
+++ b/packages/sdd/src/quality/plan-quality.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BUILT_IN_RULES,
+  GRANULARITY_RULE,
+  HAS_CONCRETE_OUTPUT_RULE,
+  NO_PLACEHOLDERS_RULE,
+  type PlanQualityRule,
+  PlanQualityValidator,
+  SINGLE_ACTION_RULE,
+  type TaskStep,
+} from './plan-quality.js';
+
+function makeStep(overrides: Partial<TaskStep> = {}): TaskStep {
+  return {
+    id: 'step-1',
+    description: 'Create the Button component',
+    files: ['src/components/Button.tsx'],
+    ...overrides,
+  };
+}
+
+describe('NO_PLACEHOLDERS_RULE', () => {
+  it('passes when no placeholder language is present', () => {
+    const step = makeStep({ description: 'Create src/Button.tsx with click handler' });
+    expect(NO_PLACEHOLDERS_RULE.check(step, [])).toBeNull();
+  });
+
+  it('detects TBD in description', () => {
+    const step = makeStep({ description: 'Implement TBD logic' });
+    const result = NO_PLACEHOLDERS_RULE.check(step, []);
+    expect(result).not.toBeNull();
+    expect(result!.ruleId).toBe('no-placeholders');
+    expect(result!.message).toContain('TBD');
+  });
+
+  it('detects TODO in commands', () => {
+    const step = makeStep({ commands: ['echo "TODO: fix this"'] });
+    const result = NO_PLACEHOLDERS_RULE.check(step, []);
+    expect(result).not.toBeNull();
+  });
+
+  it('detects "implement later" in content', () => {
+    const step = makeStep({ content: 'implement later when API is ready' });
+    const result = NO_PLACEHOLDERS_RULE.check(step, []);
+    expect(result).not.toBeNull();
+  });
+
+  it('detects "add appropriate" pattern', () => {
+    const step = makeStep({ description: 'Add appropriate error handling' });
+    const result = NO_PLACEHOLDERS_RULE.check(step, []);
+    expect(result).not.toBeNull();
+  });
+
+  it('detects "... here" pattern', () => {
+    const step = makeStep({ content: '... implementation here' });
+    const result = NO_PLACEHOLDERS_RULE.check(step, []);
+    expect(result).not.toBeNull();
+  });
+
+  it('detects "etc." pattern', () => {
+    const step = makeStep({ description: 'Add validation, logging, etc.' });
+    const result = NO_PLACEHOLDERS_RULE.check(step, []);
+    expect(result).not.toBeNull();
+  });
+
+  it('is case-insensitive', () => {
+    const step = makeStep({ description: 'fixme: handle edge case' });
+    const result = NO_PLACEHOLDERS_RULE.check(step, []);
+    expect(result).not.toBeNull();
+  });
+});
+
+describe('GRANULARITY_RULE', () => {
+  it('passes when estimatedMinutes is within limit', () => {
+    const step = makeStep({ estimatedMinutes: 5 });
+    expect(GRANULARITY_RULE.check(step, [])).toBeNull();
+  });
+
+  it('passes when estimatedMinutes is not set', () => {
+    const step = makeStep();
+    expect(GRANULARITY_RULE.check(step, [])).toBeNull();
+  });
+
+  it('flags steps exceeding 10 minutes', () => {
+    const step = makeStep({ estimatedMinutes: 15 });
+    const result = GRANULARITY_RULE.check(step, []);
+    expect(result).not.toBeNull();
+    expect(result!.ruleId).toBe('granularity');
+    expect(result!.message).toContain('15 minutes');
+  });
+
+  it('passes at exactly 10 minutes', () => {
+    const step = makeStep({ estimatedMinutes: 10 });
+    expect(GRANULARITY_RULE.check(step, [])).toBeNull();
+  });
+});
+
+describe('SINGLE_ACTION_RULE', () => {
+  it('passes with a single action verb', () => {
+    const step = makeStep({ description: 'Create the Button component' });
+    expect(SINGLE_ACTION_RULE.check(step, [])).toBeNull();
+  });
+
+  it('passes with two action verbs', () => {
+    const step = makeStep({ description: 'Create and test the component' });
+    expect(SINGLE_ACTION_RULE.check(step, [])).toBeNull();
+  });
+
+  it('flags three or more action verbs', () => {
+    const step = makeStep({
+      description: 'Create the component, add tests, and refactor the module',
+    });
+    const result = SINGLE_ACTION_RULE.check(step, []);
+    expect(result).not.toBeNull();
+    expect(result!.ruleId).toBe('single-action');
+  });
+
+  it('deduplicates repeated verbs in the message', () => {
+    const step = makeStep({
+      description: 'Create file, update config, delete old file, install deps',
+    });
+    const result = SINGLE_ACTION_RULE.check(step, []);
+    expect(result).not.toBeNull();
+  });
+});
+
+describe('HAS_CONCRETE_OUTPUT_RULE', () => {
+  it('passes when files are specified', () => {
+    const step = makeStep({ files: ['src/index.ts'] });
+    expect(HAS_CONCRETE_OUTPUT_RULE.check(step, [])).toBeNull();
+  });
+
+  it('passes when commands are specified', () => {
+    const step = makeStep({ files: undefined, commands: ['npm install zod'] });
+    expect(HAS_CONCRETE_OUTPUT_RULE.check(step, [])).toBeNull();
+  });
+
+  it('passes when content is specified', () => {
+    const step = makeStep({ files: undefined, content: 'export const x = 1;' });
+    expect(HAS_CONCRETE_OUTPUT_RULE.check(step, [])).toBeNull();
+  });
+
+  it('flags steps with no concrete output', () => {
+    const step = makeStep({ files: undefined, commands: undefined, content: undefined });
+    const result = HAS_CONCRETE_OUTPUT_RULE.check(step, []);
+    expect(result).not.toBeNull();
+    expect(result!.ruleId).toBe('has-concrete-output');
+  });
+
+  it('flags steps with empty arrays and whitespace content', () => {
+    const step = makeStep({ files: [], commands: [], content: '   ' });
+    const result = HAS_CONCRETE_OUTPUT_RULE.check(step, []);
+    expect(result).not.toBeNull();
+  });
+});
+
+describe('PlanQualityValidator', () => {
+  it('passes a valid plan with no violations', () => {
+    const validator = new PlanQualityValidator();
+    const result = validator.validate([
+      makeStep({ id: 's1', description: 'Create Button component', files: ['src/Button.tsx'] }),
+      makeStep({ id: 's2', description: 'Add unit test', files: ['src/Button.test.tsx'] }),
+    ]);
+    expect(result.passed).toBe(true);
+    expect(result.violations).toHaveLength(0);
+    expect(result.stats.totalSteps).toBe(2);
+  });
+
+  it('fails when errors are present', () => {
+    const validator = new PlanQualityValidator();
+    const result = validator.validate([
+      makeStep({ id: 's1', description: 'TBD: implement feature', files: ['src/x.ts'] }),
+    ]);
+    expect(result.passed).toBe(false);
+    expect(result.stats.errorCount).toBeGreaterThan(0);
+  });
+
+  it('passes with warnings only (no errors)', () => {
+    const validator = new PlanQualityValidator();
+    const result = validator.validate([
+      makeStep({ id: 's1', estimatedMinutes: 20, files: ['src/x.ts'] }),
+    ]);
+    expect(result.passed).toBe(true);
+    expect(result.stats.warningCount).toBeGreaterThan(0);
+  });
+
+  it('accepts custom rules', () => {
+    const customRule: PlanQualityRule = {
+      id: 'custom',
+      name: 'Custom Rule',
+      severity: 'error',
+      check: (step) =>
+        step.id === 'bad'
+          ? { ruleId: 'custom', stepId: step.id, message: 'Bad step', severity: 'error' }
+          : null,
+    };
+    const validator = new PlanQualityValidator([customRule]);
+    const result = validator.validate([makeStep({ id: 'bad' })]);
+    expect(result.passed).toBe(false);
+    expect(result.violations[0].ruleId).toBe('custom');
+  });
+
+  it('addRule appends to existing rules', () => {
+    const validator = new PlanQualityValidator([]);
+    validator.addRule(BUILT_IN_RULES[0]);
+    const result = validator.validate([makeStep({ id: 's1', description: 'TODO: fix' })]);
+    expect(result.violations).toHaveLength(1);
+  });
+
+  it('returns correct stats', () => {
+    const validator = new PlanQualityValidator();
+    const result = validator.validate([
+      makeStep({ id: 's1', description: 'TBD placeholder', files: ['a.ts'] }),
+      makeStep({ id: 's2', estimatedMinutes: 30, files: ['b.ts'] }),
+      makeStep({ id: 's3', description: 'Valid step', files: ['c.ts'] }),
+    ]);
+    expect(result.stats.totalSteps).toBe(3);
+    expect(result.stats.errorCount).toBe(1);
+    expect(result.stats.warningCount).toBeGreaterThanOrEqual(1);
+    expect(result.stats.violationCount).toBe(result.stats.errorCount + result.stats.warningCount);
+  });
+});


### PR DESCRIPTION
## Summary

Add 41 unit tests for the previously untested `packages/sdd/src/quality/` module.

## Changes

### plan-quality.test.ts (27 tests)
- NO_PLACEHOLDERS_RULE: TBD, TODO, FIXME, placeholder language detection
- GRANULARITY_RULE: step duration threshold
- SINGLE_ACTION_RULE: multiple action verb detection
- HAS_CONCRETE_OUTPUT_RULE: files/commands/content requirement
- PlanQualityValidator: orchestration, custom rules, stats aggregation

### consistency-analyzer.test.ts (14 tests)
- Missing artifact detection (spec/plan/tasks)
- Requirement extraction (checkboxes, MUST/SHALL, AC/REQ patterns)
- Coverage matching and ratio calculation
- Uncovered requirement detection

## Verification
- All 58 sdd tests pass (17 existing + 41 new)
- Lint passes
- No mocking needed (pure functions)

Closes #70