### PR TITLE
test(core): add unit tests for agent helpers and phase-checks

### DIFF
--- a/packages/core/src/agent/helpers.test.ts
+++ b/packages/core/src/agent/helpers.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { mergeRetrievalQuery, normalizeSearchQuery, truncateForPrompt } from './helpers.js';
+
+describe('truncateForPrompt', () => {
+  it('returns input unchanged when within limit', () => {
+    expect(truncateForPrompt('short', 100)).toBe('short');
+  });
+
+  it('returns input unchanged when exactly at limit', () => {
+    expect(truncateForPrompt('12345', 5)).toBe('12345');
+  });
+
+  it('truncates and appends ellipsis marker', () => {
+    expect(truncateForPrompt('hello world', 5)).toBe('hello\n...');
+  });
+
+  it('handles empty string', () => {
+    expect(truncateForPrompt('', 10)).toBe('');
+  });
+});
+
+describe('normalizeSearchQuery', () => {
+  it('removes code fences', () => {
+    const input = 'before ```code here``` after';
+    expect(normalizeSearchQuery(input)).toBe('before after');
+  });
+
+  it('collapses whitespace', () => {
+    expect(normalizeSearchQuery('a   b\n\nc')).toBe('a b c');
+  });
+
+  it('strips surrounding quotes', () => {
+    expect(normalizeSearchQuery('"hello world"')).toBe('hello world');
+    expect(normalizeSearchQuery("'hello world'")).toBe('hello world');
+    expect(normalizeSearchQuery('`hello world`')).toBe('hello world');
+  });
+
+  it('strips smart quotes', () => {
+    expect(normalizeSearchQuery('“hello”')).toBe('hello');
+  });
+
+  it('trims result', () => {
+    expect(normalizeSearchQuery('  hello  ')).toBe('hello');
+  });
+
+  it('handles empty string', () => {
+    expect(normalizeSearchQuery('')).toBe('');
+  });
+
+  it('handles multi-line code fences', () => {
+    const input = 'query ```\nconst x = 1;\nconst y = 2;\n``` end';
+    expect(normalizeSearchQuery(input)).toBe('query end');
+  });
+});
+
+describe('mergeRetrievalQuery', () => {
+  it('returns rewritten when original is empty', () => {
+    expect(mergeRetrievalQuery('', 'rewritten query')).toBe('rewritten query');
+  });
+
+  it('returns original when rewritten is empty', () => {
+    expect(mergeRetrievalQuery('original query', '')).toBe('original query');
+  });
+
+  it('returns rewritten when it contains original', () => {
+    expect(mergeRetrievalQuery('auth', 'auth validation logic')).toBe('auth validation logic');
+  });
+
+  it('returns original when it contains rewritten', () => {
+    expect(mergeRetrievalQuery('auth validation logic', 'auth')).toBe('auth validation logic');
+  });
+
+  it('concatenates when neither contains the other', () => {
+    expect(mergeRetrievalQuery('login flow', 'session management')).toBe(
+      'login flow session management',
+    );
+  });
+
+  it('truncates merged result at 320 chars', () => {
+    const long1 = 'a'.repeat(200);
+    const long2 = 'b'.repeat(200);
+    const result = mergeRetrievalQuery(long1, long2);
+    expect(result.length).toBeLessThanOrEqual(320);
+  });
+});

