### PR TITLE
test(core): add unit tests for parseTypeScriptErrors and normalizePlan

### DIFF
--- a/packages/core/src/llm/code-generation.test.ts
+++ b/packages/core/src/llm/code-generation.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { parseTypeScriptErrors } from './code-generation.js';
+
+describe('parseTypeScriptErrors', () => {
+  it('parses standard tsc error format (parentheses)', () => {
+    const steps = [
+      {
+        error: 'src/app.tsx(10,5): error TS2322: Type string is not assignable to type number',
+        params: { command: 'npx tsc --noEmit' },
+      },
+    ];
+    const result = parseTypeScriptErrors(steps);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      file: 'src/app.tsx',
+      line: 10,
+      column: 5,
+      errorCode: 'TS2322',
+      message: 'Type string is not assignable to type number',
+      rawError: 'src/app.tsx(10,5): error TS2322: Type string is not assignable to type number',
+    });
+  });
+
+  it('parses alternative tsc error format (colons)', () => {
+    const steps = [
+      {
+        error: 'src/utils.ts:25:3 - error TS7006: Parameter x implicitly has an any type',
+        params: { command: 'npm run typecheck' },
+      },
+    ];
+    const result = parseTypeScriptErrors(steps);
+    expect(result).toHaveLength(1);
+    expect(result[0].file).toBe('src/utils.ts');
+    expect(result[0].line).toBe(25);
+    expect(result[0].column).toBe(3);
+    expect(result[0].errorCode).toBe('TS7006');
+  });
+
+  it('parses multiple errors from single step', () => {
+    const steps = [
+      {
+        error: [
+          'src/a.ts(1,1): error TS1001: first error',
+          'src/b.tsx(2,3): error TS1002: second error',
+        ].join('\n'),
+        params: { command: 'tsc' },
+      },
+    ];
+    const result = parseTypeScriptErrors(steps);
+    expect(result).toHaveLength(2);
+    expect(result[0].file).toBe('src/a.ts');
+    expect(result[1].file).toBe('src/b.tsx');
+  });
+
+  it('skips non-tsc commands', () => {
+    const steps = [
+      {
+        error: 'src/app.tsx(10,5): error TS2322: some error',
+        params: { command: 'eslint .' },
+      },
+    ];
+    expect(parseTypeScriptErrors(steps)).toEqual([]);
+  });
+
+  it('returns empty array for no errors', () => {
+    const steps = [
+      {
+        error: 'Compilation successful',
+        params: { command: 'tsc --noEmit' },
+      },
+    ];
+    expect(parseTypeScriptErrors(steps)).toEqual([]);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(parseTypeScriptErrors([])).toEqual([]);
+  });
+
+  it('handles steps with typecheck command', () => {
+    const steps = [
+      {
+        error: 'src/index.ts(1,1): error TS2304: Cannot find name foo',
+        params: { command: 'pnpm typecheck' },
+      },
+    ];
+    expect(parseTypeScriptErrors(steps)).toHaveLength(1);
+  });
+});

