### PR TITLE
test: add runtime MCP contract tests

### DIFF
--- a/docs/superpowers/plans/2026-06-08-runtime-mcp-contract-tests.md
+++ b/docs/superpowers/plans/2026-06-08-runtime-mcp-contract-tests.md
@@ -1,0 +1,56 @@
+# Runtime MCP Contract Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add focused contract tests for the runtime MCP server tool list, schemas, and one read-only dispatch path for Issue #174.
+
+**Architecture:** Keep production runtime code unchanged. Add a Vitest file beside `mcp-server.ts` that mocks expensive core/runtime behavior and calls the MCP SDK server's registered request handlers directly as a protocol contract seam.
+
+**Tech Stack:** TypeScript, Vitest, `@modelcontextprotocol/sdk`, FrontAgent runtime-node package.
+
+---
+
+### Task 1: Runtime MCP Server Contract Tests
+
+**Files:**
+- Create: `packages/runtime-node/src/mcp-server.test.ts`
+- Modify: none expected in production code
+
+- [ ] **Step 1: Write focused tests**
+
+Create `packages/runtime-node/src/mcp-server.test.ts` that:
+- Uses the MCP SDK server's registered request handler map to exercise `tools/list` and `tools/call` without starting stdio.
+- Mocks `@frontagent/core` so `SkillLab.listSkills()` is cheap and deterministic, and LLM service construction does not perform network work.
+- Imports `createFrontAgentMcpServer` after mocks are registered.
+- Asserts `tools/list` exposes exactly the six public tools named in README and their required schema fields.
+- Calls the `tools/call` handler for `frontagent_list_skills`, parses the text result JSON, and asserts it returns project root, root source, and mocked skill metadata without invoking expensive run/plan paths.
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+pnpm --dir packages/runtime-node test -- mcp-server.test.ts
+```
+
+Expected before the test file exists or before implementation is complete: fail because no matching test exists or assertions cannot pass.
+
+- [ ] **Step 3: Keep implementation minimal**
+
+No production implementation change should be needed. If the tests reveal the current MCP contract is inaccessible without starting stdio, prefer test-only seams over exporting private helpers.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+pnpm --dir packages/runtime-node test -- mcp-server.test.ts
+pnpm --dir packages/runtime-node test
+pnpm typecheck
+```
+
+Expected: all focused runtime-node tests and monorepo typecheck pass. If GitNexus/precommit gates fail because `npx gitnexus analyze` cannot import `tree-sitter-swift`, record the exact failure in PR verification.
+
+- [ ] **Step 5: Finish branch**
+
+Run GitNexus `detect-changes` if available. Commit only the plan and test file, push `improve/add-runtime-mcp-contract-tests`, create a PR to `develop` with `Closes #174`, impact summary, and verification output.

