### PR TITLE
test(cli): add focused command router coverage

### DIFF
--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -1,6 +1,24 @@
 import type { Command } from 'commander';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createCliProgram } from './index.js';
+import type { CliCommandHandlers } from './index.js';
+import { createCliProgram, createProductionCliProgram } from './index.js';
+
+const commandModuleMocks = vi.hoisted(() => ({
+  registerRagCommand: vi.fn((program: Command) => {
+    program.command('rag').description('mock rag command');
+  }),
+  registerSkillCommand: vi.fn((program: Command) => {
+    program.command('skill').description('mock skill command');
+  }),
+}));
+
+vi.mock('./commands/rag.js', () => ({
+  registerRagCommand: commandModuleMocks.registerRagCommand,
+}));
+
+vi.mock('./commands/skill.js', () => ({
+  registerSkillCommand: commandModuleMocks.registerSkillCommand,
+}));
 
 async function parseWithCapturedOutput(program: Command, argv: string[]) {
   let stdout = '';
@@ -28,48 +46,73 @@ async function parseWithCapturedOutput(program: Command, argv: string[]) {
   return { stdout, stderr };
 }
 
+function createHandlerSpies(overrides: Partial<CliCommandHandlers> = {}) {
+  return {
+    init: vi.fn(async () => {}),
+    validate: vi.fn(async () => {}),
+    prompt: vi.fn(async () => {}),
+    run: vi.fn(async () => {}),
+    mcpServe: vi.fn(async () => {}),
+    info: vi.fn(async () => {}),
+    ...overrides,
+  } satisfies CliCommandHandlers;
+}
+
+function expectNoHandlerCalls(handlers: CliCommandHandlers) {
+  expect(handlers.init).not.toHaveBeenCalled();
+  expect(handlers.validate).not.toHaveBeenCalled();
+  expect(handlers.prompt).not.toHaveBeenCalled();
+  expect(handlers.run).not.toHaveBeenCalled();
+  expect(handlers.mcpServe).not.toHaveBeenCalled();
+  expect(handlers.info).not.toHaveBeenCalled();
+}
+
 describe('CLI command router', () => {
   afterEach(() => {
+    vi.clearAllMocks();
     vi.restoreAllMocks();
   });
 
   it('prints the injected version without running command handlers', async () => {
-    const program = createCliProgram({ version: '1.2.3' });
+    const handlers = createHandlerSpies();
+    const program = createCliProgram({ version: '1.2.3', handlers });
 
     const { stdout, stderr } = await parseWithCapturedOutput(program, ['--version']);
 
     expect(stdout.trim()).toBe('1.2.3');
     expect(stderr).toBe('');
+    expectNoHandlerCalls(handlers);
   });
 
   it('prints the injected version from the version subcommand', async () => {
     const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const program = createCliProgram({ version: '1.2.3' });
+    const handlers = createHandlerSpies();
+    const program = createCliProgram({ version: '1.2.3', handlers });
 
     await program.parseAsync(['node', 'fa', 'version'], { from: 'node' });
 
     expect(consoleLog).toHaveBeenCalledWith('1.2.3');
+    expectNoHandlerCalls(handlers);
   });
 
   it('prints help for the root command without running command handlers', async () => {
-    const program = createCliProgram({ version: '1.2.3' });
+    const handlers = createHandlerSpies();
+    const program = createCliProgram({ version: '1.2.3', handlers });
 
     const { stdout, stderr } = await parseWithCapturedOutput(program, ['--help']);
 
     expect(stdout).toContain('FrontAgent');
     expect(stdout).toContain('run [options] <task>');
     expect(stderr).toBe('');
+    expectNoHandlerCalls(handlers);
   });
 
   it('parses representative run flags before delegating to the run handler', async () => {
-    const runCalls: Array<{ task: string; options: Record<string, unknown> }> = [];
+    const run = vi.fn(async (_task: string, _options: Record<string, unknown>) => {});
+    const handlers = createHandlerSpies({ run });
     const program = createCliProgram({
       version: '1.2.3',
-      handlers: {
-        run: async (task, options) => {
-          runCalls.push({ task, options });
-        },
-      },
+      handlers,
     });
 
     await program.parseAsync(
@@ -95,9 +138,9 @@ describe('CLI command router', () => {
       { from: 'node' },
     );
 
-    expect(runCalls).toHaveLength(1);
-    expect(runCalls[0]?.task).toBe('ship it');
-    expect(runCalls[0]?.options).toMatchObject({
+    expect(run).toHaveBeenCalledOnce();
+    expect(run).toHaveBeenCalledWith('ship it', expect.any(Object));
+    expect(run.mock.calls[0]?.[1]).toMatchObject({
       type: 'debug',
       files: ['src/a.ts', 'src/b.ts'],
       model: 'gpt-test',
@@ -106,5 +149,26 @@ describe('CLI command router', () => {
       securityMode: 'strict',
       ragMaxResults: '7',
     });
+    expect(handlers.init).not.toHaveBeenCalled();
+    expect(handlers.validate).not.toHaveBeenCalled();
+    expect(handlers.prompt).not.toHaveBeenCalled();
+    expect(handlers.mcpServe).not.toHaveBeenCalled();
+    expect(handlers.info).not.toHaveBeenCalled();
+  });
+
+  it('keeps production version and help paths cheap after extension command registration', async () => {
+    const handlers = createHandlerSpies();
+    const versionProgram = await createProductionCliProgram({ version: '1.2.3', handlers });
+    const helpProgram = await createProductionCliProgram({ version: '1.2.3', handlers });
+
+    const versionOutput = await parseWithCapturedOutput(versionProgram, ['--version']);
+    const helpOutput = await parseWithCapturedOutput(helpProgram, ['--help']);
+
+    expect(versionOutput.stdout.trim()).toBe('1.2.3');
+    expect(helpOutput.stdout).toContain('rag');
+    expect(helpOutput.stdout).toContain('skill');
+    expect(commandModuleMocks.registerRagCommand).toHaveBeenCalledTimes(2);
+    expect(commandModuleMocks.registerSkillCommand).toHaveBeenCalledTimes(2);
+    expectNoHandlerCalls(handlers);
   });
 });

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -1,0 +1,110 @@
+import type { Command } from 'commander';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createCliProgram } from './index.js';
+
+async function parseWithCapturedOutput(program: Command, argv: string[]) {
+  let stdout = '';
+  let stderr = '';
+
+  program.configureOutput({
+    writeOut: (value) => {
+      stdout += value;
+    },
+    writeErr: (value) => {
+      stderr += value;
+    },
+  });
+  program.exitOverride();
+
+  try {
+    await program.parseAsync(['node', 'fa', ...argv], { from: 'node' });
+  } catch (error) {
+    const commanderError = error as { code?: string; exitCode?: number };
+    if (commanderError.exitCode !== 0) {
+      throw error;
+    }
+  }
+
+  return { stdout, stderr };
+}
+
+describe('CLI command router', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prints the injected version without running command handlers', async () => {
+    const program = createCliProgram({ version: '1.2.3' });
+
+    const { stdout, stderr } = await parseWithCapturedOutput(program, ['--version']);
+
+    expect(stdout.trim()).toBe('1.2.3');
+    expect(stderr).toBe('');
+  });
+
+  it('prints the injected version from the version subcommand', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = createCliProgram({ version: '1.2.3' });
+
+    await program.parseAsync(['node', 'fa', 'version'], { from: 'node' });
+
+    expect(consoleLog).toHaveBeenCalledWith('1.2.3');
+  });
+
+  it('prints help for the root command without running command handlers', async () => {
+    const program = createCliProgram({ version: '1.2.3' });
+
+    const { stdout, stderr } = await parseWithCapturedOutput(program, ['--help']);
+
+    expect(stdout).toContain('FrontAgent');
+    expect(stdout).toContain('run [options] <task>');
+    expect(stderr).toBe('');
+  });
+
+  it('parses representative run flags before delegating to the run handler', async () => {
+    const runCalls: Array<{ task: string; options: Record<string, unknown> }> = [];
+    const program = createCliProgram({
+      version: '1.2.3',
+      handlers: {
+        run: async (task, options) => {
+          runCalls.push({ task, options });
+        },
+      },
+    });
+
+    await program.parseAsync(
+      [
+        'node',
+        'fa',
+        'run',
+        'ship it',
+        '--type',
+        'debug',
+        '--files',
+        'src/a.ts',
+        'src/b.ts',
+        '--model',
+        'gpt-test',
+        '--disable-rag',
+        '--no-run-log',
+        '--security-mode',
+        'strict',
+        '--rag-max-results',
+        '7',
+      ],
+      { from: 'node' },
+    );
+
+    expect(runCalls).toHaveLength(1);
+    expect(runCalls[0]?.task).toBe('ship it');
+    expect(runCalls[0]?.options).toMatchObject({
+      type: 'debug',
+      files: ['src/a.ts', 'src/b.ts'],
+      model: 'gpt-test',
+      disableRag: true,
+      runLog: false,
+      securityMode: 'strict',
+      ragMaxResults: '7',
+    });
+  });
+});

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -6,558 +6,637 @@
  * `--version`, `-v`, `version`, `info`, and `init` never pay the startup cost.
  */
 
+import { pathToFileURL } from 'node:url';
 import { Command } from 'commander';
-import { registerRagCommand } from './commands/rag.js';
-import { registerSkillCommand } from './commands/skill.js';
 import { getCliVersion } from './version.js';
 
-const cliVersion = getCliVersion();
+export type RegisterCliCommand = (program: Command) => void;
+export type PromptCommandOptions = {
+  compact: boolean;
+  language: string;
+};
 
-const program = new Command();
+export interface CliCommandHandlers {
+  init: (options: { output: string }) => Promise<void>;
+  validate: (sddPath?: string) => Promise<void>;
+  prompt: (sddPath: string, options: PromptCommandOptions) => Promise<void>;
+  run: (task: string, options: Record<string, unknown>) => Promise<void>;
+  mcpServe: (options: Record<string, unknown>) => Promise<void>;
+  info: () => Promise<void>;
+}
 
-program
-  .name('fa')
-  .description('FrontAgent - 工程级 AI Agent 系统')
-  .version(cliVersion, '-v, --version');
+export interface CreateCliProgramOptions {
+  version?: string;
+  handlers?: Partial<CliCommandHandlers>;
+  registerCommands?: RegisterCliCommand[];
+}
 
-// ── version ─────────────────────────────────────────────────────────
-program
-  .command('version')
-  .description('显示版本号')
-  .action(() => {
-    console.log(cliVersion);
+function runtimeNodePackageName() {
+  return '@frontagent/runtime-node';
+}
+
+function createDefaultHandlers(): CliCommandHandlers {
+  return {
+    init: async (options) => {
+      const { default: initCommand } = await import('./commands/init.js');
+      await initCommand(options);
+    },
+    validate: async (sddPath) => {
+      const { default: validateCommand } = await import('./commands/validate.js');
+      await validateCommand(sddPath);
+    },
+    prompt: async (sddPath, options) => {
+      const { default: promptCommand } = await import('./commands/prompt.js');
+      await promptCommand(sddPath, options);
+    },
+    run: async (task, options) => {
+      const { default: runCommand } = await import('./commands/run.js');
+      await runCommand(task, options);
+    },
+    mcpServe: async (options) => {
+      const runtimeNode = (await import(runtimeNodePackageName())) as {
+        startFrontAgentMcpServer: (options: Record<string, unknown>) => Promise<void>;
+      };
+      await runtimeNode.startFrontAgentMcpServer(options);
+    },
+    info: async () => {
+      const { default: infoCommand } = await import('./commands/info.js');
+      await infoCommand();
+    },
+  };
+}
+
+export function createCliProgram(options: CreateCliProgramOptions = {}) {
+  const cliVersion = options.version ?? getCliVersion();
+  const handlers = { ...createDefaultHandlers(), ...options.handlers };
+  const program = new Command();
+
+  program
+    .name('fa')
+    .description('FrontAgent - 工程级 AI Agent 系统')
+    .version(cliVersion, '-v, --version');
+
+  // ── version ─────────────────────────────────────────────────────────
+  program
+    .command('version')
+    .description('显示版本号')
+    .action(() => {
+      console.log(cliVersion);
+    });
+
+  // ── init ────────────────────────────────────────────────────────────
+  program
+    .command('init')
+    .description('初始化项目 SDD 配置')
+    .option('-o, --output <path>', 'SDD 配置文件输出路径', 'sdd.yaml')
+    .action(async (options) => {
+      await handlers.init(options);
+    });
+
+  // ── validate ────────────────────────────────────────────────────────
+  program
+    .command('validate')
+    .description('验证 SDD 配置文件')
+    .argument('[sdd-path]', 'SDD 配置文件路径（默认：当前目录的 sdd.yaml）')
+    .action(async (sddPath) => {
+      await handlers.validate(sddPath);
+    });
+
+  // ── prompt ──────────────────────────────────────────────────────────
+  program
+    .command('prompt')
+    .description('生成 SDD 约束提示词')
+    .argument('[sdd-path]', 'SDD 配置文件路径', 'sdd.yaml')
+    .option('-c, --compact', '生成简洁版本', false)
+    .option('-l, --language <lang>', '语言 (zh/en)', 'zh')
+    .action(async (sddPath, options) => {
+      await handlers.prompt(sddPath, options);
+    });
+
+  // ── run ─────────────────────────────────────────────────────────────
+  program
+    .command('run')
+    .description('运行 Agent 任务')
+    .argument('<task>', '任务描述')
+    .option('-s, --sdd <path>', 'SDD 配置文件路径', 'sdd.yaml')
+    .option('-t, --type <type>', '任务类型 (create/modify/query/debug/refactor/test)', 'query')
+    .option('-f, --files <files...>', '相关文件列表')
+    .option('-u, --url <url>', '浏览器 URL (用于 Web 相关任务)')
+    .option('--provider <provider>', 'LLM 提供商 (openai/anthropic)')
+    .option('--model <model>', 'LLM 模型')
+    .option('--base-url <url>', 'LLM API 基础 URL (用于代理或兼容 API)')
+    .option('--api-key <key>', 'LLM API Key (默认从环境变量读取)')
+    .option('--max-tokens <tokens>', '最大 token 数', '4096')
+    .option('--temperature <temp>', '温度参数', '0.7')
+    .option('--top-p <n>', 'Nucleus sampling (top_p)', process.env.TOP_P)
+    .option('--top-k <n>', 'Top-k sampling（仅部分 provider 支持）', process.env.TOP_K)
+    .option(
+      '--engine <engine>',
+      '执行引擎 (native/langgraph)',
+      process.env.EXECUTION_ENGINE || 'native',
+    )
+    .option(
+      '--security-mode <mode>',
+      '安全模式 (balanced/strict/developer)',
+      process.env.FRONTAGENT_SECURITY_MODE || 'balanced',
+    )
+    .option('--langgraph-checkpoint', '启用 LangGraph checkpoint', false)
+    .option(
+      '--max-recovery-attempts <n>',
+      '阶段恢复最大重试次数',
+      process.env.MAX_RECOVERY_ATTEMPTS || '3',
+    )
+    .option('--disable-rag', '禁用远程知识库 RAG', false)
+    .option(
+      '--rag-source <source>',
+      'RAG 知识源 (git/openviking/composite)',
+      process.env.FRONTAGENT_RAG_SOURCE,
+    )
+    .option(
+      '--open-viking-endpoint <url>',
+      'OpenViking 知识库查询接口',
+      process.env.FRONTAGENT_OPENVIKING_ENDPOINT,
+    )
+    .option('--open-viking-api-key <key>', 'OpenViking API Key (默认从环境变量读取)')
+    .option(
+      '--open-viking-corpus <name>',
+      'OpenViking corpus',
+      process.env.FRONTAGENT_OPENVIKING_CORPUS,
+    )
+    .option(
+      '--open-viking-namespace <name>',
+      'OpenViking namespace',
+      process.env.FRONTAGENT_OPENVIKING_NAMESPACE,
+    )
+    .option(
+      '--open-viking-l1-entry <path>',
+      'OpenViking L1 导航入口',
+      process.env.FRONTAGENT_OPENVIKING_L1_ENTRY || 'docs/openviking/frontagent-l1.md',
+    )
+    .option(
+      '--open-viking-timeout-ms <n>',
+      'OpenViking 查询超时毫秒',
+      process.env.FRONTAGENT_OPENVIKING_TIMEOUT_MS,
+    )
+    .option('--disable-open-viking-fallback', 'OpenViking 查询失败时不回退 Git RAG', false)
+    .option(
+      '--filesense-enabled <enabled>',
+      '启用 Filesense 轻量目录导航 (true/false)',
+      process.env.FRONTAGENT_FILESENSE_ENABLED,
+    )
+    .option(
+      '--filesense-output <mode>',
+      'Filesense 输出模式 (summary/candidates/verbose)',
+      process.env.FRONTAGENT_FILESENSE_OUTPUT || 'summary',
+    )
+    .option(
+      '--filesense-write-mode <mode>',
+      'Filesense 写入模式 (cache/workspace/none)',
+      process.env.FRONTAGENT_FILESENSE_WRITE_MODE || 'cache',
+    )
+    .option(
+      '--filesense-max-entries <n>',
+      'Filesense 默认扫描条目预算',
+      process.env.FRONTAGENT_FILESENSE_MAX_ENTRIES,
+    )
+    .option(
+      '--filesense-max-bytes <n>',
+      'Filesense 默认返回字节预算',
+      process.env.FRONTAGENT_FILESENSE_MAX_BYTES,
+    )
+    .option(
+      '--filesense-timeout-ms <n>',
+      'Filesense 默认导航超时毫秒',
+      process.env.FRONTAGENT_FILESENSE_TIMEOUT_MS,
+    )
+    .option('--rag-sync-on-query', '每次 RAG 查询前同步远程仓库（默认只在缺少本地缓存时 clone）')
+    .option(
+      '--rag-repo <url>',
+      '远程知识库 Git 仓库地址',
+      process.env.FRONTAGENT_RAG_REPO || 'https://github.com/ceilf6/Lab.git',
+    )
+    .option('--rag-branch <branch>', '远程知识库分支', process.env.FRONTAGENT_RAG_BRANCH || 'main')
+    .option(
+      '--rag-max-results <n>',
+      '规划前 RAG 返回条数',
+      process.env.FRONTAGENT_RAG_MAX_RESULTS || '5',
+    )
+    .option(
+      '--rag-keyword-candidates <n>',
+      'BM25 候选文档数',
+      process.env.FRONTAGENT_RAG_KEYWORD_CANDIDATES || '40',
+    )
+    .option(
+      '--rag-semantic-candidates <n>',
+      '语义检索候选文档数',
+      process.env.FRONTAGENT_RAG_SEMANTIC_CANDIDATES || '40',
+    )
+    .option(
+      '--rag-keyword-weight <n>',
+      'BM25 权重',
+      process.env.FRONTAGENT_RAG_KEYWORD_WEIGHT || '0.45',
+    )
+    .option(
+      '--rag-semantic-weight <n>',
+      '语义检索权重',
+      process.env.FRONTAGENT_RAG_SEMANTIC_WEIGHT || '0.55',
+    )
+    .option(
+      '--rag-chunk-size <n>',
+      '索引分块大小（字符）',
+      process.env.FRONTAGENT_RAG_CHUNK_SIZE || '1200',
+    )
+    .option(
+      '--rag-chunk-overlap <n>',
+      '索引分块重叠（字符）',
+      process.env.FRONTAGENT_RAG_CHUNK_OVERLAP || '200',
+    )
+    .option(
+      '--rag-max-file-size-kb <n>',
+      '单文件最大索引大小（KB）',
+      process.env.FRONTAGENT_RAG_MAX_FILE_SIZE_KB || '256',
+    )
+    .option('--rag-exclude-path <prefixes...>', '额外排除的仓库路径前缀（子模块会自动排除）')
+    .option('--disable-rag-query-rewrite', '禁用检索前的 LLM 查询优化', false)
+    .option(
+      '--rag-query-rewrite-max-tokens <n>',
+      '检索前查询优化最大输出 token',
+      process.env.FRONTAGENT_RAG_QUERY_REWRITE_MAX_TOKENS || '160',
+    )
+    .option(
+      '--rag-query-rewrite-temperature <n>',
+      '检索前查询优化温度',
+      process.env.FRONTAGENT_RAG_QUERY_REWRITE_TEMPERATURE || '0.1',
+    )
+    .option('--disable-rag-reranker', '禁用交叉编码器重排序', false)
+    .option(
+      '--rag-reranker-model <model>',
+      '重排序模型（Jina/Cohere 兼容 /rerank）',
+      process.env.FRONTAGENT_RAG_RERANKER_MODEL,
+    )
+    .option(
+      '--rag-reranker-base-url <url>',
+      '重排序 API Base URL',
+      process.env.FRONTAGENT_RAG_RERANKER_BASE_URL ||
+        process.env.OPENAI_BASE_URL ||
+        process.env.BASE_URL,
+    )
+    .option('--rag-reranker-api-key <key>', '重排序 API Key (默认从环境变量读取)')
+    .option(
+      '--rag-reranker-candidate-count <n>',
+      '送入重排序器的候选文档数',
+      process.env.FRONTAGENT_RAG_RERANKER_CANDIDATE_COUNT || '20',
+    )
+    .option(
+      '--rag-reranker-max-document-chars <n>',
+      '单个候选文档送入重排序器的最大字符数',
+      process.env.FRONTAGENT_RAG_RERANKER_MAX_DOCUMENT_CHARS || '1800',
+    )
+    .option(
+      '--rag-reranker-timeout-ms <n>',
+      '重排序请求超时毫秒',
+      process.env.FRONTAGENT_RAG_RERANKER_TIMEOUT_MS,
+    )
+    .option('--disable-rag-semantic', '禁用 embedding 语义检索，仅保留 BM25', false)
+    .option(
+      '--rag-embedding-model <model>',
+      'Embedding 模型',
+      process.env.FRONTAGENT_RAG_EMBEDDING_MODEL,
+    )
+    .option(
+      '--rag-embedding-base-url <url>',
+      'Embedding API Base URL',
+      process.env.FRONTAGENT_RAG_EMBEDDING_BASE_URL ||
+        process.env.OPENAI_BASE_URL ||
+        process.env.BASE_URL,
+    )
+    .option('--rag-embedding-api-key <key>', 'Embedding API Key (默认从环境变量读取)')
+    .option(
+      '--rag-embedding-dimensions <n>',
+      'Embedding 维度',
+      process.env.FRONTAGENT_RAG_EMBEDDING_DIMENSIONS,
+    )
+    .option(
+      '--rag-embedding-batch-size <n>',
+      'Embedding 批量大小',
+      process.env.FRONTAGENT_RAG_EMBEDDING_BATCH_SIZE,
+    )
+    .option(
+      '--rag-embedding-timeout-ms <n>',
+      'Embedding 请求超时毫秒',
+      process.env.FRONTAGENT_RAG_EMBEDDING_TIMEOUT_MS,
+    )
+    .option(
+      '--rag-vector-store-provider <provider>',
+      '向量存储提供方 (local/weaviate)',
+      process.env.FRONTAGENT_RAG_VECTOR_STORE_PROVIDER,
+    )
+    .option(
+      '--rag-weaviate-url <url>',
+      'Weaviate REST Base URL',
+      process.env.FRONTAGENT_RAG_WEAVIATE_URL,
+    )
+    .option('--rag-weaviate-api-key <key>', 'Weaviate API Key (默认从环境变量读取)')
+    .option(
+      '--rag-weaviate-collection-prefix <prefix>',
+      'Weaviate Collection 前缀',
+      process.env.FRONTAGENT_RAG_WEAVIATE_COLLECTION_PREFIX,
+    )
+    .option(
+      '--rag-weaviate-batch-size <n>',
+      'Weaviate 批量写入大小',
+      process.env.FRONTAGENT_RAG_WEAVIATE_BATCH_SIZE,
+    )
+    .option(
+      '--rag-weaviate-timeout-ms <n>',
+      'Weaviate 请求超时毫秒',
+      process.env.FRONTAGENT_RAG_WEAVIATE_TIMEOUT_MS,
+    )
+    .option(
+      '--log-file <path>',
+      '运行日志输出路径（默认：.frontagent/runs/<timestamp>-<runId>.log）',
+    )
+    .option('--no-run-log', '关闭默认运行日志')
+    .option('--debug', '启用调试模式', false)
+    .action(async (task, options) => {
+      await handlers.run(task, options);
+    });
+
+  // ── mcp serve ──────────────────────────────────────────────────────
+  const mcpCommand = program.command('mcp').description('启动 FrontAgent MCP 服务');
+
+  mcpCommand
+    .command('serve')
+    .description('通过 stdio 启动 FrontAgent MCP Server')
+    .option('--project-root <path>', '绑定的项目根目录（可选；默认使用 Host roots 或当前工作目录）')
+    .option('--provider <provider>', 'Direct LLM 提供商 (openai/anthropic)')
+    .option('--model <model>', 'Direct LLM 模型')
+    .option('--base-url <url>', 'Direct LLM API 基础 URL')
+    .option('--api-key <key>', 'Direct LLM API Key')
+    .option('--max-tokens <tokens>', '最大 token 数', '4096')
+    .option('--temperature <temp>', '温度参数', '0.2')
+    .option('--top-p <n>', 'Nucleus sampling (top_p)', process.env.TOP_P)
+    .option('--top-k <n>', 'Top-k sampling（仅部分 provider 支持）', process.env.TOP_K)
+    .option(
+      '--engine <engine>',
+      '执行引擎 (native/langgraph)',
+      process.env.EXECUTION_ENGINE || 'native',
+    )
+    .option(
+      '--security-mode <mode>',
+      '安全模式 (balanced/strict/developer)',
+      process.env.FRONTAGENT_SECURITY_MODE || 'balanced',
+    )
+    .option('--disable-rag', '禁用远程知识库 RAG', false)
+    .option(
+      '--rag-source <source>',
+      'RAG 知识源 (git/openviking/composite)',
+      process.env.FRONTAGENT_RAG_SOURCE,
+    )
+    .option(
+      '--open-viking-endpoint <url>',
+      'OpenViking 知识库查询接口',
+      process.env.FRONTAGENT_OPENVIKING_ENDPOINT,
+    )
+    .option('--open-viking-api-key <key>', 'OpenViking API Key')
+    .option(
+      '--open-viking-corpus <name>',
+      'OpenViking corpus',
+      process.env.FRONTAGENT_OPENVIKING_CORPUS,
+    )
+    .option(
+      '--open-viking-namespace <name>',
+      'OpenViking namespace',
+      process.env.FRONTAGENT_OPENVIKING_NAMESPACE,
+    )
+    .option(
+      '--open-viking-l1-entry <path>',
+      'OpenViking L1 导航入口',
+      process.env.FRONTAGENT_OPENVIKING_L1_ENTRY || 'docs/openviking/frontagent-l1.md',
+    )
+    .option(
+      '--open-viking-timeout-ms <n>',
+      'OpenViking 查询超时毫秒',
+      process.env.FRONTAGENT_OPENVIKING_TIMEOUT_MS,
+    )
+    .option('--disable-open-viking-fallback', 'OpenViking 查询失败时不回退 Git RAG', false)
+    .option(
+      '--filesense-enabled <enabled>',
+      '启用 Filesense 轻量目录导航 (true/false)',
+      process.env.FRONTAGENT_FILESENSE_ENABLED,
+    )
+    .option(
+      '--filesense-output <mode>',
+      'Filesense 输出模式 (summary/candidates/verbose)',
+      process.env.FRONTAGENT_FILESENSE_OUTPUT || 'summary',
+    )
+    .option(
+      '--filesense-write-mode <mode>',
+      'Filesense 写入模式 (cache/workspace/none)',
+      process.env.FRONTAGENT_FILESENSE_WRITE_MODE || 'cache',
+    )
+    .option(
+      '--filesense-max-entries <n>',
+      'Filesense 默认扫描条目预算',
+      process.env.FRONTAGENT_FILESENSE_MAX_ENTRIES,
+    )
+    .option(
+      '--filesense-max-bytes <n>',
+      'Filesense 默认返回字节预算',
+      process.env.FRONTAGENT_FILESENSE_MAX_BYTES,
+    )
+    .option(
+      '--filesense-timeout-ms <n>',
+      'Filesense 默认导航超时毫秒',
+      process.env.FRONTAGENT_FILESENSE_TIMEOUT_MS,
+    )
+    .option('--rag-sync-on-query', '每次 RAG 查询前同步远程仓库')
+    .option(
+      '--rag-repo <url>',
+      '远程知识库 Git 仓库地址',
+      process.env.FRONTAGENT_RAG_REPO || 'https://github.com/ceilf6/Lab.git',
+    )
+    .option('--rag-branch <branch>', '远程知识库分支', process.env.FRONTAGENT_RAG_BRANCH || 'main')
+    .option(
+      '--rag-max-results <n>',
+      '规划前 RAG 返回条数',
+      process.env.FRONTAGENT_RAG_MAX_RESULTS || '5',
+    )
+    .option(
+      '--rag-keyword-candidates <n>',
+      'BM25 候选文档数',
+      process.env.FRONTAGENT_RAG_KEYWORD_CANDIDATES || '40',
+    )
+    .option(
+      '--rag-semantic-candidates <n>',
+      '语义检索候选文档数',
+      process.env.FRONTAGENT_RAG_SEMANTIC_CANDIDATES || '40',
+    )
+    .option(
+      '--rag-keyword-weight <n>',
+      'BM25 权重',
+      process.env.FRONTAGENT_RAG_KEYWORD_WEIGHT || '0.45',
+    )
+    .option(
+      '--rag-semantic-weight <n>',
+      '语义检索权重',
+      process.env.FRONTAGENT_RAG_SEMANTIC_WEIGHT || '0.55',
+    )
+    .option(
+      '--rag-chunk-size <n>',
+      '索引分块大小（字符）',
+      process.env.FRONTAGENT_RAG_CHUNK_SIZE || '1200',
+    )
+    .option(
+      '--rag-chunk-overlap <n>',
+      '索引分块重叠（字符）',
+      process.env.FRONTAGENT_RAG_CHUNK_OVERLAP || '200',
+    )
+    .option(
+      '--rag-max-file-size-kb <n>',
+      '单文件最大索引大小（KB）',
+      process.env.FRONTAGENT_RAG_MAX_FILE_SIZE_KB || '256',
+    )
+    .option('--rag-exclude-path <prefixes...>', '额外排除的仓库路径前缀')
+    .option('--disable-rag-query-rewrite', '禁用检索前的 LLM 查询优化', false)
+    .option(
+      '--rag-query-rewrite-max-tokens <n>',
+      '检索前查询优化最大输出 token',
+      process.env.FRONTAGENT_RAG_QUERY_REWRITE_MAX_TOKENS || '160',
+    )
+    .option(
+      '--rag-query-rewrite-temperature <n>',
+      '检索前查询优化温度',
+      process.env.FRONTAGENT_RAG_QUERY_REWRITE_TEMPERATURE || '0.1',
+    )
+    .option('--disable-rag-reranker', '禁用交叉编码器重排序', false)
+    .option(
+      '--rag-reranker-model <model>',
+      '重排序模型（Jina/Cohere 兼容 /rerank）',
+      process.env.FRONTAGENT_RAG_RERANKER_MODEL,
+    )
+    .option(
+      '--rag-reranker-base-url <url>',
+      '重排序 API Base URL',
+      process.env.FRONTAGENT_RAG_RERANKER_BASE_URL ||
+        process.env.OPENAI_BASE_URL ||
+        process.env.BASE_URL,
+    )
+    .option('--rag-reranker-api-key <key>', '重排序 API Key')
+    .option(
+      '--rag-reranker-candidate-count <n>',
+      '送入重排序器的候选文档数',
+      process.env.FRONTAGENT_RAG_RERANKER_CANDIDATE_COUNT || '20',
+    )
+    .option(
+      '--rag-reranker-max-document-chars <n>',
+      '单个候选文档送入重排序器的最大字符数',
+      process.env.FRONTAGENT_RAG_RERANKER_MAX_DOCUMENT_CHARS || '1800',
+    )
+    .option(
+      '--rag-reranker-timeout-ms <n>',
+      '重排序请求超时毫秒',
+      process.env.FRONTAGENT_RAG_RERANKER_TIMEOUT_MS,
+    )
+    .option('--disable-rag-semantic', '禁用 embedding 语义检索，仅保留 BM25', false)
+    .option(
+      '--rag-embedding-model <model>',
+      'Embedding 模型',
+      process.env.FRONTAGENT_RAG_EMBEDDING_MODEL,
+    )
+    .option(
+      '--rag-embedding-base-url <url>',
+      'Embedding API Base URL',
+      process.env.FRONTAGENT_RAG_EMBEDDING_BASE_URL ||
+        process.env.OPENAI_BASE_URL ||
+        process.env.BASE_URL,
+    )
+    .option('--rag-embedding-api-key <key>', 'Embedding API Key')
+    .option(
+      '--rag-embedding-dimensions <n>',
+      'Embedding 维度',
+      process.env.FRONTAGENT_RAG_EMBEDDING_DIMENSIONS,
+    )
+    .option(
+      '--rag-embedding-batch-size <n>',
+      'Embedding 批量大小',
+      process.env.FRONTAGENT_RAG_EMBEDDING_BATCH_SIZE,
+    )
+    .option(
+      '--rag-embedding-timeout-ms <n>',
+      'Embedding 请求超时毫秒',
+      process.env.FRONTAGENT_RAG_EMBEDDING_TIMEOUT_MS,
+    )
+    .option(
+      '--rag-vector-store-provider <provider>',
+      '向量存储提供方 (local/weaviate)',
+      process.env.FRONTAGENT_RAG_VECTOR_STORE_PROVIDER,
+    )
+    .option(
+      '--rag-weaviate-url <url>',
+      'Weaviate REST Base URL',
+      process.env.FRONTAGENT_RAG_WEAVIATE_URL,
+    )
+    .option('--rag-weaviate-api-key <key>', 'Weaviate API Key')
+    .option(
+      '--rag-weaviate-collection-prefix <prefix>',
+      'Weaviate Collection 前缀',
+      process.env.FRONTAGENT_RAG_WEAVIATE_COLLECTION_PREFIX,
+    )
+    .option(
+      '--rag-weaviate-batch-size <n>',
+      'Weaviate 批量写入大小',
+      process.env.FRONTAGENT_RAG_WEAVIATE_BATCH_SIZE,
+    )
+    .option(
+      '--rag-weaviate-timeout-ms <n>',
+      'Weaviate 请求超时毫秒',
+      process.env.FRONTAGENT_RAG_WEAVIATE_TIMEOUT_MS,
+    )
+    .option('--log-file <path>', '运行日志输出路径')
+    .option('--debug', '启用调试模式', false)
+    .action(async (options) => {
+      await handlers.mcpServe(options);
+    });
+
+  // ── optional extension commands ─────────────────────────────────────
+  for (const registerCommand of options.registerCommands ?? []) {
+    registerCommand(program);
+  }
+
+  // ── info ────────────────────────────────────────────────────────────
+  program
+    .command('info')
+    .description('显示系统信息')
+    .action(async () => {
+      await handlers.info();
+    });
+
+  return program;
+}
+
+export async function createProductionCliProgram(options: CreateCliProgramOptions = {}) {
+  const [{ registerRagCommand }, { registerSkillCommand }] = await Promise.all([
+    import('./commands/rag.js'),
+    import('./commands/skill.js'),
+  ]);
+
+  return createCliProgram({
+    ...options,
+    registerCommands: [
+      ...(options.registerCommands ?? []),
+      registerRagCommand,
+      registerSkillCommand,
+    ],
   });
+}
 
-// ── init ────────────────────────────────────────────────────────────
-program
-  .command('init')
-  .description('初始化项目 SDD 配置')
-  .option('-o, --output <path>', 'SDD 配置文件输出路径', 'sdd.yaml')
-  .action(async (options) => {
-    const { default: initCommand } = await import('./commands/init.js');
-    await initCommand(options);
+export function isDirectCliEntry(moduleUrl: string, argvPath = process.argv[1]) {
+  return argvPath ? moduleUrl === pathToFileURL(argvPath).href : false;
+}
+
+if (isDirectCliEntry(import.meta.url)) {
+  void createProductionCliProgram().then((program) => {
+    program.parse();
   });
-
-// ── validate ────────────────────────────────────────────────────────
-program
-  .command('validate')
-  .description('验证 SDD 配置文件')
-  .argument('[sdd-path]', 'SDD 配置文件路径（默认：当前目录的 sdd.yaml）')
-  .action(async (sddPath) => {
-    const { default: validateCommand } = await import('./commands/validate.js');
-    await validateCommand(sddPath);
-  });
-
-// ── prompt ──────────────────────────────────────────────────────────
-program
-  .command('prompt')
-  .description('生成 SDD 约束提示词')
-  .argument('[sdd-path]', 'SDD 配置文件路径', 'sdd.yaml')
-  .option('-c, --compact', '生成简洁版本', false)
-  .option('-l, --language <lang>', '语言 (zh/en)', 'zh')
-  .action(async (sddPath, options) => {
-    const { default: promptCommand } = await import('./commands/prompt.js');
-    await promptCommand(sddPath, options);
-  });
-
-// ── run ─────────────────────────────────────────────────────────────
-program
-  .command('run')
-  .description('运行 Agent 任务')
-  .argument('<task>', '任务描述')
-  .option('-s, --sdd <path>', 'SDD 配置文件路径', 'sdd.yaml')
-  .option('-t, --type <type>', '任务类型 (create/modify/query/debug/refactor/test)', 'query')
-  .option('-f, --files <files...>', '相关文件列表')
-  .option('-u, --url <url>', '浏览器 URL (用于 Web 相关任务)')
-  .option('--provider <provider>', 'LLM 提供商 (openai/anthropic)')
-  .option('--model <model>', 'LLM 模型')
-  .option('--base-url <url>', 'LLM API 基础 URL (用于代理或兼容 API)')
-  .option('--api-key <key>', 'LLM API Key (默认从环境变量读取)')
-  .option('--max-tokens <tokens>', '最大 token 数', '4096')
-  .option('--temperature <temp>', '温度参数', '0.7')
-  .option('--top-p <n>', 'Nucleus sampling (top_p)', process.env.TOP_P)
-  .option('--top-k <n>', 'Top-k sampling（仅部分 provider 支持）', process.env.TOP_K)
-  .option(
-    '--engine <engine>',
-    '执行引擎 (native/langgraph)',
-    process.env.EXECUTION_ENGINE || 'native',
-  )
-  .option(
-    '--security-mode <mode>',
-    '安全模式 (balanced/strict/developer)',
-    process.env.FRONTAGENT_SECURITY_MODE || 'balanced',
-  )
-  .option('--langgraph-checkpoint', '启用 LangGraph checkpoint', false)
-  .option(
-    '--max-recovery-attempts <n>',
-    '阶段恢复最大重试次数',
-    process.env.MAX_RECOVERY_ATTEMPTS || '3',
-  )
-  .option('--disable-rag', '禁用远程知识库 RAG', false)
-  .option(
-    '--rag-source <source>',
-    'RAG 知识源 (git/openviking/composite)',
-    process.env.FRONTAGENT_RAG_SOURCE,
-  )
-  .option(
-    '--open-viking-endpoint <url>',
-    'OpenViking 知识库查询接口',
-    process.env.FRONTAGENT_OPENVIKING_ENDPOINT,
-  )
-  .option('--open-viking-api-key <key>', 'OpenViking API Key (默认从环境变量读取)')
-  .option(
-    '--open-viking-corpus <name>',
-    'OpenViking corpus',
-    process.env.FRONTAGENT_OPENVIKING_CORPUS,
-  )
-  .option(
-    '--open-viking-namespace <name>',
-    'OpenViking namespace',
-    process.env.FRONTAGENT_OPENVIKING_NAMESPACE,
-  )
-  .option(
-    '--open-viking-l1-entry <path>',
-    'OpenViking L1 导航入口',
-    process.env.FRONTAGENT_OPENVIKING_L1_ENTRY || 'docs/openviking/frontagent-l1.md',
-  )
-  .option(
-    '--open-viking-timeout-ms <n>',
-    'OpenViking 查询超时毫秒',
-    process.env.FRONTAGENT_OPENVIKING_TIMEOUT_MS,
-  )
-  .option('--disable-open-viking-fallback', 'OpenViking 查询失败时不回退 Git RAG', false)
-  .option(
-    '--filesense-enabled <enabled>',
-    '启用 Filesense 轻量目录导航 (true/false)',
-    process.env.FRONTAGENT_FILESENSE_ENABLED,
-  )
-  .option(
-    '--filesense-output <mode>',
-    'Filesense 输出模式 (summary/candidates/verbose)',
-    process.env.FRONTAGENT_FILESENSE_OUTPUT || 'summary',
-  )
-  .option(
-    '--filesense-write-mode <mode>',
-    'Filesense 写入模式 (cache/workspace/none)',
-    process.env.FRONTAGENT_FILESENSE_WRITE_MODE || 'cache',
-  )
-  .option(
-    '--filesense-max-entries <n>',
-    'Filesense 默认扫描条目预算',
-    process.env.FRONTAGENT_FILESENSE_MAX_ENTRIES,
-  )
-  .option(
-    '--filesense-max-bytes <n>',
-    'Filesense 默认返回字节预算',
-    process.env.FRONTAGENT_FILESENSE_MAX_BYTES,
-  )
-  .option(
-    '--filesense-timeout-ms <n>',
-    'Filesense 默认导航超时毫秒',
-    process.env.FRONTAGENT_FILESENSE_TIMEOUT_MS,
-  )
-  .option('--rag-sync-on-query', '每次 RAG 查询前同步远程仓库（默认只在缺少本地缓存时 clone）')
-  .option(
-    '--rag-repo <url>',
-    '远程知识库 Git 仓库地址',
-    process.env.FRONTAGENT_RAG_REPO || 'https://github.com/ceilf6/Lab.git',
-  )
-  .option('--rag-branch <branch>', '远程知识库分支', process.env.FRONTAGENT_RAG_BRANCH || 'main')
-  .option(
-    '--rag-max-results <n>',
-    '规划前 RAG 返回条数',
-    process.env.FRONTAGENT_RAG_MAX_RESULTS || '5',
-  )
-  .option(
-    '--rag-keyword-candidates <n>',
-    'BM25 候选文档数',
-    process.env.FRONTAGENT_RAG_KEYWORD_CANDIDATES || '40',
-  )
-  .option(
-    '--rag-semantic-candidates <n>',
-    '语义检索候选文档数',
-    process.env.FRONTAGENT_RAG_SEMANTIC_CANDIDATES || '40',
-  )
-  .option(
-    '--rag-keyword-weight <n>',
-    'BM25 权重',
-    process.env.FRONTAGENT_RAG_KEYWORD_WEIGHT || '0.45',
-  )
-  .option(
-    '--rag-semantic-weight <n>',
-    '语义检索权重',
-    process.env.FRONTAGENT_RAG_SEMANTIC_WEIGHT || '0.55',
-  )
-  .option(
-    '--rag-chunk-size <n>',
-    '索引分块大小（字符）',
-    process.env.FRONTAGENT_RAG_CHUNK_SIZE || '1200',
-  )
-  .option(
-    '--rag-chunk-overlap <n>',
-    '索引分块重叠（字符）',
-    process.env.FRONTAGENT_RAG_CHUNK_OVERLAP || '200',
-  )
-  .option(
-    '--rag-max-file-size-kb <n>',
-    '单文件最大索引大小（KB）',
-    process.env.FRONTAGENT_RAG_MAX_FILE_SIZE_KB || '256',
-  )
-  .option('--rag-exclude-path <prefixes...>', '额外排除的仓库路径前缀（子模块会自动排除）')
-  .option('--disable-rag-query-rewrite', '禁用检索前的 LLM 查询优化', false)
-  .option(
-    '--rag-query-rewrite-max-tokens <n>',
-    '检索前查询优化最大输出 token',
-    process.env.FRONTAGENT_RAG_QUERY_REWRITE_MAX_TOKENS || '160',
-  )
-  .option(
-    '--rag-query-rewrite-temperature <n>',
-    '检索前查询优化温度',
-    process.env.FRONTAGENT_RAG_QUERY_REWRITE_TEMPERATURE || '0.1',
-  )
-  .option('--disable-rag-reranker', '禁用交叉编码器重排序', false)
-  .option(
-    '--rag-reranker-model <model>',
-    '重排序模型（Jina/Cohere 兼容 /rerank）',
-    process.env.FRONTAGENT_RAG_RERANKER_MODEL,
-  )
-  .option(
-    '--rag-reranker-base-url <url>',
-    '重排序 API Base URL',
-    process.env.FRONTAGENT_RAG_RERANKER_BASE_URL ||
-      process.env.OPENAI_BASE_URL ||
-      process.env.BASE_URL,
-  )
-  .option('--rag-reranker-api-key <key>', '重排序 API Key (默认从环境变量读取)')
-  .option(
-    '--rag-reranker-candidate-count <n>',
-    '送入重排序器的候选文档数',
-    process.env.FRONTAGENT_RAG_RERANKER_CANDIDATE_COUNT || '20',
-  )
-  .option(
-    '--rag-reranker-max-document-chars <n>',
-    '单个候选文档送入重排序器的最大字符数',
-    process.env.FRONTAGENT_RAG_RERANKER_MAX_DOCUMENT_CHARS || '1800',
-  )
-  .option(
-    '--rag-reranker-timeout-ms <n>',
-    '重排序请求超时毫秒',
-    process.env.FRONTAGENT_RAG_RERANKER_TIMEOUT_MS,
-  )
-  .option('--disable-rag-semantic', '禁用 embedding 语义检索，仅保留 BM25', false)
-  .option(
-    '--rag-embedding-model <model>',
-    'Embedding 模型',
-    process.env.FRONTAGENT_RAG_EMBEDDING_MODEL,
-  )
-  .option(
-    '--rag-embedding-base-url <url>',
-    'Embedding API Base URL',
-    process.env.FRONTAGENT_RAG_EMBEDDING_BASE_URL ||
-      process.env.OPENAI_BASE_URL ||
-      process.env.BASE_URL,
-  )
-  .option('--rag-embedding-api-key <key>', 'Embedding API Key (默认从环境变量读取)')
-  .option(
-    '--rag-embedding-dimensions <n>',
-    'Embedding 维度',
-    process.env.FRONTAGENT_RAG_EMBEDDING_DIMENSIONS,
-  )
-  .option(
-    '--rag-embedding-batch-size <n>',
-    'Embedding 批量大小',
-    process.env.FRONTAGENT_RAG_EMBEDDING_BATCH_SIZE,
-  )
-  .option(
-    '--rag-embedding-timeout-ms <n>',
-    'Embedding 请求超时毫秒',
-    process.env.FRONTAGENT_RAG_EMBEDDING_TIMEOUT_MS,
-  )
-  .option(
-    '--rag-vector-store-provider <provider>',
-    '向量存储提供方 (local/weaviate)',
-    process.env.FRONTAGENT_RAG_VECTOR_STORE_PROVIDER,
-  )
-  .option(
-    '--rag-weaviate-url <url>',
-    'Weaviate REST Base URL',
-    process.env.FRONTAGENT_RAG_WEAVIATE_URL,
-  )
-  .option('--rag-weaviate-api-key <key>', 'Weaviate API Key (默认从环境变量读取)')
-  .option(
-    '--rag-weaviate-collection-prefix <prefix>',
-    'Weaviate Collection 前缀',
-    process.env.FRONTAGENT_RAG_WEAVIATE_COLLECTION_PREFIX,
-  )
-  .option(
-    '--rag-weaviate-batch-size <n>',
-    'Weaviate 批量写入大小',
-    process.env.FRONTAGENT_RAG_WEAVIATE_BATCH_SIZE,
-  )
-  .option(
-    '--rag-weaviate-timeout-ms <n>',
-    'Weaviate 请求超时毫秒',
-    process.env.FRONTAGENT_RAG_WEAVIATE_TIMEOUT_MS,
-  )
-  .option('--log-file <path>', '运行日志输出路径（默认：.frontagent/runs/<timestamp>-<runId>.log）')
-  .option('--no-run-log', '关闭默认运行日志')
-  .option('--debug', '启用调试模式', false)
-  .action(async (task, options) => {
-    const { default: runCommand } = await import('./commands/run.js');
-    await runCommand(task, options);
-  });
-
-// ── mcp serve ──────────────────────────────────────────────────────
-const mcpCommand = program.command('mcp').description('启动 FrontAgent MCP 服务');
-
-mcpCommand
-  .command('serve')
-  .description('通过 stdio 启动 FrontAgent MCP Server')
-  .option('--project-root <path>', '绑定的项目根目录（可选；默认使用 Host roots 或当前工作目录）')
-  .option('--provider <provider>', 'Direct LLM 提供商 (openai/anthropic)')
-  .option('--model <model>', 'Direct LLM 模型')
-  .option('--base-url <url>', 'Direct LLM API 基础 URL')
-  .option('--api-key <key>', 'Direct LLM API Key')
-  .option('--max-tokens <tokens>', '最大 token 数', '4096')
-  .option('--temperature <temp>', '温度参数', '0.2')
-  .option('--top-p <n>', 'Nucleus sampling (top_p)', process.env.TOP_P)
-  .option('--top-k <n>', 'Top-k sampling（仅部分 provider 支持）', process.env.TOP_K)
-  .option(
-    '--engine <engine>',
-    '执行引擎 (native/langgraph)',
-    process.env.EXECUTION_ENGINE || 'native',
-  )
-  .option(
-    '--security-mode <mode>',
-    '安全模式 (balanced/strict/developer)',
-    process.env.FRONTAGENT_SECURITY_MODE || 'balanced',
-  )
-  .option('--disable-rag', '禁用远程知识库 RAG', false)
-  .option(
-    '--rag-source <source>',
-    'RAG 知识源 (git/openviking/composite)',
-    process.env.FRONTAGENT_RAG_SOURCE,
-  )
-  .option(
-    '--open-viking-endpoint <url>',
-    'OpenViking 知识库查询接口',
-    process.env.FRONTAGENT_OPENVIKING_ENDPOINT,
-  )
-  .option('--open-viking-api-key <key>', 'OpenViking API Key')
-  .option(
-    '--open-viking-corpus <name>',
-    'OpenViking corpus',
-    process.env.FRONTAGENT_OPENVIKING_CORPUS,
-  )
-  .option(
-    '--open-viking-namespace <name>',
-    'OpenViking namespace',
-    process.env.FRONTAGENT_OPENVIKING_NAMESPACE,
-  )
-  .option(
-    '--open-viking-l1-entry <path>',
-    'OpenViking L1 导航入口',
-    process.env.FRONTAGENT_OPENVIKING_L1_ENTRY || 'docs/openviking/frontagent-l1.md',
-  )
-  .option(
-    '--open-viking-timeout-ms <n>',
-    'OpenViking 查询超时毫秒',
-    process.env.FRONTAGENT_OPENVIKING_TIMEOUT_MS,
-  )
-  .option('--disable-open-viking-fallback', 'OpenViking 查询失败时不回退 Git RAG', false)
-  .option(
-    '--filesense-enabled <enabled>',
-    '启用 Filesense 轻量目录导航 (true/false)',
-    process.env.FRONTAGENT_FILESENSE_ENABLED,
-  )
-  .option(
-    '--filesense-output <mode>',
-    'Filesense 输出模式 (summary/candidates/verbose)',
-    process.env.FRONTAGENT_FILESENSE_OUTPUT || 'summary',
-  )
-  .option(
-    '--filesense-write-mode <mode>',
-    'Filesense 写入模式 (cache/workspace/none)',
-    process.env.FRONTAGENT_FILESENSE_WRITE_MODE || 'cache',
-  )
-  .option(
-    '--filesense-max-entries <n>',
-    'Filesense 默认扫描条目预算',
-    process.env.FRONTAGENT_FILESENSE_MAX_ENTRIES,
-  )
-  .option(
-    '--filesense-max-bytes <n>',
-    'Filesense 默认返回字节预算',
-    process.env.FRONTAGENT_FILESENSE_MAX_BYTES,
-  )
-  .option(
-    '--filesense-timeout-ms <n>',
-    'Filesense 默认导航超时毫秒',
-    process.env.FRONTAGENT_FILESENSE_TIMEOUT_MS,
-  )
-  .option('--rag-sync-on-query', '每次 RAG 查询前同步远程仓库')
-  .option(
-    '--rag-repo <url>',
-    '远程知识库 Git 仓库地址',
-    process.env.FRONTAGENT_RAG_REPO || 'https://github.com/ceilf6/Lab.git',
-  )
-  .option('--rag-branch <branch>', '远程知识库分支', process.env.FRONTAGENT_RAG_BRANCH || 'main')
-  .option(
-    '--rag-max-results <n>',
-    '规划前 RAG 返回条数',
-    process.env.FRONTAGENT_RAG_MAX_RESULTS || '5',
-  )
-  .option(
-    '--rag-keyword-candidates <n>',
-    'BM25 候选文档数',
-    process.env.FRONTAGENT_RAG_KEYWORD_CANDIDATES || '40',
-  )
-  .option(
-    '--rag-semantic-candidates <n>',
-    '语义检索候选文档数',
-    process.env.FRONTAGENT_RAG_SEMANTIC_CANDIDATES || '40',
-  )
-  .option(
-    '--rag-keyword-weight <n>',
-    'BM25 权重',
-    process.env.FRONTAGENT_RAG_KEYWORD_WEIGHT || '0.45',
-  )
-  .option(
-    '--rag-semantic-weight <n>',
-    '语义检索权重',
-    process.env.FRONTAGENT_RAG_SEMANTIC_WEIGHT || '0.55',
-  )
-  .option(
-    '--rag-chunk-size <n>',
-    '索引分块大小（字符）',
-    process.env.FRONTAGENT_RAG_CHUNK_SIZE || '1200',
-  )
-  .option(
-    '--rag-chunk-overlap <n>',
-    '索引分块重叠（字符）',
-    process.env.FRONTAGENT_RAG_CHUNK_OVERLAP || '200',
-  )
-  .option(
-    '--rag-max-file-size-kb <n>',
-    '单文件最大索引大小（KB）',
-    process.env.FRONTAGENT_RAG_MAX_FILE_SIZE_KB || '256',
-  )
-  .option('--rag-exclude-path <prefixes...>', '额外排除的仓库路径前缀')
-  .option('--disable-rag-query-rewrite', '禁用检索前的 LLM 查询优化', false)
-  .option(
-    '--rag-query-rewrite-max-tokens <n>',
-    '检索前查询优化最大输出 token',
-    process.env.FRONTAGENT_RAG_QUERY_REWRITE_MAX_TOKENS || '160',
-  )
-  .option(
-    '--rag-query-rewrite-temperature <n>',
-    '检索前查询优化温度',
-    process.env.FRONTAGENT_RAG_QUERY_REWRITE_TEMPERATURE || '0.1',
-  )
-  .option('--disable-rag-reranker', '禁用交叉编码器重排序', false)
-  .option(
-    '--rag-reranker-model <model>',
-    '重排序模型（Jina/Cohere 兼容 /rerank）',
-    process.env.FRONTAGENT_RAG_RERANKER_MODEL,
-  )
-  .option(
-    '--rag-reranker-base-url <url>',
-    '重排序 API Base URL',
-    process.env.FRONTAGENT_RAG_RERANKER_BASE_URL ||
-      process.env.OPENAI_BASE_URL ||
-      process.env.BASE_URL,
-  )
-  .option('--rag-reranker-api-key <key>', '重排序 API Key')
-  .option(
-    '--rag-reranker-candidate-count <n>',
-    '送入重排序器的候选文档数',
-    process.env.FRONTAGENT_RAG_RERANKER_CANDIDATE_COUNT || '20',
-  )
-  .option(
-    '--rag-reranker-max-document-chars <n>',
-    '单个候选文档送入重排序器的最大字符数',
-    process.env.FRONTAGENT_RAG_RERANKER_MAX_DOCUMENT_CHARS || '1800',
-  )
-  .option(
-    '--rag-reranker-timeout-ms <n>',
-    '重排序请求超时毫秒',
-    process.env.FRONTAGENT_RAG_RERANKER_TIMEOUT_MS,
-  )
-  .option('--disable-rag-semantic', '禁用 embedding 语义检索，仅保留 BM25', false)
-  .option(
-    '--rag-embedding-model <model>',
-    'Embedding 模型',
-    process.env.FRONTAGENT_RAG_EMBEDDING_MODEL,
-  )
-  .option(
-    '--rag-embedding-base-url <url>',
-    'Embedding API Base URL',
-    process.env.FRONTAGENT_RAG_EMBEDDING_BASE_URL ||
-      process.env.OPENAI_BASE_URL ||
-      process.env.BASE_URL,
-  )
-  .option('--rag-embedding-api-key <key>', 'Embedding API Key')
-  .option(
-    '--rag-embedding-dimensions <n>',
-    'Embedding 维度',
-    process.env.FRONTAGENT_RAG_EMBEDDING_DIMENSIONS,
-  )
-  .option(
-    '--rag-embedding-batch-size <n>',
-    'Embedding 批量大小',
-    process.env.FRONTAGENT_RAG_EMBEDDING_BATCH_SIZE,
-  )
-  .option(
-    '--rag-embedding-timeout-ms <n>',
-    'Embedding 请求超时毫秒',
-    process.env.FRONTAGENT_RAG_EMBEDDING_TIMEOUT_MS,
-  )
-  .option(
-    '--rag-vector-store-provider <provider>',
-    '向量存储提供方 (local/weaviate)',
-    process.env.FRONTAGENT_RAG_VECTOR_STORE_PROVIDER,
-  )
-  .option(
-    '--rag-weaviate-url <url>',
-    'Weaviate REST Base URL',
-    process.env.FRONTAGENT_RAG_WEAVIATE_URL,
-  )
-  .option('--rag-weaviate-api-key <key>', 'Weaviate API Key')
-  .option(
-    '--rag-weaviate-collection-prefix <prefix>',
-    'Weaviate Collection 前缀',
-    process.env.FRONTAGENT_RAG_WEAVIATE_COLLECTION_PREFIX,
-  )
-  .option(
-    '--rag-weaviate-batch-size <n>',
-    'Weaviate 批量写入大小',
-    process.env.FRONTAGENT_RAG_WEAVIATE_BATCH_SIZE,
-  )
-  .option(
-    '--rag-weaviate-timeout-ms <n>',
-    'Weaviate 请求超时毫秒',
-    process.env.FRONTAGENT_RAG_WEAVIATE_TIMEOUT_MS,
-  )
-  .option('--log-file <path>', '运行日志输出路径')
-  .option('--debug', '启用调试模式', false)
-  .action(async (options) => {
-    const { startFrontAgentMcpServer } = await import('@frontagent/runtime-node');
-    await startFrontAgentMcpServer(options);
-  });
-
-// ── rag (export / import) ───────────────────────────────────────────
-registerRagCommand(program);
-
-// ── skill (list / scaffold / benchmark / improve / promote / …) ─────
-registerSkillCommand(program);
-
-// ── info ────────────────────────────────────────────────────────────
-program
-  .command('info')
-  .description('显示系统信息')
-  .action(async () => {
-    const { default: infoCommand } = await import('./commands/info.js');
-    await infoCommand();
-  });
-
-program.parse();
+}


### PR DESCRIPTION
## Linked Issue Or Context

Closes #173

## Summary

- Exported a testable `createCliProgram()` factory with injectable handlers so Commander routing can be parsed without invoking runtime-heavy commands.
- Kept production CLI behavior behind a direct-entry path via `createProductionCliProgram()` for extension command registration.
- Added focused Vitest coverage for `--version`, the `version` subcommand, root `--help`, representative `run` option parsing, handler cheap-path spies, and production factory cheap-path behavior with mocked extension registrars.

## Impact Scope

- `apps/cli/src/index.ts`
- `apps/cli/src/index.test.ts`

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: none; touched CLI router/test files only, no critical skeleton categories from `docs/knowledge-contract.md`.
- GitNexus impact: `impact program` and `impact runCommand` both reported LOW risk with 0 upstream impacted symbols/processes; cached `gitnexus detect-changes --scope staged` reported 2 files, 3 symbols (`cliVersion`, `program`, `mcpCommand`), 0 affected processes, risk low. Follow-up pure test change reported no indexed symbol changes. FTS was unavailable, so keyword query returned degraded/no process results.
- Verification: `pnpm --dir apps/cli test`, `pnpm typecheck`, `pnpm quality:precommit`, and `pnpm quality:ci` passed. `pnpm quality:local` could not complete locally because GitNexus analyze failed in npx/npm cache/dependency resolution (`tree-sitter-swift` peer/ENOTEMPTY), so pushes used `SKIP_QUALITY_HOOKS=1` after `quality:ci`; CI and Contract Guard passed on the PR.

## Verification

- `pnpm agent:bootstrap` passed.
- `pnpm quality:predev` attempted before code changes but failed at GitNexus analyze due local `tree-sitter-swift` package resolution, documented above.
- `pnpm --filter @frontagent/shared build` passed to provide workspace dist files for CLI tests.
- `pnpm --dir apps/cli test` passed: 5 test files, 16 tests.
- `pnpm typecheck` passed: 22/22 turbo tasks successful.
- `pnpm quality:precommit` passed; Biome emitted existing warnings in `packages/core/src/executor/executor.test.ts` and schema info, but exited 0.
- `pnpm quality:ci` passed, including build and VSIX package.
- cached GitNexus `detect-changes --scope staged` passed for source change: risk low, 0 affected processes; follow-up test-only change had no indexed symbol changes.
- PR checks passed: CI, Contract Guard / gitnexus-contract, check (20), check (22), guard.

## Repo Guard Follow-up

- Adopted: added handler spies for cheap `--version`, `version`, and `--help` paths; added production factory cheap-path coverage with mocked `rag` / `skill` registrars.
- Ignored: latest low-risk suggestion to add deeper import sentinels for heavy command modules is non-blocking and outside the focused Issue #173 scope after production/factory cheap-path coverage was added.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.