### PR TITLE
fix: resolve CI lint errors from noExplicitAny

### DIFF
--- a/apps/cli/src/commands/rag.ts
+++ b/apps/cli/src/commands/rag.ts
@@ -47,28 +47,35 @@ function readJsonFile(path: string): unknown {
 function createRagCacheManifest(cacheDir: string, includesRepo: boolean): RagCacheBundleManifest {
   const indexPath = join(cacheDir, 'index.json');
   const embeddingPath = join(cacheDir, 'embeddings.json');
-  const index = existsSync(indexPath) ? readJsonFile(indexPath) : undefined;
-  const embeddingStore = existsSync(embeddingPath) ? readJsonFile(embeddingPath) : undefined;
+  const index = existsSync(indexPath)
+    ? (readJsonFile(indexPath) as Record<string, unknown>)
+    : undefined;
+  const embeddingStore = existsSync(embeddingPath)
+    ? (readJsonFile(embeddingPath) as Record<string, unknown>)
+    : undefined;
+
+  const indexSource = (index?.source ?? {}) as Record<string, unknown>;
+  const vectors = embeddingStore?.vectors as Record<string, unknown> | undefined;
 
   return {
     version: RAG_BUNDLE_VERSION,
     generatedAt: new Date().toISOString(),
     includesRepo,
     source: {
-      repoUrl: index?.source?.repoUrl,
-      branch: index?.source?.branch,
-      revision: index?.source?.revision,
-      indexedFiles: index?.source?.indexedFiles,
-      indexedChunks: index?.source?.indexedChunks,
+      repoUrl: indexSource.repoUrl as string | undefined,
+      branch: indexSource.branch as string | undefined,
+      revision: indexSource.revision as string | undefined,
+      indexedFiles: indexSource.indexedFiles as number | undefined,
+      indexedChunks: indexSource.indexedChunks as number | undefined,
     },
     embedding: {
-      model: embeddingStore?.model,
-      baseURL: embeddingStore?.baseURL,
-      dimensions: embeddingStore?.dimensions,
-      vectorCount: embeddingStore?.vectors ? Object.keys(embeddingStore.vectors).length : undefined,
-      storeVersion: embeddingStore?.version,
+      model: embeddingStore?.model as string | undefined,
+      baseURL: embeddingStore?.baseURL as string | undefined,
+      dimensions: embeddingStore?.dimensions as number | undefined,
+      vectorCount: vectors ? Object.keys(vectors).length : undefined,
+      storeVersion: embeddingStore?.version as number | undefined,
     },
-    indexVersion: index?.version,
+    indexVersion: index?.version as number | undefined,
   };
 }
 

--- a/apps/cli/src/commands/run.tsx
+++ b/apps/cli/src/commands/run.tsx
@@ -34,7 +34,7 @@ function isDebugEnabled(value: unknown): boolean {
 
 export default async function runCommand(task: string, options: Record<string, unknown>) {
   const projectRoot = process.cwd();
-  const sddPath = resolve(projectRoot, options.sdd);
+  const sddPath = resolve(projectRoot, options.sdd as string);
   const debug = isDebugEnabled(options.debug);
   const canPromptForApproval = process.stdin.isTTY !== false;
 
@@ -56,11 +56,11 @@ export default async function runCommand(task: string, options: Record<string, u
       ...options,
       projectRoot,
       task,
-      sddPath: options.sdd,
-      type: options.type,
-      files: options.files,
-      url: options.url,
-      runLog: options.runLog,
+      sddPath: options.sdd as string | undefined,
+      type: options.type as string | undefined,
+      files: options.files as string[] | undefined,
+      url: options.url as string | undefined,
+      runLog: options.runLog as boolean | undefined,
       filterConsole: true,
       debug,
       onRunLogPath: (runLogPath) => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -5,12 +5,7 @@
 
 import { HallucinationGuard } from '@frontagent/hallucination-guard';
 import { SDDParser, SDDPromptGenerator } from '@frontagent/sdd';
-import type {
-  AgentTask,
-  ExecutionPlan,
-  SDDConfig,
-  ValidationResult,
-} from '@frontagent/shared';
+import type { AgentTask, ExecutionPlan, SDDConfig, ValidationResult } from '@frontagent/shared';
 import { generateId, logger } from '@frontagent/shared';
 import { type A2AAgent, InMemoryA2ABus } from '../a2a.js';
 import { ContextManager } from '../context.js';
@@ -47,15 +42,15 @@ import { detectDevServerPort } from './dev-server-detection.js';
 import { mergeRetrievalQuery, normalizeSearchQuery } from './helpers.js';
 import { persistMemory, preloadMemory } from './memory-lifecycle.js';
 import {
-  createOnPhaseComplete,
-  createOnPhaseError,
-  createOnStepComplete,
-} from './step-callbacks.js';
-import {
   formatRagResult,
   retrieveRagContext,
   rewriteRagQueryForRetrieval,
 } from './rag-retrieval.js';
+import {
+  createOnPhaseComplete,
+  createOnPhaseError,
+  createOnStepComplete,
+} from './step-callbacks.js';
 
 /**
  * FrontAgent 主类

--- a/packages/core/src/agent/step-callbacks.ts
+++ b/packages/core/src/agent/step-callbacks.ts
@@ -10,7 +10,12 @@ import type { ContextManager } from '../context.js';
 import type { Executor } from '../executor.js';
 import type { LLMService } from '../llm.js';
 import type { CodeQualityIssue } from '../sub-agents/index.js';
-import type { AgentEvent, ExecutorOutput, FilesenseNavigationIntent, SubAgentConfig } from '../types.js';
+import type {
+  AgentEvent,
+  ExecutorOutput,
+  FilesenseNavigationIntent,
+  SubAgentConfig,
+} from '../types.js';
 import type { PhaseCheckDeps } from './phase-checks.js';
 import {
   checkMissingNpmDependencies,

--- a/packages/core/src/executor/phase-runner.ts
+++ b/packages/core/src/executor/phase-runner.ts
@@ -1,6 +1,6 @@
 import type { AgentTask, ExecutionStep } from '@frontagent/shared';
-import type { ExecutorCollectedContext, PhaseExecutionGroup } from './types.js';
 import type { ExecutorOutput } from '../types.js';
+import type { ExecutorCollectedContext, PhaseExecutionGroup } from './types.js';
 
 export interface PhaseRunnerDeps {
   executeStep(
@@ -69,13 +69,27 @@ export class PhaseRunner {
 
     if (this.deps.parallelExecution) {
       await this.executePhaseParallel(
-        phaseSteps, context, completedStepIds, allResults,
-        phaseResults, phaseErrors, onStepStart, onStepComplete, signal,
+        phaseSteps,
+        context,
+        completedStepIds,
+        allResults,
+        phaseResults,
+        phaseErrors,
+        onStepStart,
+        onStepComplete,
+        signal,
       );
     } else {
       await this.executePhaseSequential(
-        phaseSteps, context, completedStepIds, allResults,
-        phaseResults, phaseErrors, onStepStart, onStepComplete, signal,
+        phaseSteps,
+        context,
+        completedStepIds,
+        allResults,
+        phaseResults,
+        phaseErrors,
+        onStepStart,
+        onStepComplete,
+        signal,
       );
     }
 
@@ -95,9 +109,17 @@ export class PhaseRunner {
     }
 
     await this.runPhaseRecovery(
-      phase, phaseSteps, phaseErrors, context,
-      completedStepIds, allResults, onStepStart, onStepComplete,
-      onPhaseError, onPhaseComplete, signal,
+      phase,
+      phaseSteps,
+      phaseErrors,
+      context,
+      completedStepIds,
+      allResults,
+      onStepStart,
+      onStepComplete,
+      onPhaseError,
+      onPhaseComplete,
+      signal,
     );
 
     const phaseStats = {
@@ -201,7 +223,9 @@ export class PhaseRunner {
         const missingDeps = step.dependencies.filter((dep) => !completedStepIds.has(dep));
         this.deps.debugWarn(`[Executor] ⏭️  Skipping step ${step.stepId}: dependencies not met`);
         this.deps.debugWarn(`[Executor]    Step description: ${step.description}`);
-        this.deps.debugWarn(`[Executor]    Required dependencies: [${step.dependencies.join(', ')}]`);
+        this.deps.debugWarn(
+          `[Executor]    Required dependencies: [${step.dependencies.join(', ')}]`,
+        );
         this.deps.debugWarn(`[Executor]    Missing dependencies: [${missingDeps.join(', ')}]`);
         this.deps.debugWarn(
           `[Executor]    Completed steps: [${Array.from(completedStepIds).join(', ')}]`,

--- a/packages/core/src/workflow-integration.ts
+++ b/packages/core/src/workflow-integration.ts
@@ -4,7 +4,6 @@
  */
 
 import { join } from 'node:path';
-import { logger } from '@frontagent/shared';
 import {
   type ArtifactStore,
   type ChecklistResult,
@@ -26,6 +25,7 @@ import {
   type WorkflowState,
   createWorkflowEngine,
 } from '@frontagent/sdd';
+import { logger } from '@frontagent/shared';
 import type { SDDWorkflowConfig } from './types.js';
 
 export interface WorkflowIntegrationOptions {

--- a/packages/sdd/src/artifacts/store.test.ts
+++ b/packages/sdd/src/artifacts/store.test.ts
@@ -122,7 +122,7 @@ describe('FileArtifactStore', () => {
       const meta = await store.loadMeta('change-001', 'spec');
       expect(meta).not.toBeNull();
       expect(meta!.id).toBe('art-1');
-      expect((meta as any).content).toBeUndefined();
+      expect((meta as unknown as Record<string, unknown>).content).toBeUndefined();
     });
 
     it('finds meta in archive if not in active', async () => {

--- a/packages/shared/src/utils.test.ts
+++ b/packages/shared/src/utils.test.ts
@@ -56,34 +56,35 @@ describe('safeJsonParse', () => {
 
 describe('deepMerge', () => {
   it('merges flat objects', () => {
-    const result = deepMerge({ a: 1, b: 2 }, { b: 3, c: 4 } as any);
+    const target = { a: 1, b: 2 };
+    const result = deepMerge(target, { b: 3, c: 4 } as Partial<typeof target>);
     expect(result).toEqual({ a: 1, b: 3, c: 4 });
   });
 
   it('deep merges nested objects', () => {
     const target = { nested: { a: 1, b: 2 } };
     const source = { nested: { b: 3 } };
-    const result = deepMerge(target, source as any);
+    const result = deepMerge(target, source as Partial<typeof target>);
     expect(result).toEqual({ nested: { a: 1, b: 3 } });
   });
 
   it('overwrites arrays (no merge)', () => {
     const target = { arr: [1, 2, 3] };
     const source = { arr: [4, 5] };
-    const result = deepMerge(target, source as any);
+    const result = deepMerge(target, source as Partial<typeof target>);
     expect(result).toEqual({ arr: [4, 5] });
   });
 
   it('skips undefined values', () => {
     const target = { a: 1, b: 2 };
-    const source = { a: undefined, b: 3 };
-    const result = deepMerge(target, source as any);
+    const source: Partial<typeof target> = { a: undefined, b: 3 };
+    const result = deepMerge(target, source);
     expect(result).toEqual({ a: 1, b: 3 });
   });
 
   it('does not mutate target', () => {
     const target = { a: 1 };
-    deepMerge(target, { a: 2 } as any);
+    deepMerge(target, { a: 2 });
     expect(target.a).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the CI lint failures caused by `noExplicitAny` warnings being treated as errors, plus biome format/organizeImports issues in recently refactored files.

## Changes

- `packages/shared/src/utils.test.ts` — replace `as any` with `Partial<typeof target>` casts
- `packages/sdd/src/artifacts/store.test.ts` — replace `as any` with `as unknown as Record<string, unknown>`
- `apps/cli/src/commands/rag.ts` — type `readJsonFile` results as `Record<string, unknown>`, add field-level casts
- `apps/cli/src/commands/run.tsx` — add type assertions for options properties
- Core files — auto-fix biome format and organizeImports

## Verification

- `pnpm lint` passes (0 errors)
- `pnpm test` passes (22/22 tasks)
- Full build passes (12/12 packages)