--- a/packages/core/src/agent/phase-checks.test.ts
+++ b/packages/core/src/agent/phase-checks.test.ts
@@ -1,0 +1,122 @@
+import type { ExecutionStep } from '@frontagent/shared';
+import { describe, expect, it } from 'vitest';
+import { collectGeneratedCodeFilesForPhase, shouldRunPhaseChecks } from './phase-checks.js';
+
+describe('shouldRunPhaseChecks', () => {
+  it('returns true for Chinese create phase', () => {
+    expect(shouldRunPhaseChecks('创建组件')).toBe(true);
+  });
+
+  it('returns true for Chinese implement phase', () => {
+    expect(shouldRunPhaseChecks('实现功能')).toBe(true);
+  });
+
+  it('returns true for ungrouped phase', () => {
+    expect(shouldRunPhaseChecks('未分组')).toBe(true);
+  });
+
+  it('returns true for English create phase (case-insensitive)', () => {
+    expect(shouldRunPhaseChecks('Create Components')).toBe(true);
+  });
+
+  it('returns true for English implement phase (case-insensitive)', () => {
+    expect(shouldRunPhaseChecks('Implement Feature')).toBe(true);
+  });
+
+  it('returns false for review phase', () => {
+    expect(shouldRunPhaseChecks('review')).toBe(false);
+  });
+
+  it('returns false for planning phase', () => {
+    expect(shouldRunPhaseChecks('planning')).toBe(false);
+  });
+
+  it('returns false for testing phase', () => {
+    expect(shouldRunPhaseChecks('测试')).toBe(false);
+  });
+});
+
+describe('collectGeneratedCodeFilesForPhase', () => {
+  const baseDeps = {
+    config: { subAgents: { codeQualityEvaluator: { maxFilesPerPhase: 20 } } },
+  } as Parameters<typeof collectGeneratedCodeFilesForPhase>[0];
+
+  function makeStep(overrides: Partial<ExecutionStep>): ExecutionStep {
+    return {
+      stepId: 'step-1',
+      description: 'test',
+      action: 'create_file',
+      tool: 'write_file',
+      params: { path: 'src/app.ts' },
+      dependencies: [],
+      validation: [],
+      status: 'completed',
+      phase: '实现',
+      ...overrides,
+    };
+  }
+
+  it('collects code files from completed create_file steps', () => {
+    const steps = [makeStep({ params: { path: 'src/component.tsx' } })];
+    const result = collectGeneratedCodeFilesForPhase(baseDeps, '实现', steps);
+    expect(result).toEqual(['src/component.tsx']);
+  });
+
+  it('collects apply_patch steps', () => {
+    const steps = [makeStep({ action: 'apply_patch', params: { path: 'src/fix.ts' } })];
+    const result = collectGeneratedCodeFilesForPhase(baseDeps, '实现', steps);
+    expect(result).toEqual(['src/fix.ts']);
+  });
+
+  it('skips non-code files', () => {
+    const steps = [makeStep({ params: { path: 'README.md' } })];
+    const result = collectGeneratedCodeFilesForPhase(baseDeps, '实现', steps);
+    expect(result).toEqual([]);
+  });
+
+  it('skips steps from other phases', () => {
+    const steps = [makeStep({ phase: '测试' })];
+    const result = collectGeneratedCodeFilesForPhase(baseDeps, '实现', steps);
+    expect(result).toEqual([]);
+  });
+
+  it('skips non-completed steps', () => {
+    const steps = [makeStep({ status: 'pending' })];
+    const result = collectGeneratedCodeFilesForPhase(baseDeps, '实现', steps);
+    expect(result).toEqual([]);
+  });
+
+  it('skips non-file-creation actions', () => {
+    const steps = [makeStep({ action: 'read_file' })];
+    const result = collectGeneratedCodeFilesForPhase(baseDeps, '实现', steps);
+    expect(result).toEqual([]);
+  });
+
+  it('deduplicates paths', () => {
+    const steps = [
+      makeStep({ stepId: 's1', params: { path: 'src/app.ts' } }),
+      makeStep({ stepId: 's2', params: { path: 'src/app.ts' } }),
+    ];
+    const result = collectGeneratedCodeFilesForPhase(baseDeps, '实现', steps);
+    expect(result).toEqual(['src/app.ts']);
+  });
+
+  it('respects maxFilesPerPhase limit', () => {
+    const deps = {
+      config: { subAgents: { codeQualityEvaluator: { maxFilesPerPhase: 2 } } },
+    } as Parameters<typeof collectGeneratedCodeFilesForPhase>[0];
+    const steps = [
+      makeStep({ stepId: 's1', params: { path: 'src/a.ts' } }),
+      makeStep({ stepId: 's2', params: { path: 'src/b.ts' } }),
+      makeStep({ stepId: 's3', params: { path: 'src/c.ts' } }),
+    ];
+    const result = collectGeneratedCodeFilesForPhase(deps, '实现', steps);
+    expect(result).toHaveLength(2);
+  });
+
+  it('treats steps without phase as ungrouped', () => {
+    const steps = [makeStep({ phase: undefined })];
+    const result = collectGeneratedCodeFilesForPhase(baseDeps, '未分组', steps);
+    expect(result).toEqual(['src/app.ts']);
+  });
+});


### PR DESCRIPTION
## Summary
Adds 34 unit tests across two new test files for pure functions in the agent module.

## Coverage

**helpers.test.ts (17 tests):**
- `truncateForPrompt` — within/at/over limit, empty string
- `normalizeSearchQuery` — code fence removal, whitespace collapse, quote stripping
- `mergeRetrievalQuery` — empty inputs, containment, concatenation, length cap

**phase-checks.test.ts (17 tests):**
- `shouldRunPhaseChecks` — Chinese/English phase names, case insensitivity, negative cases
- `collectGeneratedCodeFilesForPhase` — file filtering, phase matching, deduplication, maxFiles limit

## Verification
- All 34 tests pass
- Biome lint clean
- TypeScript build passes

Closes #99