### PR TITLE
fix(mcp-file): delete persisted snapshot files during cleanup

### DIFF
--- a/packages/mcp-file/src/snapshot.ts
+++ b/packages/mcp-file/src/snapshot.ts
@@ -192,7 +192,10 @@ export class SnapshotManager {
     const toRemove = fileHistory.slice(0, fileHistory.length - keepCount);
     for (const snapshotId of toRemove) {
       this.snapshots.delete(snapshotId);
-      // TODO: 删除持久化的快照文件
+      const snapshotPath = join(this.snapshotDir, `${snapshotId}.json`);
+      if (existsSync(snapshotPath)) {
+        unlinkSync(snapshotPath);
+      }
     }
 
     this.fileSnapshots.set(filePath, fileHistory.slice(-keepCount));


### PR DESCRIPTION
## Summary

`SnapshotManager.cleanup()` was removing old snapshots from memory but leaving orphaned `.json` files on disk. Now it deletes the persisted files too.

## Changes

- Added `unlinkSync` call in the cleanup loop to remove the snapshot file from `.frontagent/snapshots/`
- Removed the TODO comment

## Verification

- Typecheck clean
- All 50 mcp-file tests pass

Closes #87