--- a/packages/runtime-node/src/mcp-server.test.ts
+++ b/packages/runtime-node/src/mcp-server.test.ts
@@ -1,0 +1,153 @@
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const listSkills = vi.fn(() => [
+  {
+    name: 'frontend-design',
+    description: 'Design polished frontend UI',
+    source: 'built-in',
+    skillFilePath: '/skills/frontend-design/SKILL.md',
+  },
+]);
+
+const runFrontAgentTask = vi.fn(async () => {
+  throw new Error('frontagent_run_task should not be invoked by contract tests');
+});
+
+const planFrontAgentTask = vi.fn(async () => {
+  throw new Error('frontagent_plan_task should not be invoked by contract tests');
+});
+
+vi.mock('@frontagent/core', () => ({
+  LLMService: vi.fn(function LLMService() {}),
+  SkillLab: vi.fn(function SkillLab() {
+    return {
+      listSkills,
+    };
+  }),
+}));
+
+vi.mock('./run.js', () => ({
+  runFrontAgentTask,
+  planFrontAgentTask,
+}));
+
+const { createFrontAgentMcpServer } = await import('./mcp-server.js');
+
+function getRequestHandler(
+  server: unknown,
+  method: string,
+): (request: { method: string; params?: Record<string, unknown> }) => Promise<unknown> {
+  const handlers = (
+    server as { _requestHandlers: Map<string, (request: unknown) => Promise<unknown>> }
+  )._requestHandlers;
+  const handler = handlers.get(method);
+  if (!handler) {
+    throw new Error(`Missing handler for ${method}`);
+  }
+  return handler as (request: {
+    method: string;
+    params?: Record<string, unknown>;
+  }) => Promise<unknown>;
+}
+
+function parseTextResult(result: unknown): Record<string, unknown> {
+  const text = (result as { content: Array<{ type: string; text: string }> }).content[0]?.text;
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+describe('createFrontAgentMcpServer contract', () => {
+  beforeEach(() => {
+    listSkills.mockClear();
+    runFrontAgentTask.mockClear();
+    planFrontAgentTask.mockClear();
+  });
+
+  it('lists the public runtime MCP tools with stable schemas', async () => {
+    const server = createFrontAgentMcpServer({ projectRoot: '/workspace/project' });
+    const handler = getRequestHandler(server, ListToolsRequestSchema.shape.method.value);
+
+    const result = (await handler({ method: 'tools/list' })) as {
+      tools: Array<{
+        name: string;
+        description: string;
+        inputSchema: {
+          type: string;
+          properties: Record<string, unknown>;
+          required: string[];
+        };
+      }>;
+    };
+
+    expect(result.tools.map((tool) => tool.name)).toEqual([
+      'frontagent_status',
+      'frontagent_run_task',
+      'frontagent_plan_task',
+      'frontagent_validate_sdd',
+      'frontagent_list_skills',
+      'frontagent_init_sdd',
+    ]);
+
+    expect(result.tools.find((tool) => tool.name === 'frontagent_status')?.inputSchema).toEqual({
+      type: 'object',
+      properties: {},
+      required: [],
+    });
+    expect(
+      result.tools.find((tool) => tool.name === 'frontagent_list_skills')?.inputSchema,
+    ).toEqual({
+      type: 'object',
+      properties: {},
+      required: [],
+    });
+    expect(
+      result.tools.find((tool) => tool.name === 'frontagent_run_task')?.inputSchema.required,
+    ).toEqual(['task']);
+    expect(
+      Object.keys(
+        result.tools.find((tool) => tool.name === 'frontagent_run_task')?.inputSchema.properties ??
+          {},
+      ),
+    ).toEqual(expect.arrayContaining(['task', 'type', 'files', 'securityMode', 'runLog']));
+    expect(
+      result.tools.find((tool) => tool.name === 'frontagent_plan_task')?.inputSchema.required,
+    ).toEqual(['task']);
+    expect(
+      result.tools.find((tool) => tool.name === 'frontagent_validate_sdd')?.inputSchema.required,
+    ).toEqual([]);
+    expect(
+      result.tools.find((tool) => tool.name === 'frontagent_init_sdd')?.inputSchema.required,
+    ).toEqual([]);
+  });
+
+  it('dispatches frontagent_list_skills without invoking task execution or planning', async () => {
+    const server = createFrontAgentMcpServer({ projectRoot: '/workspace/project' });
+    const handler = getRequestHandler(server, CallToolRequestSchema.shape.method.value);
+
+    const result = await handler({
+      method: 'tools/call',
+      params: {
+        name: 'frontagent_list_skills',
+        arguments: {},
+      },
+    });
+    const payload = parseTextResult(result);
+
+    expect(payload).toEqual({
+      success: true,
+      projectRoot: '/workspace/project',
+      projectRootSource: 'explicit',
+      skills: [
+        {
+          name: 'frontend-design',
+          description: 'Design polished frontend UI',
+          source: 'built-in',
+          path: '/skills/frontend-design/SKILL.md',
+        },
+      ],
+    });
+    expect(listSkills).toHaveBeenCalledTimes(1);
+    expect(runFrontAgentTask).not.toHaveBeenCalled();
+    expect(planFrontAgentTask).not.toHaveBeenCalled();
+  });
+});

--- a/packages/runtime-node/src/mcp-server.test.ts
+++ b/packages/runtime-node/src/mcp-server.test.ts
@@ -56,6 +56,118 @@ function parseTextResult(result: unknown): Record<string, unknown> {
   return JSON.parse(text) as Record<string, unknown>;
 }
 
+type ListedTool = {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: string;
+    properties: Record<string, unknown>;
+    required: string[];
+  };
+};
+
+const sharedTaskPropertyNames = [
+  'task',
+  'type',
+  'files',
+  'url',
+  'sddPath',
+  'securityMode',
+  'disableRag',
+  'ragSource',
+  'ragRepo',
+  'ragBranch',
+  'openVikingEndpoint',
+  'openVikingCorpus',
+  'openVikingNamespace',
+  'openVikingL1Entry',
+  'filesenseEnabled',
+  'filesenseOutput',
+  'filesenseWriteMode',
+  'filesenseMaxEntries',
+  'filesenseMaxBytes',
+  'filesenseTimeoutMs',
+  'runLog',
+  'logFile',
+  'debug',
+  'provider',
+  'model',
+  'baseUrl',
+  'apiKey',
+  'maxTokens',
+  'temperature',
+  'topP',
+  'topK',
+];
+
+function toolByName(tools: ListedTool[], name: string): ListedTool {
+  const tool = tools.find((candidate) => candidate.name === name);
+  if (!tool) {
+    throw new Error(`Missing tool ${name}`);
+  }
+  return tool;
+}
+
+function expectSharedTaskSchema(tool: ListedTool): void {
+  expect(tool.inputSchema.type).toBe('object');
+  expect(tool.inputSchema.required).toEqual(['task']);
+  expect(Object.keys(tool.inputSchema.properties)).toEqual(sharedTaskPropertyNames);
+  expect(tool.inputSchema.properties).toMatchObject({
+    task: { type: 'string' },
+    type: {
+      type: 'string',
+      enum: ['create', 'modify', 'debug', 'query', 'refactor', 'test'],
+    },
+    files: {
+      type: 'array',
+      items: { type: 'string' },
+    },
+    url: { type: 'string' },
+    sddPath: { type: 'string' },
+    securityMode: {
+      type: 'string',
+      enum: ['balanced', 'strict', 'developer'],
+    },
+    disableRag: { type: 'boolean' },
+    ragSource: {
+      type: 'string',
+      enum: ['git', 'openviking', 'composite'],
+    },
+    ragRepo: { type: 'string' },
+    ragBranch: { type: 'string' },
+    openVikingEndpoint: { type: 'string' },
+    openVikingCorpus: { type: 'string' },
+    openVikingNamespace: { type: 'string' },
+    openVikingL1Entry: { type: 'string' },
+    filesenseEnabled: { type: 'boolean' },
+    filesenseOutput: {
+      type: 'string',
+      enum: ['summary', 'candidates', 'verbose'],
+    },
+    filesenseWriteMode: {
+      type: 'string',
+      enum: ['cache', 'workspace', 'none'],
+    },
+    filesenseMaxEntries: { type: ['string', 'number'] },
+    filesenseMaxBytes: { type: ['string', 'number'] },
+    filesenseTimeoutMs: { type: ['string', 'number'] },
+    runLog: { type: 'boolean' },
+    logFile: { type: 'string' },
+    debug: { type: 'boolean' },
+    provider: {
+      type: 'string',
+      enum: ['openai', 'anthropic'],
+    },
+    model: { type: 'string' },
+    baseUrl: { type: 'string' },
+    apiKey: { type: 'string' },
+    maxTokens: { type: ['string', 'number'] },
+    temperature: { type: ['string', 'number'] },
+    topP: { type: ['string', 'number'] },
+    topK: { type: ['string', 'number'] },
+  });
+}
+
 describe('createFrontAgentMcpServer contract', () => {
   beforeEach(() => {
     listSkills.mockClear();
@@ -67,17 +179,7 @@ describe('createFrontAgentMcpServer contract', () => {
     const server = createFrontAgentMcpServer({ projectRoot: '/workspace/project' });
     const handler = getRequestHandler(server, ListToolsRequestSchema.shape.method.value);
 
-    const result = (await handler({ method: 'tools/list' })) as {
-      tools: Array<{
-        name: string;
-        description: string;
-        inputSchema: {
-          type: string;
-          properties: Record<string, unknown>;
-          required: string[];
-        };
-      }>;
-    };
+    const result = (await handler({ method: 'tools/list' })) as { tools: ListedTool[] };
 
     expect(result.tools.map((tool) => tool.name)).toEqual([
       'frontagent_status',
@@ -88,36 +190,42 @@ describe('createFrontAgentMcpServer contract', () => {
       'frontagent_init_sdd',
     ]);
 
-    expect(result.tools.find((tool) => tool.name === 'frontagent_status')?.inputSchema).toEqual({
+    expect(toolByName(result.tools, 'frontagent_status').inputSchema).toEqual({
       type: 'object',
       properties: {},
       required: [],
     });
-    expect(
-      result.tools.find((tool) => tool.name === 'frontagent_list_skills')?.inputSchema,
-    ).toEqual({
+    expect(toolByName(result.tools, 'frontagent_list_skills').inputSchema).toEqual({
       type: 'object',
       properties: {},
       required: [],
     });
-    expect(
-      result.tools.find((tool) => tool.name === 'frontagent_run_task')?.inputSchema.required,
-    ).toEqual(['task']);
-    expect(
-      Object.keys(
-        result.tools.find((tool) => tool.name === 'frontagent_run_task')?.inputSchema.properties ??
-          {},
-      ),
-    ).toEqual(expect.arrayContaining(['task', 'type', 'files', 'securityMode', 'runLog']));
-    expect(
-      result.tools.find((tool) => tool.name === 'frontagent_plan_task')?.inputSchema.required,
-    ).toEqual(['task']);
-    expect(
-      result.tools.find((tool) => tool.name === 'frontagent_validate_sdd')?.inputSchema.required,
-    ).toEqual([]);
-    expect(
-      result.tools.find((tool) => tool.name === 'frontagent_init_sdd')?.inputSchema.required,
-    ).toEqual([]);
+    expectSharedTaskSchema(toolByName(result.tools, 'frontagent_run_task'));
+    expectSharedTaskSchema(toolByName(result.tools, 'frontagent_plan_task'));
+    expect(toolByName(result.tools, 'frontagent_validate_sdd').inputSchema).toEqual({
+      type: 'object',
+      properties: {
+        sddPath: {
+          type: 'string',
+          description: 'Project-relative SDD path. Defaults to sdd.yaml.',
+        },
+      },
+      required: [],
+    });
+    expect(toolByName(result.tools, 'frontagent_init_sdd').inputSchema).toEqual({
+      type: 'object',
+      properties: {
+        output: {
+          type: 'string',
+          description: 'Project-relative output path. Defaults to sdd.yaml.',
+        },
+        force: {
+          type: 'boolean',
+          description: 'Overwrite an existing SDD file. Defaults to false.',
+        },
+      },
+      required: [],
+    });
   });
 
   it('dispatches frontagent_list_skills without invoking task execution or planning', async () => {


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #174

## Summary

- Add focused runtime MCP server contract tests for public tool names and schemas.
- Cover the read-only `frontagent_list_skills` dispatch path with mocked SkillLab/task execution dependencies.
- Add a short implementation plan under `docs/superpowers/plans/` per workflow requirements.

## Impact Scope

- Test-only runtime-node coverage; no production runtime behavior changes.
- Touched files: `packages/runtime-node/src/mcp-server.test.ts`, `docs/superpowers/plans/2026-06-08-runtime-mcp-contract-tests.md`.

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: mcp-boundary test coverage only; production MCP server code was not modified.
- GitNexus impact: `detect_changes --scope compare --base-ref origin/develop` reported 3 files / 11 changed symbols, 0 affected processes, low risk. `impact createFrontAgentMcpServer --direction upstream --depth 3` reported 1 direct caller (`startFrontAgentMcpServer`), 1 affected process group, LOW risk. `context createFrontAgentMcpServer` confirmed the symbol participates in the `StartFrontAgentMcpServer` flows and has only `startFrontAgentMcpServer` as an incoming caller.
- Verification: `pnpm contract:local` passed after refreshing GitNexus index; `pnpm quality:local` passed in pre-push.

## Verification

- `pnpm --dir packages/runtime-node test -- mcp-server.test.ts` - 1 file, 2 tests passed.
- `pnpm --dir packages/runtime-node test` - 4 files, 40 tests passed.
- `pnpm typecheck` - 22 turbo tasks passed.
- `pnpm exec biome check packages/runtime-node/src/mcp-server.test.ts docs/superpowers/plans/2026-06-08-runtime-mcp-contract-tests.md` - passed.
- `pnpm quality:precommit` - passed; existing Biome warnings remain in unrelated `packages/core/src/executor/executor.test.ts`.
- `pnpm quality:local` - passed during pre-push; includes `pnpm contract:local`, `pnpm quality:ci`, workflow tests, and build/package.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.
