### PR TITLE
fix: resolve biome lint errors from iteration 1 merges

### DIFF
--- a/packages/core/src/memory/store.test.ts
+++ b/packages/core/src/memory/store.test.ts
@@ -1,13 +1,10 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ProjectFactsSnapshot } from '../types.js';
 import { MemoryStore } from './store.js';
-import type { MemoryEntry, MemoryIndex, MemoryTopic, PersistenceInput } from './types.js';
+import type { PersistenceInput } from './types.js';
 import {
-  DEFAULT_MAX_TOPIC_FILES,
-  DEFAULT_PRELOAD_BUDGET_CHARS,
-  DEFAULT_RECALL_BUDGET_CHARS,
   FACTS_SNAPSHOT_FILE_NAME,
   INDEX_FILE_NAME,
   MEMORY_DIR_NAME,
@@ -23,7 +20,6 @@ vi.mock('@frontagent/shared', () => ({
 
 const PROJECT_ROOT = '/tmp/test-project';
 const MEMORY_DIR = join(PROJECT_ROOT, MEMORY_DIR_NAME);
-const TOPICS_DIR = join(MEMORY_DIR, TOPICS_DIR_NAME);
 const SNAPSHOTS_DIR = join(MEMORY_DIR, SNAPSHOTS_DIR_NAME);
 
 // --- Helpers ---
@@ -33,7 +29,7 @@ function makeIndexContent(topics: Array<{ title: string; id: string; summary: st
     '# FrontAgent Memory',
     '',
     `Project: \`${PROJECT_ROOT}\``,
-    `Updated: 2024-01-01T00:00:00.000Z`,
+    'Updated: 2024-01-01T00:00:00.000Z',
     '',
     '## Topics',
     '',
@@ -47,7 +43,10 @@ function makeIndexContent(topics: Array<{ title: string; id: string; summary: st
   return lines.join('\n');
 }
 
-function makeTopicContent(title: string, entries: Array<{ key: string; content: string; tags?: string[] }>): string {
+function makeTopicContent(
+  title: string,
+  entries: Array<{ key: string; content: string; tags?: string[] }>,
+): string {
   const lines = [`# ${title}`, ''];
   for (const e of entries) {
     const tagsStr = e.tags && e.tags.length > 0 ? ` [tags: ${e.tags.join(', ')}]` : '';
@@ -147,7 +146,11 @@ describe('MemoryStore', () => {
 
     it('loadTopic parses a valid topic file with entries', () => {
       const topicContent = makeTopicContent('Error Resolutions', [
-        { key: 'TypeError: x is not a function', content: 'Check import path', tags: ['error', 'TypeError'] },
+        {
+          key: 'TypeError: x is not a function',
+          content: 'Check import path',
+          tags: ['error', 'TypeError'],
+        },
         { key: 'ReferenceError: y is not defined', content: 'Add missing import', tags: ['error'] },
       ]);
       mockedExistsSync.mockReturnValue(true);
@@ -252,7 +255,11 @@ describe('MemoryStore', () => {
         factsSnapshot: createFactsSnapshot(),
         createdFiles: [],
         errorResolutions: [
-          { errorType: 'TypeError', errorMessage: 'Cannot read property x', resolution: 'Add null check' },
+          {
+            errorType: 'TypeError',
+            errorMessage: 'Cannot read property x',
+            resolution: 'Add null check',
+          },
         ],
         dependencyChanges: { installed: [], missing: [] },
         taskDescription: 'Fix bug',
@@ -577,11 +584,23 @@ describe('MemoryStore', () => {
         { title: 'Patterns', id: 'patterns', summary: 'code patterns' },
       ]);
       const errorsTopic = makeTopicContent('Errors', [
-        { key: 'TypeError in utils', content: 'Check null before access', tags: ['error', 'TypeError'] },
+        {
+          key: 'TypeError in utils',
+          content: 'Check null before access',
+          tags: ['error', 'TypeError'],
+        },
       ]);
       const patternsTopic = makeTopicContent('Patterns', [
-        { key: 'src/components/Button.tsx', content: 'Use forwardRef pattern', tags: ['component', 'react'] },
-        { key: 'src/api/client.ts', content: 'Always use try-catch', tags: ['api', 'error-handling'] },
+        {
+          key: 'src/components/Button.tsx',
+          content: 'Use forwardRef pattern',
+          tags: ['component', 'react'],
+        },
+        {
+          key: 'src/api/client.ts',
+          content: 'Always use try-catch',
+          tags: ['api', 'error-handling'],
+        },
       ]);
 
       mockedExistsSync.mockReturnValue(true);
@@ -654,7 +673,11 @@ describe('MemoryStore', () => {
 
     it('recall results are sorted by score descending', () => {
       setupRecallStore();
-      const results = store.recall({ filePath: 'src/api/client.ts', action: 'apply_patch', tags: ['api'] });
+      const results = store.recall({
+        filePath: 'src/api/client.ts',
+        action: 'apply_patch',
+        tags: ['api'],
+      });
       for (let i = 1; i < results.length; i++) {
         expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score);
       }
@@ -694,9 +717,7 @@ describe('MemoryStore', () => {
     });
 
     it('preload skips topics with no entries', () => {
-      const indexContent = makeIndexContent([
-        { title: 'Empty', id: 'empty', summary: 'nothing' },
-      ]);
+      const indexContent = makeIndexContent([{ title: 'Empty', id: 'empty', summary: 'nothing' }]);
       const emptyTopic = makeTopicContent('Empty', []);
 
       mockedExistsSync.mockReturnValue(true);
@@ -831,13 +852,17 @@ describe('MemoryStore', () => {
         if (path.includes('topic-a.md')) return true;
         return false;
       });
-      mockedReaddirSync.mockReturnValue(['topic-a.md'] as any);
+      mockedReaddirSync.mockReturnValue(['topic-a.md'] as unknown as ReturnType<
+        typeof readdirSync
+      >);
       mockedReadFileSync.mockReturnValue(
         makeTopicContent('Topic A', [{ key: 'entry', content: 'data' }]),
       );
 
       const input: PersistenceInput = {
-        factsSnapshot: createFactsSnapshot({ project: { devServerRunning: false, buildStatus: 'success' } }),
+        factsSnapshot: createFactsSnapshot({
+          project: { devServerRunning: false, buildStatus: 'success' },
+        }),
         createdFiles: [],
         errorResolutions: [],
         dependencyChanges: { installed: [], missing: [] },

--- a/packages/core/src/planner.test.ts
+++ b/packages/core/src/planner.test.ts
@@ -45,9 +45,21 @@ function mockLLMGeneratePlan(planner: Planner, mockFn: (...args: unknown[]) => u
 /** Default step params to reduce verbosity in mock LLM responses */
 function defaultParams(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
-    path: '', recursive: false, query: '', pattern: '', filePattern: '',
-    globOnly: false, maxResults: 0, directory: '', command: '', url: '',
-    selector: '', text: '', fullPage: false, codeDescription: '', changeDescription: '',
+    path: '',
+    recursive: false,
+    query: '',
+    pattern: '',
+    filePattern: '',
+    globOnly: false,
+    maxResults: 0,
+    directory: '',
+    command: '',
+    url: '',
+    selector: '',
+    text: '',
+    fullPage: false,
+    codeDescription: '',
+    changeDescription: '',
     ...overrides,
   };
 }
@@ -154,11 +166,7 @@ describe('Planner LLM-based plan generation', () => {
       alternatives: [],
     }));
 
-    const result = await planner.plan(
-      createTask({ type: 'create' }),
-      emptyContext(),
-      [],
-    );
+    const result = await planner.plan(createTask({ type: 'create' }), emptyContext(), []);
 
     expect(result.needsMoreContext).toBe(false);
     expect(result.plan).toBeDefined();
@@ -249,12 +257,14 @@ describe('Planner step ordering and dependencies', () => {
     const steps = result.plan!.steps;
     const readStep = steps.find((s) => s.action === 'read_file');
     const patchStep = steps.find((s) => s.action === 'apply_patch');
-    const runStep = steps.find((s) => s.action === 'run_command' && s.params.command === 'pnpm test');
+    const runStep = steps.find(
+      (s) => s.action === 'run_command' && s.params.command === 'pnpm test',
+    );
 
     expect(patchStep!.dependencies).toContain(readStep!.stepId);
     expect(runStep!.dependencies).toContain(patchStep!.stepId);
   });
-// PLACEHOLDER_CHUNK5
+  // PLACEHOLDER_CHUNK5
 
   it('allows parallel execution of consecutive read-only steps (no dependency)', async () => {
     const planner = createPlanner({ useLLM: true });
@@ -389,7 +399,7 @@ describe('Planner error handling', () => {
     const step = result.plan!.steps[0];
     expect(step.action).toBe('read_file');
   });
-// PLACEHOLDER_CHUNK7
+  // PLACEHOLDER_CHUNK7
 
   it('requests more context when modify task has unread relevant files', async () => {
     const planner = createPlanner({ useLLM: false });
@@ -495,7 +505,7 @@ describe('Planner edge cases', () => {
       maxRollbackSteps: 10,
     });
   });
-// PLACEHOLDER_CHUNK9
+  // PLACEHOLDER_CHUNK9
 
   it('disables rollback for query tasks', async () => {
     const planner = createPlanner({ useLLM: false });
@@ -543,7 +553,7 @@ describe('Planner edge cases', () => {
     );
     expect(hasRepoPhase).toBe(false);
   });
-// PLACEHOLDER_CHUNK10
+  // PLACEHOLDER_CHUNK10
 
   it('injects repository management phase when plan has code changes and acceptance steps', async () => {
     const planner = createPlanner({ useLLM: true });
@@ -661,9 +671,7 @@ describe('Planner skill registration', () => {
 describe('Planner configuration', () => {
   it('updates SDD config', () => {
     const planner = createPlanner();
-    expect(() =>
-      planner.updateSDDConfig({ contracts: [], invariants: [] }),
-    ).not.toThrow();
+    expect(() => planner.updateSDDConfig({ contracts: [], invariants: [] })).not.toThrow();
   });
 
   it('updates LLM config', () => {

--- a/packages/core/src/security.test.ts
+++ b/packages/core/src/security.test.ts
@@ -3,12 +3,7 @@ import type { AgentTask, ExecutionStep, SDDConfig, SecurityDecision } from '@fro
 import { describe, expect, it } from 'vitest';
 import { Executor, type MCPClient } from './executor.js';
 import { LLMService } from './llm.js';
-import {
-  SecurityManager,
-  normalizeSecurity,
-  toApprovalRequest,
-  type SecurityEvaluationInput,
-} from './security.js';
+import { SecurityManager, normalizeSecurity, toApprovalRequest } from './security.js';
 
 const projectRoot = '/tmp/frontagent-project';
 
@@ -82,7 +77,7 @@ describe('normalizeSecurity', () => {
 
   it('passes through unrecognized mode values without validation', () => {
     // normalizeSecurity does not validate mode values; it trusts the caller
-    const result = normalizeSecurity({ mode: 'turbo' as any });
+    const result = normalizeSecurity({ mode: 'turbo' as unknown as 'strict' });
     expect(result.mode).toBe('turbo');
   });
 });
@@ -495,11 +490,7 @@ describe('SecurityManager', () => {
     });
 
     describe('install commands', () => {
-      const installCommands = [
-        'pnpm add left-pad',
-        'npm install express',
-        'yarn add lodash',
-      ];
+      const installCommands = ['pnpm add left-pad', 'npm install express', 'yarn add lodash'];
 
       for (const cmd of installCommands) {
         it(`asks approval for install command: ${cmd}`, () => {
@@ -612,11 +603,7 @@ describe('SecurityManager', () => {
     });
 
     describe('localhost access', () => {
-      const localUrls = [
-        'http://localhost:3000',
-        'http://127.0.0.1:8080',
-        'http://[::1]:5173',
-      ];
+      const localUrls = ['http://localhost:3000', 'http://127.0.0.1:8080', 'http://[::1]:5173'];
 
       for (const url of localUrls) {
         it(`allows browser action on local URL: ${url}`, () => {
@@ -721,7 +708,6 @@ describe('SecurityManager', () => {
       const MAX_SUMMARY_LENGTH = 220;
       expect(result.argsSummary!.length).toBeLessThanOrEqual(MAX_SUMMARY_LENGTH + 3);
       expect(result.argsSummary!).toMatch(/\.\.\.$/);
-
     });
   });
 
@@ -783,4 +769,3 @@ describe('SecurityManager', () => {
     });
   });
 });
-

--- a/packages/core/src/skill-lab/behavior-benchmark.ts
+++ b/packages/core/src/skill-lab/behavior-benchmark.ts
@@ -1,8 +1,8 @@
 import type { LLMService } from '../llm.js';
 import type { SkillContentResolver } from '../skill-content/resolver.js';
 import type { SkillManifest } from '../skill-content/types.js';
-import { BehaviorCaseGradeSchema } from './schemas.js';
 import { summarizeBehaviorResults } from './benchmark.js';
+import { BehaviorCaseGradeSchema } from './schemas.js';
 import type {
   SkillBehaviorBenchmark,
   SkillBehaviorCheckResult,
@@ -283,8 +283,7 @@ export function createStarterBehaviorChecks(keyword: string): SkillBehaviorEvalC
     },
     {
       id: 'scope-discipline',
-      question:
-        'Does the answer stay focused on the task scope implied by the prompt and keyword?',
+      question: 'Does the answer stay focused on the task scope implied by the prompt and keyword?',
       passCriteria: `Focuses on "${keyword}" and related request scope without drifting into unrelated domains.`,
       failCriteria:
         'Derails into unrelated topics or broad advice that does not help complete the requested task.',
@@ -295,8 +294,7 @@ export function createStarterBehaviorChecks(keyword: string): SkillBehaviorEvalC
       question: 'Is the answer well-structured and easy to execute?',
       passCriteria:
         'Uses clear sections or steps, avoids contradictions, and remains concise enough to follow.',
-      failCriteria:
-        'Hard to follow, contradictory, or excessively verbose for the requested task.',
+      failCriteria: 'Hard to follow, contradictory, or excessively verbose for the requested task.',
       weight: 1,
     },
   ];
@@ -323,6 +321,3 @@ export function createNoTriggerBehaviorChecks(): SkillBehaviorEvalCase['checks']
     },
   ];
 }
-
-
-

--- a/packages/core/src/skill-lab/improve.ts
+++ b/packages/core/src/skill-lab/improve.ts
@@ -1,11 +1,11 @@
-import type { z } from 'zod';
 import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
+import type { z } from 'zod';
 import type { LLMService } from '../llm.js';
 import type { SkillContentResolver } from '../skill-content/resolver.js';
 import type { SkillManifest } from '../skill-content/types.js';
-import { compareBenchmarks } from './benchmark.js';
 import { analyzeBehaviorFailures, runBehaviorBenchmark } from './behavior-benchmark.js';
+import { compareBenchmarks } from './benchmark.js';
 import { writeBenchmarkSummary } from './reporting.js';
 import { SkillImprovementSchema } from './schemas.js';
 import { runTriggerBenchmark } from './trigger-benchmark.js';
@@ -263,10 +263,7 @@ export async function executeImprovement(
     .map((relativePath) => resolve(candidateSkillDir, relativePath))
     .filter((absolutePath) => !existsSync(absolutePath));
 
-  const fallbackRoots = [
-    join(projectRoot, 'skills'),
-    ...(userSkillRoots ?? []),
-  ];
+  const fallbackRoots = [join(projectRoot, 'skills'), ...(userSkillRoots ?? [])];
   const candidateManifest = resolveSkillManifestForRoot(
     skillName,
     candidateProjectRoot,
@@ -358,4 +355,3 @@ export async function executeImprovement(
     backupPath,
   };
 }
-

--- a/packages/core/src/skill-lab/reporting.ts
+++ b/packages/core/src/skill-lab/reporting.ts
@@ -52,9 +52,7 @@ export function writeBenchmarkSummary(
     lines.push('');
     lines.push(`- Behavior cases: ${behavior.summary.totalCases}`);
     lines.push(`- Behavior pass rate: ${(behavior.summary.passRate * 100).toFixed(1)}%`);
-    lines.push(
-      `- Behavior check pass rate: ${(behavior.summary.checkPassRate * 100).toFixed(1)}%`,
-    );
+    lines.push(`- Behavior check pass rate: ${(behavior.summary.checkPassRate * 100).toFixed(1)}%`);
     lines.push(`- Behavior score rate: ${(behavior.summary.scoreRate * 100).toFixed(1)}%`);
     lines.push(`- Trigger expectation failures: ${behavior.summary.triggerExpectationFailures}`);
     if (extras.baselineBehaviorBenchmark && comparison?.behavior) {
@@ -136,4 +134,3 @@ export function writeBenchmarkSummary(
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, `${lines.join('\n')}\n`, 'utf-8');
 }
-

--- a/packages/core/src/skill-lab/skill-lab.ts
+++ b/packages/core/src/skill-lab/skill-lab.ts
@@ -4,10 +4,7 @@ import { LLMService } from '../llm.js';
 import { SkillContentLoader } from '../skill-content/loader.js';
 import { SkillContentResolver } from '../skill-content/resolver.js';
 import type { SkillManifest } from '../skill-content/types.js';
-import {
-  createStarterBehaviorSuite,
-  runBehaviorBenchmark,
-} from './behavior-benchmark.js';
+import { createStarterBehaviorSuite, runBehaviorBenchmark } from './behavior-benchmark.js';
 import { executeImprovement } from './improve.js';
 import { writeBenchmarkSummary } from './reporting.js';
 import { scaffoldSkill } from './scaffold.js';
@@ -27,13 +24,7 @@ import type {
   SkillLabSkillSummary,
   SkillTriggerEvalSuite,
 } from './types.js';
-import {
-  normalizeText,
-  sanitizeToken,
-  timestampId,
-  writeJsonFile,
-} from './utils.js';
-
+import { normalizeText, sanitizeToken, timestampId, writeJsonFile } from './utils.js';
 
 export class SkillLab {
   private readonly config: Required<Pick<SkillLabConfig, 'projectRoot' | 'outputRoot' | 'debug'>> &
@@ -134,7 +125,13 @@ export class SkillLab {
       this.config.projectRoot,
       this.config.skillContent?.userSkillRoots,
     );
-    const benchmark = runTriggerBenchmark(skillName, suite, suitePath, this.config.projectRoot, resolver);
+    const benchmark = runTriggerBenchmark(
+      skillName,
+      suite,
+      suitePath,
+      this.config.projectRoot,
+      resolver,
+    );
     const runId = timestampId();
     const runDir = join(this.getSkillLabDir(skillName), 'runs');
     const outputPath = join(runDir, `${runId}-baseline.json`);
@@ -344,10 +341,3 @@ export class SkillLab {
     return BehaviorEvalSuiteSchema.parse(raw);
   }
 }
-
-
-
-
-
-
-


### PR DESCRIPTION
Fix 11 biome lint violations across 7 files introduced by iteration 1 PRs (#138-#142):

- Remove unused `TOPICS_DIR` variable in store.test.ts
- Replace `as any` with proper type assertions in security.test.ts and store.test.ts
- Fix unnecessary template literal in store.test.ts
- Apply biome formatting to skill-lab modules

All lint checks pass. All tests pass.

Closes #143