### PR TITLE
test(hallucination-guard): add unit tests for check modules

### DIFF
--- a/packages/hallucination-guard/src/checks/file-existence.test.ts
+++ b/packages/hallucination-guard/src/checks/file-existence.test.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { checkFileExistence, checkFilesExistence } from './file-existence.js';
+
+let roots: string[] = [];
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'hallucination-guard-'));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots) {
+    rmSync(root, { recursive: true, force: true });
+  }
+  roots = [];
+});
+
+describe('checkFileExistence', () => {
+  it('passes for existing file', async () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'app.ts'), '', 'utf-8');
+
+    const result = await checkFileExistence({ path: 'app.ts', projectRoot: root });
+    expect(result.pass).toBe(true);
+    expect(result.type).toBe('file_existence');
+  });
+
+  it('fails for non-existent file', async () => {
+    const root = makeRoot();
+
+    const result = await checkFileExistence({ path: 'missing.ts', projectRoot: root });
+    expect(result.pass).toBe(false);
+    expect(result.message).toMatch(/does not exist/i);
+  });
+
+  it('blocks path traversal outside project root', async () => {
+    const root = makeRoot();
+
+    const result = await checkFileExistence({ path: '../../../etc/passwd', projectRoot: root });
+    expect(result.pass).toBe(false);
+    expect(result.severity).toBe('block');
+    expect(result.message).toMatch(/outside project root/i);
+  });
+
+  it('fails when path is a directory, not a file', async () => {
+    const root = makeRoot();
+    mkdirSync(join(root, 'src'));
+
+    const result = await checkFileExistence({ path: 'src', projectRoot: root });
+    expect(result.pass).toBe(false);
+    expect(result.message).toMatch(/not a file/i);
+  });
+
+  it('passes with shouldExist=false when file does not exist', async () => {
+    const root = makeRoot();
+
+    const result = await checkFileExistence({
+      path: 'new-file.ts',
+      projectRoot: root,
+      shouldExist: false,
+    });
+    expect(result.pass).toBe(true);
+  });
+
+  it('fails with shouldExist=false when file exists', async () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'existing.ts'), '', 'utf-8');
+
+    const result = await checkFileExistence({
+      path: 'existing.ts',
+      projectRoot: root,
+      shouldExist: false,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.severity).toBe('warn');
+  });
+});
+
+describe('checkFilesExistence', () => {
+  it('checks multiple files in batch', async () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'a.ts'), '', 'utf-8');
+
+    const results = await checkFilesExistence(['a.ts', 'b.ts'], root);
+    expect(results).toHaveLength(2);
+    expect(results[0].pass).toBe(true);
+    expect(results[1].pass).toBe(false);
+  });
+});

--- a/packages/hallucination-guard/src/checks/import-validity.test.ts
+++ b/packages/hallucination-guard/src/checks/import-validity.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { extractImports } from './import-validity.js';
+
+describe('extractImports', () => {
+  it('extracts ES6 named imports', () => {
+    const code = `import { foo, bar } from './utils';`;
+    expect(extractImports(code)).toEqual(['./utils']);
+  });
+
+  it('extracts ES6 default imports', () => {
+    const code = `import React from 'react';`;
+    expect(extractImports(code)).toEqual(['react']);
+  });
+
+  it('extracts ES6 namespace imports', () => {
+    const code = `import * as path from 'node:path';`;
+    expect(extractImports(code)).toEqual(['node:path']);
+  });
+
+  it('extracts side-effect imports', () => {
+    const code = `import './polyfill';`;
+    expect(extractImports(code)).toEqual(['./polyfill']);
+  });
+
+  it('extracts dynamic imports', () => {
+    const code = `const mod = await import('./lazy-module');`;
+    expect(extractImports(code)).toEqual(['./lazy-module']);
+  });
+
+  it('extracts require calls', () => {
+    const code = `const fs = require('fs');`;
+    expect(extractImports(code)).toEqual(['fs']);
+  });
+
+  it('extracts multiple imports and deduplicates', () => {
+    const code = `
+import { a } from './shared';
+import { b } from './shared';
+import { c } from './other';
+`;
+    const result = extractImports(code);
+    expect(result).toContain('./shared');
+    expect(result).toContain('./other');
+    expect(result.filter((i) => i === './shared')).toHaveLength(1);
+  });
+
+  it('handles mixed import styles', () => {
+    const code = `
+import { readFile } from 'node:fs';
+const path = require('path');
+const lazy = await import('./lazy');
+`;
+    const result = extractImports(code);
+    expect(result).toContain('node:fs');
+    expect(result).toContain('path');
+    expect(result).toContain('./lazy');
+  });
+
+  it('returns empty array for code without imports', () => {
+    const code = 'const x = 1;\nconsole.log(x);';
+    expect(extractImports(code)).toEqual([]);
+  });
+});

