### PR TITLE
fix(ci): remove duplicate pnpm version from action-setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Problem

`pnpm/action-setup@v4` now rejects having the pnpm version specified in both places:
- `version: 9` in the workflow YAML
- `"packageManager": "pnpm@9.0.0"` in package.json

Error:
```
Error: Multiple versions of pnpm specified:
  - version 9 in the GitHub Action config with the key "version"
  - version pnpm@9.0.0 in the package.json with the key "packageManager"
Remove one of these versions to avoid version mismatch errors
```

## Fix

Remove the explicit `version: 9` from the workflow. The action reads it from `packageManager` automatically.