### PR TITLE
Integrate Open Memory Gateway for managed long-term memory

### DIFF
--- a/docs/superpowers/plans/2026-06-05-open-memory-gateway-integration.md
+++ b/docs/superpowers/plans/2026-06-05-open-memory-gateway-integration.md
@@ -1,0 +1,82 @@
+# Open Memory Gateway Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an Open Memory Gateway-compatible adapter so FrontAgent can persist reviewable draft memories and recall active gateway memories.
+
+**Architecture:** Keep `MemoryStore` as FrontAgent's stable memory facade and add a small local adapter for Open Memory Gateway's Markdown storage contract. Gateway mode is opt-in via `memory.gateway.enabled`; when disabled or unavailable, existing `.frontagent/memory` preload, recall, and persistence remain the default fallback.
+
+**Tech Stack:** TypeScript, Node `fs`/`path` APIs, Vitest, existing FrontAgent memory lifecycle.
+
+---
+
+### Task 1: Add Gateway Configuration And Adapter Tests
+
+**Files:**
+- Modify: `packages/core/src/memory/types.ts`
+- Create: `packages/core/src/memory/open-memory-gateway.ts`
+- Create: `packages/core/src/memory/open-memory-gateway.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests proving:
+- `OpenMemoryGatewayAdapter.captureDraft()` writes a draft under `memory/inbox`.
+- `listActive()` reads only `memory/active/*.md`.
+- malformed gateway files are ignored.
+- config names are `memory.gateway.enabled`, `memory.gateway.rootDir`, `memory.gateway.captureSource`, and `memory.gateway.autoApprove`.
+
+Run: `pnpm --dir packages/core exec vitest run src/memory/open-memory-gateway.test.ts`
+Expected: FAIL because the adapter does not exist.
+
+- [ ] **Step 2: Implement adapter**
+
+Create a synchronous adapter that writes Open Memory Gateway-compatible Markdown files with frontmatter fields: `id`, `status`, `scope`, `source`, `tags`, `createdAt`, `updatedAt`. Use `memory/inbox` for `draft` and `memory/active` for active memories.
+
+- [ ] **Step 3: Verify adapter tests**
+
+Run: `pnpm --dir packages/core exec vitest run src/memory/open-memory-gateway.test.ts`
+Expected: PASS.
+
+### Task 2: Wire Gateway Into MemoryStore
+
+**Files:**
+- Modify: `packages/core/src/memory/store.ts`
+- Modify: `packages/core/src/memory/store.test.ts`
+- Modify: `packages/core/src/memory/index.ts`
+
+- [ ] **Step 1: Write failing MemoryStore tests**
+
+Add tests proving:
+- when `memory.gateway.enabled` is true, `persist()` captures a draft gateway memory containing task, created files, dependencies, and error resolutions.
+- when active gateway memories exist, `preload()` includes them before local topic memory.
+- when gateway mode is disabled, existing behavior remains unchanged.
+- when gateway root is unavailable, local fallback remains non-blocking.
+
+Run: `pnpm --dir packages/core exec vitest run src/memory/store.test.ts`
+Expected: FAIL because `MemoryStore` does not use the adapter yet.
+
+- [ ] **Step 2: Implement MemoryStore gateway integration**
+
+Instantiate the adapter only when `memory.gateway.enabled === true`. Default `gateway.rootDir` to `projectRoot`, `gateway.captureSource` to `frontagent`, and `gateway.autoApprove` to `false`. Keep existing local topic persistence and recall behavior as fallback.
+
+- [ ] **Step 3: Verify MemoryStore tests**
+
+Run: `pnpm --dir packages/core exec vitest run src/memory/store.test.ts`
+Expected: PASS.
+
+### Task 3: Verify And Prepare PR
+
+**Files:**
+- Modify: `.claude/repo-evolver.local.md`
+
+- [ ] **Step 1: Run verification**
+
+Run:
+- `pnpm --dir packages/core exec vitest run src/memory/open-memory-gateway.test.ts src/memory/store.test.ts`
+- `pnpm typecheck`
+- `pnpm test`
+- GitNexus MCP `detect_changes` with scope `all`.
+
+- [ ] **Step 2: Commit and PR**
+
+Commit with `feat: integrate open memory gateway`. Push `codex/open-memory-gateway-integration` and open a PR against `develop` with `Closes #164`, explicitly documenting the config names and fallback behavior.

--- a/packages/core/src/memory/index.ts
+++ b/packages/core/src/memory/index.ts
@@ -1,3 +1,10 @@
+export type {
+  OpenMemoryGatewayAdapterOptions,
+  OpenMemoryGatewayCaptureInput,
+  OpenMemoryGatewayRecord,
+  OpenMemoryGatewayStatus,
+} from './open-memory-gateway.js';
+export { OpenMemoryGatewayAdapter } from './open-memory-gateway.js';
 export { MemoryStore } from './store.js';
 export type {
   MemoryConfig,
@@ -5,6 +12,7 @@ export type {
   MemoryIndex,
   MemoryTopic,
   MemoryTopicMeta,
+  OpenMemoryGatewayConfig,
   PersistenceInput,
   RecalledMemory,
   RecallQuery,

--- a/packages/core/src/memory/open-memory-gateway.test.ts
+++ b/packages/core/src/memory/open-memory-gateway.test.ts
@@ -1,0 +1,133 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { OpenMemoryGatewayAdapter } from './open-memory-gateway.js';
+import type { OpenMemoryGatewayConfig } from './types.js';
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'frontagent-omg-'));
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe('OpenMemoryGatewayAdapter', () => {
+  it('writes draft captures to the Open Memory Gateway inbox contract', () => {
+    const adapter = new OpenMemoryGatewayAdapter({ rootDir: root, captureSource: 'frontagent' });
+
+    const record = adapter.captureDraft({
+      content: 'Remember that this repository prefers TDD.',
+      tags: ['FrontAgent', 'TDD'],
+    });
+
+    expect(record.id).toMatch(/^mem_\d{8}_[a-f0-9]{8}$/);
+    expect(record.status).toBe('draft');
+    expect(record.source).toBe('frontagent');
+    expect(record.tags).toEqual(['frontagent', 'tdd']);
+    expect(record.path).toBe(join(root, 'memory', 'inbox', `${record.id}.md`));
+
+    const active = adapter.listActive();
+    expect(active).toEqual([]);
+  });
+
+  it('lists only active memories from the gateway active directory', async () => {
+    const activeDir = join(root, 'memory', 'active');
+    const inboxDir = join(root, 'memory', 'inbox');
+    await mkdir(activeDir, { recursive: true });
+    await mkdir(inboxDir, { recursive: true });
+    await writeFile(
+      join(activeDir, 'mem_20260605_active123.md'),
+      [
+        '---',
+        'id: mem_20260605_active123',
+        'status: active',
+        'scope: personal',
+        'source: manual',
+        'tags:',
+        '  - preference',
+        'createdAt: "2026-06-05T09:00:00.000Z"',
+        'updatedAt: "2026-06-05T09:01:00.000Z"',
+        '---',
+        'Prefer small focused adapters.',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    await writeFile(
+      join(inboxDir, 'mem_20260605_draft123.md'),
+      [
+        '---',
+        'id: mem_20260605_draft123',
+        'status: draft',
+        'scope: personal',
+        'source: manual',
+        'tags: []',
+        'createdAt: "2026-06-05T09:00:00.000Z"',
+        'updatedAt: "2026-06-05T09:01:00.000Z"',
+        '---',
+        'This draft should not preload.',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const adapter = new OpenMemoryGatewayAdapter({ rootDir: root });
+
+    expect(adapter.listActive()).toMatchObject([
+      {
+        id: 'mem_20260605_active123',
+        status: 'active',
+        tags: ['preference'],
+        content: 'Prefer small focused adapters.',
+      },
+    ]);
+  });
+
+  it('ignores malformed gateway files while listing active memories', async () => {
+    const activeDir = join(root, 'memory', 'active');
+    await mkdir(activeDir, { recursive: true });
+    await writeFile(join(activeDir, 'broken.md'), 'not frontmatter', 'utf-8');
+    await writeFile(
+      join(activeDir, 'mem_20260605_good123.md'),
+      [
+        '---',
+        'id: mem_20260605_good123',
+        'status: active',
+        'scope: personal',
+        'source: manual',
+        'tags: []',
+        'createdAt: "2026-06-05T09:00:00.000Z"',
+        'updatedAt: "2026-06-05T09:01:00.000Z"',
+        '---',
+        'Valid active memory.',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const adapter = new OpenMemoryGatewayAdapter({ rootDir: root });
+
+    expect(adapter.listActive()).toHaveLength(1);
+    expect(adapter.listActive()[0].content).toBe('Valid active memory.');
+  });
+
+  it('documents the public gateway config field names', () => {
+    const config = {
+      enabled: true,
+      rootDir: root,
+      captureSource: 'frontagent',
+      autoApprove: false,
+    } satisfies OpenMemoryGatewayConfig;
+
+    expect(config).toEqual({
+      enabled: true,
+      rootDir: root,
+      captureSource: 'frontagent',
+      autoApprove: false,
+    });
+  });
+});

--- a/packages/core/src/memory/open-memory-gateway.ts
+++ b/packages/core/src/memory/open-memory-gateway.ts
@@ -1,0 +1,214 @@
+import { randomBytes } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+
+export type OpenMemoryGatewayStatus = 'draft' | 'active' | 'archived' | 'rejected';
+
+export interface OpenMemoryGatewayAdapterOptions {
+  rootDir: string;
+  captureSource?: string;
+  autoApprove?: boolean;
+}
+
+export interface OpenMemoryGatewayCaptureInput {
+  content: string;
+  tags?: string[];
+  scope?: string;
+  source?: string;
+}
+
+export interface OpenMemoryGatewayRecord {
+  id: string;
+  status: OpenMemoryGatewayStatus;
+  scope: string;
+  source: string;
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+  content: string;
+  path: string;
+}
+
+const MEMORY_ID_PATTERN = /^mem_[0-9]{8}_[a-z0-9]+$/;
+
+export class OpenMemoryGatewayAdapter {
+  private readonly rootDir: string;
+  private readonly captureSource: string;
+  private readonly autoApprove: boolean;
+
+  constructor(options: OpenMemoryGatewayAdapterOptions) {
+    this.rootDir = options.rootDir;
+    this.captureSource = options.captureSource ?? 'frontagent';
+    this.autoApprove = options.autoApprove ?? false;
+  }
+
+  captureDraft(input: OpenMemoryGatewayCaptureInput): OpenMemoryGatewayRecord {
+    const content = input.content.trim();
+    if (!content) {
+      throw new Error('Memory content is required');
+    }
+
+    const now = new Date().toISOString();
+    const status: OpenMemoryGatewayStatus = this.autoApprove ? 'active' : 'draft';
+    const record: OpenMemoryGatewayRecord = {
+      id: createMemoryId(new Date(now)),
+      status,
+      scope: input.scope ?? 'personal',
+      source: input.source ?? this.captureSource,
+      tags: normalizeTags(input.tags),
+      createdAt: now,
+      updatedAt: now,
+      content,
+      path: this.memoryFilePath(status, ''),
+    };
+    record.path = this.memoryFilePath(status, record.id);
+
+    const file = serializeRecord(record);
+    mkdirSync(dirname(record.path), { recursive: true });
+    writeFileAtomically(record.path, file);
+    return record;
+  }
+
+  listActive(): OpenMemoryGatewayRecord[] {
+    const activeDir = join(this.rootDir, 'memory', 'active');
+    if (!existsSync(activeDir)) {
+      return [];
+    }
+
+    const records: OpenMemoryGatewayRecord[] = [];
+    for (const entry of readdirSync(activeDir, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+      const filePath = join(activeDir, entry.name);
+      const record = readRecord(filePath);
+      if (record?.status === 'active') {
+        records.push(record);
+      }
+    }
+
+    return records.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  }
+
+  hasActiveMemories(): boolean {
+    return this.listActive().length > 0;
+  }
+
+  private memoryFilePath(status: OpenMemoryGatewayStatus, id: string): string {
+    const statusDir = status === 'active' ? 'active' : status === 'archived' ? 'archived' : 'inbox';
+    return join(this.rootDir, 'memory', statusDir, `${id}.md`);
+  }
+}
+
+function createMemoryId(now = new Date()): string {
+  const yyyymmdd = now.toISOString().slice(0, 10).replaceAll('-', '');
+  const suffix = randomBytes(4).toString('hex');
+  return `mem_${yyyymmdd}_${suffix}`;
+}
+
+function normalizeTags(tags: string[] = []): string[] {
+  return [...new Set(tags.map((tag) => tag.trim().toLowerCase()).filter(Boolean))];
+}
+
+function serializeRecord(record: OpenMemoryGatewayRecord): string {
+  const lines = [
+    '---',
+    `id: ${record.id}`,
+    `status: ${record.status}`,
+    `scope: ${record.scope}`,
+    `source: ${record.source}`,
+    'tags:',
+    ...record.tags.map((tag) => `  - ${tag}`),
+    `createdAt: "${record.createdAt}"`,
+    `updatedAt: "${record.updatedAt}"`,
+    '---',
+    record.content,
+    '',
+  ];
+  return lines.join('\n');
+}
+
+function readRecord(filePath: string): OpenMemoryGatewayRecord | null {
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const parsed = parseFrontmatter(raw);
+    if (!parsed) return null;
+    const status = parseStatus(parsed.data.status);
+    if (!MEMORY_ID_PATTERN.test(parsed.data.id ?? '')) return null;
+    if (!status) return null;
+
+    return {
+      id: parsed.data.id,
+      status,
+      scope: parsed.data.scope ?? 'personal',
+      source: parsed.data.source ?? 'manual',
+      tags: parsed.data.tags ? normalizeTags(parsed.data.tags.split(',')) : [],
+      createdAt: parsed.data.createdAt ?? '',
+      updatedAt: parsed.data.updatedAt ?? '',
+      content: parsed.content.trim(),
+      path: filePath,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function parseFrontmatter(raw: string): { data: Record<string, string>; content: string } | null {
+  const lines = raw.split('\n');
+  if (lines[0] !== '---') return null;
+
+  const data: Record<string, string> = {};
+  let i = 1;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line === '---') {
+      return { data, content: lines.slice(i + 1).join('\n') };
+    }
+    const keyValue = line.match(/^([A-Za-z][A-Za-z0-9]*):\s*(.*)$/);
+    if (keyValue) {
+      const key = keyValue[1];
+      const value = stripQuotes(keyValue[2].trim());
+      if (key === 'tags') {
+        const tags: string[] = [];
+        i++;
+        while (i < lines.length && lines[i].startsWith('  - ')) {
+          tags.push(stripQuotes(lines[i].slice(4).trim()));
+          i++;
+        }
+        data.tags = tags.join(',');
+        continue;
+      }
+      data[key] = value === '[]' ? '' : value;
+    }
+    i++;
+  }
+  return null;
+}
+
+function stripQuotes(value: string): string {
+  return value.replace(/^["']|["']$/g, '');
+}
+
+function parseStatus(status?: string): OpenMemoryGatewayStatus | null {
+  if (status === 'draft' || status === 'active' || status === 'archived' || status === 'rejected') {
+    return status;
+  }
+  return null;
+}
+
+function writeFileAtomically(filePath: string, content: string): void {
+  const tempPath = join(dirname(filePath), `.${Date.now()}.${randomBytes(4).toString('hex')}.tmp`);
+  try {
+    writeFileSync(tempPath, content, 'utf-8');
+    renameSync(tempPath, filePath);
+  } catch (error) {
+    rmSync(tempPath, { force: true });
+    throw error;
+  }
+}

--- a/packages/core/src/memory/store.test.ts
+++ b/packages/core/src/memory/store.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ProjectFactsSnapshot } from '../types.js';
@@ -94,12 +102,16 @@ describe('MemoryStore', () => {
   const mockedWriteFileSync = vi.mocked(writeFileSync);
   const mockedMkdirSync = vi.mocked(mkdirSync);
   const mockedReaddirSync = vi.mocked(readdirSync);
+  const mockedRenameSync = vi.mocked(renameSync);
+  const mockedRmSync = vi.mocked(rmSync);
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockedExistsSync.mockReturnValue(false);
     mockedMkdirSync.mockReturnValue(undefined);
     mockedWriteFileSync.mockReturnValue(undefined);
+    mockedRenameSync.mockReturnValue(undefined);
+    mockedRmSync.mockReturnValue(undefined);
     store = new MemoryStore(PROJECT_ROOT);
   });
 
@@ -297,6 +309,73 @@ describe('MemoryStore', () => {
       expect(content).toContain('moment');
       expect(content).toContain('Known missing dependency');
     });
+
+    it('gateway mode captures post-task learning as an Open Memory Gateway draft', () => {
+      const gatewayStore = new MemoryStore(PROJECT_ROOT, {
+        gateway: {
+          enabled: true,
+          rootDir: '/gateway-root',
+          captureSource: 'frontagent',
+        },
+      });
+      mockedExistsSync.mockReturnValue(false);
+
+      const input: PersistenceInput = {
+        factsSnapshot: createFactsSnapshot(),
+        createdFiles: ['src/App.tsx'],
+        errorResolutions: [
+          {
+            errorType: 'TypeError',
+            errorMessage: 'Cannot read property x',
+            resolution: 'Add null check',
+          },
+        ],
+        dependencyChanges: { installed: ['react'], missing: ['zod'] },
+        taskDescription: 'Create app shell',
+      };
+
+      gatewayStore.persist(input);
+
+      const gatewayWrite = mockedWriteFileSync.mock.calls.find((call) =>
+        (call[0] as string).includes('/gateway-root/memory/inbox/.'),
+      );
+      expect(gatewayWrite).toBeDefined();
+      const content = gatewayWrite![1] as string;
+      expect(content).toContain('status: draft');
+      expect(content).toContain('source: frontagent');
+      expect(content).toContain('Task: Create app shell');
+      expect(content).toContain('Created files: src/App.tsx');
+      expect(content).toContain('Installed dependencies: react');
+      expect(content).toContain('Missing dependencies: zod');
+      expect(content).toContain('TypeError: Cannot read property x');
+      expect(content).toContain('Add null check');
+    });
+
+    it('gateway capture failures do not block local memory persistence', () => {
+      const gatewayStore = new MemoryStore(PROJECT_ROOT, {
+        gateway: { enabled: true, rootDir: '/gateway-root' },
+      });
+      mockedExistsSync.mockReturnValue(false);
+      mockedWriteFileSync.mockImplementation((path) => {
+        if ((path as string).includes('/gateway-root/memory/inbox/.')) {
+          throw new Error('gateway unavailable');
+        }
+      });
+
+      const input: PersistenceInput = {
+        factsSnapshot: createFactsSnapshot(),
+        createdFiles: ['src/App.tsx'],
+        errorResolutions: [],
+        dependencyChanges: { installed: [], missing: [] },
+        taskDescription: 'Create app shell',
+      };
+
+      expect(() => gatewayStore.persist(input)).not.toThrow();
+      const localWrite = mockedWriteFileSync.mock.calls.find((call) =>
+        (call[0] as string).includes('project-structure.md'),
+      );
+      expect(localWrite).toBeDefined();
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -472,6 +551,57 @@ describe('MemoryStore', () => {
       // The most recently updated topic (New Topic) should be loaded first
       expect(result).toContain('New Topic');
       expect(result).not.toContain('Old Topic');
+    });
+
+    it('preload includes active Open Memory Gateway memories before local topics', () => {
+      const gatewayStore = new MemoryStore(PROJECT_ROOT, {
+        gateway: { enabled: true, rootDir: '/gateway-root' },
+      });
+      const indexContent = makeIndexContent([
+        { title: 'Project Structure', id: 'project-structure', summary: 'tracked files' },
+      ]);
+      const localTopic = makeTopicContent('Project Structure', [
+        { key: 'src/App.tsx', content: 'Local memory content', tags: ['component'] },
+      ]);
+      const gatewayMemory = [
+        '---',
+        'id: mem_20260605_active123',
+        'status: active',
+        'scope: personal',
+        'source: manual',
+        'tags:',
+        '  - preference',
+        'createdAt: "2026-06-05T09:00:00.000Z"',
+        'updatedAt: "2026-06-05T09:01:00.000Z"',
+        '---',
+        'Gateway active memory content.',
+        '',
+      ].join('\n');
+
+      mockedExistsSync.mockReturnValue(true);
+      mockedReaddirSync.mockImplementation((path) => {
+        if ((path as string).includes('/gateway-root/memory/active')) {
+          return [{ name: 'mem_20260605_active123.md', isFile: () => true }] as ReturnType<
+            typeof readdirSync
+          >;
+        }
+        return [] as unknown as ReturnType<typeof readdirSync>;
+      });
+      mockedReadFileSync.mockImplementation((path) => {
+        const filePath = path as string;
+        if (filePath.includes('/gateway-root/memory/active')) return gatewayMemory;
+        if (filePath.includes(INDEX_FILE_NAME)) return indexContent;
+        return localTopic;
+      });
+
+      const result = gatewayStore.preload();
+
+      expect(result).toContain('## Open Memory Gateway Active Memories');
+      expect(result).toContain('Gateway active memory content.');
+      expect(result).toContain('Local memory content');
+      expect(result!.indexOf('Gateway active memory content.')).toBeLessThan(
+        result!.indexOf('Local memory content'),
+      );
     });
 
     it('persist caps project-structure entries at 200', () => {

--- a/packages/core/src/memory/store.test.ts
+++ b/packages/core/src/memory/store.test.ts
@@ -420,6 +420,32 @@ describe('MemoryStore', () => {
       expect(result).toContain('Auto approve gateway memory');
     });
 
+    it('gateway capture is attempted even when local memory persistence fails', () => {
+      const gatewayStore = new MemoryStore(PROJECT_ROOT, {
+        gateway: { enabled: true, rootDir: '/gateway-root' },
+      });
+      mockedExistsSync.mockReturnValue(false);
+      mockedWriteFileSync.mockImplementation((path) => {
+        if ((path as string).includes(SNAPSHOTS_DIR)) {
+          throw new Error('local memory unavailable');
+        }
+      });
+
+      gatewayStore.persist({
+        factsSnapshot: createFactsSnapshot(),
+        createdFiles: ['src/App.tsx'],
+        errorResolutions: [],
+        dependencyChanges: { installed: [], missing: [] },
+        taskDescription: 'Capture despite local failure',
+      });
+
+      const gatewayWrite = mockedWriteFileSync.mock.calls.find((call) =>
+        (call[0] as string).includes('/gateway-root/memory/inbox/.'),
+      );
+      expect(gatewayWrite).toBeDefined();
+      expect(gatewayWrite![1] as string).toContain('Capture despite local failure');
+    });
+
     it('gateway capture failures do not block local memory persistence', () => {
       const gatewayStore = new MemoryStore(PROJECT_ROOT, {
         gateway: { enabled: true, rootDir: '/gateway-root' },
@@ -897,6 +923,56 @@ describe('MemoryStore', () => {
       expect(results.length).toBeGreaterThan(0);
       const buttonEntry = results.find((r) => r.content.includes('forwardRef'));
       expect(buttonEntry).toBeDefined();
+    });
+
+    it('recall returns active Open Memory Gateway memories and deduplicates them per session', () => {
+      const gatewayStore = new MemoryStore(PROJECT_ROOT, {
+        gateway: { enabled: true, rootDir: '/gateway-root' },
+      });
+      const gatewayMemory = [
+        '---',
+        'id: mem_20260605_active123',
+        'status: active',
+        'scope: personal',
+        'source: manual',
+        'tags:',
+        '  - preference',
+        'createdAt: "2026-06-05T09:00:00.000Z"',
+        'updatedAt: "2026-06-05T09:01:00.000Z"',
+        '---',
+        'Remember to preserve the compact toolbar layout for editor actions.',
+        '',
+      ].join('\n');
+
+      mockedExistsSync.mockImplementation((path) =>
+        (path as string).includes('/gateway-root/memory/active'),
+      );
+      mockedReaddirSync.mockImplementation((path) => {
+        if ((path as string).includes('/gateway-root/memory/active')) {
+          return [{ name: 'mem_20260605_active123.md', isFile: () => true }] as ReturnType<
+            typeof readdirSync
+          >;
+        }
+        return [] as unknown as ReturnType<typeof readdirSync>;
+      });
+      mockedReadFileSync.mockImplementation((path) => {
+        if ((path as string).includes('/gateway-root/memory/active')) return gatewayMemory;
+        return '';
+      });
+
+      const first = gatewayStore.recall({ tags: ['preference'], text: 'compact toolbar' });
+      expect(first).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            topicId: 'open-memory-gateway',
+            entryKey: 'mem_20260605_active123',
+            content: 'Remember to preserve the compact toolbar layout for editor actions.',
+          }),
+        ]),
+      );
+
+      const second = gatewayStore.recall({ tags: ['preference'], text: 'compact toolbar' });
+      expect(second.find((memory) => memory.entryKey === 'mem_20260605_active123')).toBeUndefined();
     });
 
     it('recall deduplicates entries already injected in this session', () => {

--- a/packages/core/src/memory/store.test.ts
+++ b/packages/core/src/memory/store.test.ts
@@ -351,6 +351,75 @@ describe('MemoryStore', () => {
       expect(content).toContain('Add null check');
     });
 
+    it('gateway mode honors a custom captureSource when capturing drafts', () => {
+      const gatewayStore = new MemoryStore(PROJECT_ROOT, {
+        gateway: {
+          enabled: true,
+          rootDir: '/gateway-root',
+          captureSource: 'frontagent-test-suite',
+        },
+      });
+      mockedExistsSync.mockReturnValue(false);
+
+      gatewayStore.persist({
+        factsSnapshot: createFactsSnapshot(),
+        createdFiles: ['src/App.tsx'],
+        errorResolutions: [],
+        dependencyChanges: { installed: [], missing: [] },
+        taskDescription: 'Capture custom source',
+      });
+
+      const gatewayWrite = mockedWriteFileSync.mock.calls.find((call) =>
+        (call[0] as string).includes('/gateway-root/memory/inbox/.'),
+      );
+      expect(gatewayWrite).toBeDefined();
+      expect(gatewayWrite![1] as string).toContain('source: frontagent-test-suite');
+    });
+
+    it('gateway autoApprove writes active memories that preload can inject', () => {
+      const gatewayStore = new MemoryStore(PROJECT_ROOT, {
+        gateway: { enabled: true, rootDir: '/gateway-root', autoApprove: true },
+      });
+      mockedExistsSync.mockImplementation((path) => {
+        const filePath = path as string;
+        return filePath.includes('/gateway-root/memory/active');
+      });
+      mockedReaddirSync.mockImplementation((path) => {
+        if ((path as string).includes('/gateway-root/memory/active')) {
+          return [{ name: 'mem_20260605_active123.md', isFile: () => true }] as ReturnType<
+            typeof readdirSync
+          >;
+        }
+        return [] as unknown as ReturnType<typeof readdirSync>;
+      });
+      mockedReadFileSync.mockImplementation((path) => {
+        if ((path as string).includes('/gateway-root/memory/active')) {
+          const activeWrite = mockedWriteFileSync.mock.calls.find((call) =>
+            (call[0] as string).includes('/gateway-root/memory/active/.'),
+          );
+          return activeWrite?.[1] as string;
+        }
+        return '';
+      });
+
+      gatewayStore.persist({
+        factsSnapshot: createFactsSnapshot(),
+        createdFiles: ['src/App.tsx'],
+        errorResolutions: [],
+        dependencyChanges: { installed: [], missing: [] },
+        taskDescription: 'Auto approve gateway memory',
+      });
+
+      const activeWrite = mockedWriteFileSync.mock.calls.find((call) =>
+        (call[0] as string).includes('/gateway-root/memory/active/.'),
+      );
+      expect(activeWrite).toBeDefined();
+      expect(activeWrite![1] as string).toContain('status: active');
+
+      const result = gatewayStore.preload();
+      expect(result).toContain('Auto approve gateway memory');
+    });
+
     it('gateway capture failures do not block local memory persistence', () => {
       const gatewayStore = new MemoryStore(PROJECT_ROOT, {
         gateway: { enabled: true, rootDir: '/gateway-root' },
@@ -602,6 +671,49 @@ describe('MemoryStore', () => {
       expect(result!.indexOf('Gateway active memory content.')).toBeLessThan(
         result!.indexOf('Local memory content'),
       );
+    });
+
+    it('preload keeps Open Memory Gateway active memories within the character budget', () => {
+      const gatewayStore = new MemoryStore(PROJECT_ROOT, {
+        preloadBudgetChars: 120,
+        gateway: { enabled: true, rootDir: '/gateway-root' },
+      });
+      const gatewayMemory = [
+        '---',
+        'id: mem_20260605_active123',
+        'status: active',
+        'scope: personal',
+        'source: manual',
+        'tags:',
+        '  - preference',
+        'createdAt: "2026-06-05T09:00:00.000Z"',
+        'updatedAt: "2026-06-05T09:01:00.000Z"',
+        '---',
+        `${'Gateway active memory content. '.repeat(20)}`,
+        '',
+      ].join('\n');
+
+      mockedExistsSync.mockReturnValue(true);
+      mockedReaddirSync.mockImplementation((path) => {
+        if ((path as string).includes('/gateway-root/memory/active')) {
+          return [{ name: 'mem_20260605_active123.md', isFile: () => true }] as ReturnType<
+            typeof readdirSync
+          >;
+        }
+        return [] as unknown as ReturnType<typeof readdirSync>;
+      });
+      mockedReadFileSync.mockImplementation((path) => {
+        const filePath = path as string;
+        if (filePath.includes('/gateway-root/memory/active')) return gatewayMemory;
+        if (filePath.includes(INDEX_FILE_NAME)) return makeIndexContent([]);
+        return '';
+      });
+
+      const result = gatewayStore.preload();
+
+      expect(result).not.toBeNull();
+      expect(result!.length).toBeLessThanOrEqual(120);
+      expect(result).toContain('...(truncated)');
     });
 
     it('persist caps project-structure entries at 200', () => {

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 
 import { basename, join } from 'node:path';
 import { logger } from '@frontagent/shared';
 import type { ProjectFactsSnapshot } from '../types.js';
+import { OpenMemoryGatewayAdapter, type OpenMemoryGatewayRecord } from './open-memory-gateway.js';
 import type {
   MemoryConfig,
   MemoryEntry,
@@ -35,6 +36,7 @@ export class MemoryStore {
   private readonly preloadBudget: number;
   private readonly recallBudget: number;
   private readonly maxTopicFiles: number;
+  private readonly gateway: OpenMemoryGatewayAdapter | null;
 
   private index: MemoryIndex | null = null;
   private topicCache: Map<string, MemoryTopic> = new Map();
@@ -49,6 +51,14 @@ export class MemoryStore {
     this.preloadBudget = config?.preloadBudgetChars ?? DEFAULT_PRELOAD_BUDGET_CHARS;
     this.recallBudget = config?.recallBudgetChars ?? DEFAULT_RECALL_BUDGET_CHARS;
     this.maxTopicFiles = config?.maxTopicFiles ?? DEFAULT_MAX_TOPIC_FILES;
+    this.gateway =
+      config?.gateway?.enabled === true
+        ? new OpenMemoryGatewayAdapter({
+            rootDir: config.gateway.rootDir ?? projectRoot,
+            captureSource: config.gateway.captureSource ?? 'frontagent',
+            autoApprove: config.gateway.autoApprove ?? false,
+          })
+        : null;
   }
 
   // ---------------------------------------------------------------------------
@@ -284,14 +294,20 @@ export class MemoryStore {
    * within the configured budget.
    */
   preload(): string | null {
-    const index = this.loadIndex();
-    if (!index || index.topics.length === 0) {
-      return null;
-    }
-    this.index = index;
-
     const parts: string[] = ['## 项目记忆 (跨会话持久化)'];
     let charCount = parts[0].length;
+
+    const gatewaySection = this.renderGatewayForPreload();
+    if (gatewaySection) {
+      parts.push(gatewaySection);
+      charCount += gatewaySection.length;
+    }
+
+    const index = this.loadIndex();
+    if (!index || index.topics.length === 0) {
+      return parts.length > 1 ? parts.join('\n\n') : null;
+    }
+    this.index = index;
 
     // Load topic files within budget
     const sortedTopics = [...index.topics].sort(
@@ -325,6 +341,17 @@ export class MemoryStore {
     return parts.length > 1 ? parts.join('\n\n') : null;
   }
 
+  private renderGatewayForPreload(): string | null {
+    const memories = this.listGatewayActiveMemories();
+    if (memories.length === 0) return null;
+
+    const lines = ['## Open Memory Gateway Active Memories'];
+    for (const memory of memories) {
+      lines.push(`- **${memory.id}**: ${memory.content}`);
+    }
+    return lines.join('\n');
+  }
+
   private renderTopicForPreload(topic: MemoryTopic): string {
     const lines: string[] = [`### ${topic.meta.title}`];
     for (const entry of topic.entries) {
@@ -343,28 +370,55 @@ export class MemoryStore {
    */
   recall(query: RecallQuery): RecalledMemory[] {
     const index = this.index ?? this.loadIndex();
-    if (!index || index.topics.length === 0) {
+    const gatewayMemories = this.listGatewayActiveMemories();
+    if ((!index || index.topics.length === 0) && gatewayMemories.length === 0) {
       return [];
     }
 
     const candidates: RecalledMemory[] = [];
 
-    for (const topicMeta of index.topics) {
-      const topic = this.loadTopic(topicMeta.id);
-      if (!topic) continue;
+    for (const memory of gatewayMemories) {
+      const dedupKey = `open-memory-gateway::${memory.id}`;
+      if (this.injectedKeys.has(dedupKey)) continue;
 
-      for (const entry of topic.entries) {
-        const dedupKey = `${topicMeta.id}::${entry.key}`;
-        if (this.injectedKeys.has(dedupKey)) continue;
+      const score = this.scoreEntry(
+        {
+          key: memory.id,
+          content: memory.content,
+          tags: memory.tags,
+          updatedAt: memory.updatedAt,
+        },
+        'open-memory-gateway',
+        query,
+      );
+      if (score > 0) {
+        candidates.push({
+          topicId: 'open-memory-gateway',
+          entryKey: memory.id,
+          content: memory.content,
+          score,
+        });
+      }
+    }
 
-        const score = this.scoreEntry(entry, topicMeta.id, query);
-        if (score > 0) {
-          candidates.push({
-            topicId: topicMeta.id,
-            entryKey: entry.key,
-            content: entry.content,
-            score,
-          });
+    if (index) {
+      for (const topicMeta of index.topics) {
+        const topic = this.loadTopic(topicMeta.id);
+        if (!topic) continue;
+
+        for (const entry of topic.entries) {
+          const dedupKey = `${topicMeta.id}::${entry.key}`;
+          if (this.injectedKeys.has(dedupKey)) continue;
+
+          const score = this.scoreEntry(entry, topicMeta.id, query);
+          if (score > 0) {
+            candidates.push({
+              topicId: topicMeta.id,
+              entryKey: entry.key,
+              content: entry.content,
+              score,
+            });
+          }
         }
       }
     }
@@ -486,10 +540,28 @@ export class MemoryStore {
 
       // 5. Rebuild index
       this.rebuildIndex(input.factsSnapshot);
+
+      this.persistGateway(input);
     } catch (error) {
       // Non-blocking: swallow errors to avoid disrupting the main task
       if (process.env.DEBUG) {
         logger.warn('[MemoryStore] Persistence failed:', error);
+      }
+    }
+  }
+
+  private persistGateway(input: PersistenceInput): void {
+    if (!this.gateway) return;
+
+    try {
+      this.gateway.captureDraft({
+        content: renderGatewayCapture(input),
+        source: 'frontagent',
+        tags: ['frontagent', 'task-memory'],
+      });
+    } catch (error) {
+      if (process.env.DEBUG) {
+        logger.warn('[MemoryStore] Open Memory Gateway capture failed:', error);
       }
     }
   }
@@ -675,6 +747,48 @@ export class MemoryStore {
   /** Check whether any memory exists on disk */
   hasMemory(): boolean {
     const indexPath = join(this.memoryDir, INDEX_FILE_NAME);
-    return existsSync(indexPath);
+    return existsSync(indexPath) || this.hasGatewayMemory();
   }
+
+  private listGatewayActiveMemories(): OpenMemoryGatewayRecord[] {
+    if (!this.gateway) return [];
+    try {
+      return this.gateway.listActive();
+    } catch {
+      return [];
+    }
+  }
+
+  private hasGatewayMemory(): boolean {
+    if (!this.gateway) return false;
+    try {
+      return this.gateway.hasActiveMemories();
+    } catch {
+      return false;
+    }
+  }
+}
+
+function renderGatewayCapture(input: PersistenceInput): string {
+  const lines = [`Task: ${input.taskDescription}`];
+
+  if (input.createdFiles.length > 0) {
+    lines.push(`Created files: ${input.createdFiles.join(', ')}`);
+  }
+  if (input.dependencyChanges.installed.length > 0) {
+    lines.push(`Installed dependencies: ${input.dependencyChanges.installed.join(', ')}`);
+  }
+  if (input.dependencyChanges.missing.length > 0) {
+    lines.push(`Missing dependencies: ${input.dependencyChanges.missing.join(', ')}`);
+  }
+  if (input.errorResolutions.length > 0) {
+    lines.push('Error resolutions:');
+    for (const resolution of input.errorResolutions) {
+      lines.push(
+        `- ${resolution.errorType}: ${resolution.errorMessage} -> ${resolution.resolution}`,
+      );
+    }
+  }
+
+  return lines.join('\n');
 }

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -569,14 +569,14 @@ export class MemoryStore {
 
       // 5. Rebuild index
       this.rebuildIndex(input.factsSnapshot);
-
-      this.persistGateway(input);
     } catch (error) {
       // Non-blocking: swallow errors to avoid disrupting the main task
       if (process.env.DEBUG) {
         logger.warn('[MemoryStore] Persistence failed:', error);
       }
     }
+
+    this.persistGateway(input);
   }
 
   private persistGateway(input: PersistenceInput): void {

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -25,6 +25,8 @@ import {
   TOPICS_DIR_NAME,
 } from './types.js';
 
+const PRELOAD_HEADER = '## 项目记忆 (跨会话持久化)';
+
 /**
  * Durable memory store backed by human-readable Markdown files and JSON snapshots.
  * All writes funnel through this class (single-writer pattern).
@@ -294,13 +296,13 @@ export class MemoryStore {
    * within the configured budget.
    */
   preload(): string | null {
-    const parts: string[] = ['## 项目记忆 (跨会话持久化)'];
+    const parts: string[] = [PRELOAD_HEADER];
     let charCount = parts[0].length;
 
     const gatewaySection = this.renderGatewayForPreload();
-    if (gatewaySection) {
+    if (gatewaySection && charCount < this.preloadBudget) {
       parts.push(gatewaySection);
-      charCount += gatewaySection.length;
+      charCount = measurePreloadParts(parts);
     }
 
     const index = this.loadIndex();
@@ -323,18 +325,18 @@ export class MemoryStore {
       if (!topic || topic.entries.length === 0) continue;
 
       const section = this.renderTopicForPreload(topic);
-      if (charCount + section.length > this.preloadBudget) {
-        // Try to include a truncated version
-        const remaining = this.preloadBudget - charCount;
+      const sectionLength = section.length + sectionSeparatorLength(parts);
+      if (charCount + sectionLength > this.preloadBudget) {
+        const remaining = this.preloadBudget - charCount - sectionSeparatorLength(parts);
         if (remaining > 200) {
-          parts.push(`${section.slice(0, remaining)}\n...(truncated)`);
-          charCount = this.preloadBudget;
+          parts.push(truncatePreloadSection(section, remaining));
+          charCount = measurePreloadParts(parts);
         }
         break;
       }
 
       parts.push(section);
-      charCount += section.length;
+      charCount = measurePreloadParts(parts);
       loaded++;
     }
 
@@ -345,11 +347,38 @@ export class MemoryStore {
     const memories = this.listGatewayActiveMemories();
     if (memories.length === 0) return null;
 
-    const lines = ['## Open Memory Gateway Active Memories'];
+    const lines: string[] = [];
+    const title = '## Open Memory Gateway Active Memories';
+    const marker = '\n...(truncated)';
+    let charCount = 0;
+
+    if (title.length > this.remainingPreloadBudgetAfterHeader()) {
+      return null;
+    }
+
+    lines.push(title);
+    charCount = title.length;
     for (const memory of memories) {
-      lines.push(`- **${memory.id}**: ${memory.content}`);
+      const line = `- **${memory.id}**: ${memory.content}`;
+      const lineLength = line.length + 1;
+      const remaining = this.remainingPreloadBudgetAfterHeader() - charCount - 1;
+
+      if (charCount + lineLength <= this.remainingPreloadBudgetAfterHeader()) {
+        lines.push(line);
+        charCount += lineLength;
+        continue;
+      }
+
+      if (remaining > marker.length) {
+        lines.push(truncatePreloadSection(line, remaining));
+      }
+      break;
     }
     return lines.join('\n');
+  }
+
+  private remainingPreloadBudgetAfterHeader(): number {
+    return this.preloadBudget - PRELOAD_HEADER.length - 2;
   }
 
   private renderTopicForPreload(topic: MemoryTopic): string {
@@ -556,7 +585,6 @@ export class MemoryStore {
     try {
       this.gateway.captureDraft({
         content: renderGatewayCapture(input),
-        source: 'frontagent',
         tags: ['frontagent', 'task-memory'],
       });
     } catch (error) {
@@ -767,6 +795,22 @@ export class MemoryStore {
       return false;
     }
   }
+}
+
+function measurePreloadParts(parts: string[]): number {
+  return parts.join('\n\n').length;
+}
+
+function sectionSeparatorLength(parts: string[]): number {
+  return parts.length > 0 ? 2 : 0;
+}
+
+function truncatePreloadSection(section: string, budget: number): string {
+  const marker = '\n...(truncated)';
+  if (budget <= marker.length) {
+    return section.slice(0, Math.max(0, budget));
+  }
+  return `${section.slice(0, budget - marker.length)}${marker}`;
 }
 
 function renderGatewayCapture(input: PersistenceInput): string {

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -5,12 +5,25 @@ export interface MemoryConfig {
   enabled?: boolean;
   /** Root directory for memory storage (default <projectRoot>/.frontagent/memory) */
   memoryDir?: string;
+  /** Optional Open Memory Gateway-compatible storage integration */
+  gateway?: OpenMemoryGatewayConfig;
   /** Max characters to inject from memory at startup (default 8000) */
   preloadBudgetChars?: number;
   /** Max characters of memory context per code-gen call (default 2000) */
   recallBudgetChars?: number;
   /** Max topic files to load at startup (default 10) */
   maxTopicFiles?: number;
+}
+
+export interface OpenMemoryGatewayConfig {
+  /** Whether to mirror FrontAgent memory into Open Memory Gateway storage (default false) */
+  enabled?: boolean;
+  /** Open Memory Gateway root directory containing the `memory/` folder (default project root) */
+  rootDir?: string;
+  /** Source label for captured FrontAgent memories (default frontagent) */
+  captureSource?: string;
+  /** Capture directly as active instead of draft/inbox (default false) */
+  autoApprove?: boolean;
 }
 
 export interface MemoryTopicMeta {


### PR DESCRIPTION
## Summary
- Adds an opt-in Open Memory Gateway-compatible adapter for Markdown-backed memory storage.
- Wires `MemoryStore` to capture post-task learnings as gateway draft memories and preload/recall active gateway memories.
- Keeps existing `.frontagent/memory` behavior as the default fallback when `memory.gateway.enabled` is unset or false.

## Configuration
- `memory.gateway.enabled`: opt in to Open Memory Gateway integration. Default: `false`.
- `memory.gateway.rootDir`: Open Memory Gateway root containing the `memory/` folder. Default: `projectRoot`.
- `memory.gateway.captureSource`: source label for FrontAgent captures. Default: `frontagent`.
- `memory.gateway.autoApprove`: capture directly to active memories instead of draft inbox. Default: `false`.

## Fallback Behavior
- Gateway mode is disabled by default, so existing `.frontagent/memory` preload, recall, facts snapshots, and topic persistence remain unchanged.
- Gateway read/write failures are non-blocking and swallowed like existing memory persistence failures.
- Active gateway memories are additive: they are injected before local FrontAgent topic memory when available.

## GitNexus Risk
- Pre-change impact: `MemoryStore` LOW risk; `MemoryConfig` MEDIUM risk due broad imports.
- Staged detect_changes reported HIGH because this PR adds the new `PersistGateway` flow and touches `MemoryStore.persist/preload/recall`.
- Affected runtime area is limited to memory persistence/preload/recall. Agent-facing APIs are unchanged.

## Test Plan
- `pnpm exec biome check packages/core/src/memory/open-memory-gateway.ts packages/core/src/memory/open-memory-gateway.test.ts packages/core/src/memory/store.ts packages/core/src/memory/store.test.ts packages/core/src/memory/types.ts packages/core/src/memory/index.ts docs/superpowers/plans/2026-06-05-open-memory-gateway-integration.md`
- `pnpm exec vitest run src/memory/open-memory-gateway.test.ts src/memory/store.test.ts` from `packages/core`
- `pnpm typecheck`
- `pnpm test`
- GitNexus MCP `detect_changes` on staged changes

Closes #164