--- a/packages/hallucination-guard/src/checks/syntax-validity.test.ts
+++ b/packages/hallucination-guard/src/checks/syntax-validity.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { checkSyntaxValidity } from './syntax-validity.js';
+
+describe('checkSyntaxValidity', () => {
+  describe('typescript/javascript', () => {
+    it('passes for valid code', async () => {
+      const code = `function hello() {\n  return "world";\n}`;
+      const result = await checkSyntaxValidity({ code, language: 'typescript' });
+      expect(result.pass).toBe(true);
+    });
+
+    it('detects unclosed brackets', async () => {
+      const code = `function hello() {\n  return "world";\n`;
+      const result = await checkSyntaxValidity({ code, language: 'typescript' });
+      expect(result.pass).toBe(false);
+      expect(result.message).toMatch(/syntax errors/i);
+    });
+
+    it('detects mismatched brackets', async () => {
+      const code = 'const arr = [1, 2, 3);';
+      const result = await checkSyntaxValidity({ code, language: 'javascript' });
+      expect(result.pass).toBe(false);
+    });
+
+    it('ignores brackets in strings', async () => {
+      const code = `const s = "hello { world }";`;
+      const result = await checkSyntaxValidity({ code, language: 'typescript' });
+      expect(result.pass).toBe(true);
+    });
+
+    it('ignores brackets in comments', async () => {
+      const code = '// this has { unclosed\nconst x = 1;';
+      const result = await checkSyntaxValidity({ code, language: 'typescript' });
+      expect(result.pass).toBe(true);
+    });
+
+    it('ignores brackets in multi-line comments', async () => {
+      const code = '/* { unclosed */\nconst x = 1;';
+      const result = await checkSyntaxValidity({ code, language: 'typescript' });
+      expect(result.pass).toBe(true);
+    });
+  });
+
+  describe('json', () => {
+    it('passes for valid JSON', async () => {
+      const code = `{"name": "test", "version": "1.0.0"}`;
+      const result = await checkSyntaxValidity({ code, language: 'json' });
+      expect(result.pass).toBe(true);
+    });
+
+    it('detects invalid JSON', async () => {
+      const code = `{name: "test"}`;
+      const result = await checkSyntaxValidity({ code, language: 'json' });
+      expect(result.pass).toBe(false);
+      expect(result.type).toBe('syntax_validity');
+    });
+
+    it('detects trailing commas in JSON', async () => {
+      const code = `{"a": 1,}`;
+      const result = await checkSyntaxValidity({ code, language: 'json' });
+      expect(result.pass).toBe(false);
+    });
+  });
+
+  describe('yaml', () => {
+    it('passes for any YAML (simplified check)', async () => {
+      const code = 'key: value\nnested:\n  child: true';
+      const result = await checkSyntaxValidity({ code, language: 'yaml' });
+      expect(result.pass).toBe(true);
+    });
+  });
+
+  it('includes filePath in error message when provided', async () => {
+    const code = '{invalid';
+    const result = await checkSyntaxValidity({
+      code,
+      language: 'typescript',
+      filePath: 'src/broken.ts',
+    });
+    expect(result.pass).toBe(false);
+    expect(result.message).toContain('src/broken.ts');
+  });
+});


### PR DESCRIPTION
## Summary

Adds 27 unit tests for the three check modules in `packages/hallucination-guard/src/checks/` that previously had no dedicated tests.

## Tests added

### file-existence.test.ts (7 tests)
- Existing file passes, non-existent fails
- Path traversal detection (blocks `../` escape)
- Directory vs file distinction
- `shouldExist=false` flag behavior
- Batch file checking

### import-validity.test.ts (9 tests)
- ES6 named/default/namespace/side-effect imports
- Dynamic imports and require calls
- Deduplication of repeated imports
- Mixed import styles
- Empty code handling

### syntax-validity.test.ts (11 tests)
- Valid TS/JS code passes
- Unclosed and mismatched brackets detected
- Brackets in strings/comments correctly ignored
- JSON validation (valid, invalid, trailing commas)
- YAML passthrough
- filePath included in error messages

## Verification

- All 45 tests pass (27 new + 18 existing)
- Biome lint clean

Closes #82