### PR TITLE
refactor(core): replace any with AnthropicProviderSettings

### DIFF
--- a/packages/core/src/llm/llm-service.ts
+++ b/packages/core/src/llm/llm-service.ts
@@ -1,4 +1,4 @@
-import { createAnthropic } from '@ai-sdk/anthropic';
+import { type AnthropicProviderSettings, createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
 import { type CoreMessage, type LanguageModel, generateObject, generateText, streamText } from 'ai';
 import type { z } from 'zod';
@@ -127,7 +127,7 @@ export class LLMService {
         const betaHeaders: string[] = [];
         betaHeaders.push('advanced-tool-use-2025-11-20');
 
-        const anthropicConfig: any = {
+        const anthropicConfig: AnthropicProviderSettings = {
           apiKey: key,
           baseURL: endpoint,
         };


### PR DESCRIPTION
## Summary

Replaces the `any` type annotation on the Anthropic config object in `llm-service.ts` with the SDK-exported `AnthropicProviderSettings` type.

## Changes

- Import `AnthropicProviderSettings` from `@ai-sdk/anthropic`
- Type `anthropicConfig` variable with it instead of `any`

## Verification

- Typecheck clean
- Biome lint clean

Closes #80