--- a/packages/core/src/llm/plan-generation.test.ts
+++ b/packages/core/src/llm/plan-generation.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import type { PlanGenerationDeps } from './plan-generation.js';
+import { normalizePlan } from './plan-generation.js';
+
+const noopDeps: PlanGenerationDeps = {
+  debugLog: () => {},
+  debugWarn: () => {},
+  debugError: () => {},
+  generateObject: async () => ({}) as never,
+};
+
+describe('normalizePlan', () => {
+  it('passes through well-formed plan', () => {
+    const raw = {
+      summary: 'Test plan',
+      steps: [
+        {
+          description: 'step 1',
+          action: 'create_file',
+          tool: 'write_file',
+          phase: 'phase-1',
+          params: { path: 'src/app.ts' },
+          reasoning: 'needed',
+          needsCodeGeneration: true,
+        },
+      ],
+      risks: ['risk 1'],
+      alternatives: ['alt 1'],
+    };
+    const result = normalizePlan(raw, noopDeps);
+    expect(result.summary).toBe('Test plan');
+    expect(result.steps).toHaveLength(1);
+    expect(result.risks).toEqual(['risk 1']);
+    expect(result.alternatives).toEqual(['alt 1']);
+  });
+
+  it('defaults summary when missing', () => {
+    const result = normalizePlan({ steps: [], risks: [], alternatives: [] }, noopDeps);
+    expect(result.summary).toBe('Generated Plan');
+  });
+
+  it('handles steps as string (malformed LLM output)', () => {
+    const result = normalizePlan(
+      { summary: 'plan', steps: 'not an array', risks: [], alternatives: [] },
+      noopDeps,
+    );
+    expect(result.steps).toEqual([]);
+  });
+
+  it('parses stringified params in steps', () => {
+    const raw = {
+      summary: 'plan',
+      steps: [
+        {
+          description: 'write',
+          action: 'create_file',
+          tool: 'write_file',
+          phase: 'p1',
+          params: '{"path":"src/x.ts"}',
+          reasoning: 'r',
+          needsCodeGeneration: false,
+        },
+      ],
+      risks: [],
+      alternatives: [],
+    };
+    const result = normalizePlan(raw, noopDeps);
+    expect(result.steps[0].params).toEqual({ path: 'src/x.ts' });
+  });
+
+  it('wraps unparseable string params in value key', () => {
+    const raw = {
+      summary: 'plan',
+      steps: [
+        {
+          description: 'write',
+          action: 'create_file',
+          tool: 'write_file',
+          phase: 'p1',
+          params: 'not json',
+          reasoning: 'r',
+          needsCodeGeneration: false,
+        },
+      ],
+      risks: [],
+      alternatives: [],
+    };
+    const result = normalizePlan(raw, noopDeps);
+    expect(result.steps[0].params).toEqual({ value: 'not json' });
+  });
+
+  it('defaults null/undefined params to empty object', () => {
+    const raw = {
+      summary: 'plan',
+      steps: [
+        {
+          description: 'write',
+          action: 'create_file',
+          tool: 'write_file',
+          phase: 'p1',
+          params: null,
+          reasoning: 'r',
+          needsCodeGeneration: false,
+        },
+      ],
+      risks: [],
+      alternatives: [],
+    };
+    const result = normalizePlan(raw, noopDeps);
+    expect(result.steps[0].params).toEqual({});
+  });
+
+  it('coerces string needsCodeGeneration to boolean', () => {
+    const raw = {
+      summary: 'plan',
+      steps: [
+        {
+          description: 'write',
+          action: 'create_file',
+          tool: 'write_file',
+          phase: 'p1',
+          params: {},
+          reasoning: 'r',
+          needsCodeGeneration: 'true',
+        },
+      ],
+      risks: [],
+      alternatives: [],
+    };
+    const result = normalizePlan(raw, noopDeps);
+    expect(result.steps[0].needsCodeGeneration).toBe(true);
+  });
+
+  it('converts string risks to array', () => {
+    const result = normalizePlan(
+      { summary: 'plan', steps: [], risks: 'single risk', alternatives: [] },
+      noopDeps,
+    );
+    expect(result.risks).toEqual(['single risk']);
+  });
+
+  it('converts string alternatives to array', () => {
+    const result = normalizePlan(
+      { summary: 'plan', steps: [], risks: [], alternatives: 'single alt' },
+      noopDeps,
+    );
+    expect(result.alternatives).toEqual(['single alt']);
+  });
+
+  it('defaults non-array risks to empty array', () => {
+    const result = normalizePlan(
+      { summary: 'plan', steps: [], risks: 123, alternatives: [] },
+      noopDeps,
+    );
+    expect(result.risks).toEqual([]);
+  });
+
+  it('defaults non-array alternatives to empty array', () => {
+    const result = normalizePlan(
+      { summary: 'plan', steps: [], risks: [], alternatives: null },
+      noopDeps,
+    );
+    expect(result.alternatives).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Adds 18 unit tests for two critical LLM output handling functions.

## Coverage

**code-generation.test.ts (7 tests):**
- `parseTypeScriptErrors`: standard format (parentheses), alternative format (colons), multiple errors, non-tsc filtering, empty input

**plan-generation.test.ts (11 tests):**
- `normalizePlan`: well-formed passthrough, missing summary default, stringified params parsing, unparseable params wrapping, null params, string-to-boolean coercion, string-to-array conversion for risks/alternatives

## Verification
- All 18 tests pass
- Biome lint clean
- TypeScript build passes

Closes #103