### PR TITLE
refactor: extract executor step feedback runner

### DIFF
--- a/docs/superpowers/plans/2026-06-08-reduce-executor-step-feedback.md
+++ b/docs/superpowers/plans/2026-06-08-reduce-executor-step-feedback.md
@@ -1,0 +1,48 @@
+# Reduce Executor Step Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce `Executor` class size by extracting the LangGraph step-feedback execution path while keeping public behavior stable.
+
+**Architecture:** Move the private LangGraph phase graph construction and invocation into a focused helper beside the executor. `Executor.executeStepsWithErrorFeedback` remains the public entry point and delegates to the helper only when the LangGraph engine is selected.
+
+**Tech Stack:** TypeScript, Vitest, LangGraph, existing executor phase-ordering and phase-runner contracts.
+
+---
+
+### Task 1: Extract LangGraph Feedback Runner
+
+**Files:**
+- Create: `packages/core/src/executor/step-feedback-runner.ts`
+- Create: `packages/core/src/executor/step-feedback-runner.test.ts`
+- Modify: `packages/core/src/executor/executor.ts`
+
+- [ ] **Step 1: Write the failing helper test**
+
+Add a Vitest test that imports `executeStepsWithErrorFeedbackViaLangGraph` from `step-feedback-runner.ts`, passes two independent steps, and verifies the injected `executeSinglePhaseWithRecovery` callback receives a phase group and returns accumulated results.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `pnpm --filter @frontagent/core test -- packages/core/src/executor/step-feedback-runner.test.ts`
+
+Expected: FAIL because `packages/core/src/executor/step-feedback-runner.ts` does not exist yet.
+
+- [ ] **Step 3: Move the LangGraph implementation**
+
+Create `step-feedback-runner.ts` with the LangGraph-specific implementation currently inside `Executor.executeStepsWithErrorFeedbackViaLangGraph`. Keep callback signatures and `LangGraphRuntimeState` serialization unchanged.
+
+- [ ] **Step 4: Delegate from Executor**
+
+Remove the private `executeStepsWithErrorFeedbackViaLangGraph` method from `executor.ts`, import the helper, and call it from `executeStepsWithErrorFeedback` with the existing callbacks, config, and `executeSinglePhaseWithRecovery` delegate.
+
+- [ ] **Step 5: Verify GREEN**
+
+Run: `pnpm --filter @frontagent/core test -- packages/core/src/executor/step-feedback-runner.test.ts packages/core/src/executor/executor.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Broaden verification**
+
+Run: `pnpm typecheck`, `npx gitnexus detect-changes --scope all --repo FrontAgent`, and `pnpm quality:precommit`.
+
+Expected: all commands exit 0, and detect_changes reports only the executor feedback helper, executor delegation, focused tests, and this plan.

--- a/packages/core/src/executor/executor.ts
+++ b/packages/core/src/executor/executor.ts
@@ -8,7 +8,6 @@ import type {
   ValidationResult,
 } from '@frontagent/shared';
 import { logger } from '@frontagent/shared';
-import { Annotation, END, MemorySaver, START, StateGraph } from '@langchain/langgraph';
 import { SecurityManager, toApprovalRequest } from '../security.js';
 import {
   createDefaultExecutorSkillRegistry,
@@ -18,15 +17,14 @@ import {
 import type { ExecutorOutput } from '../types.js';
 import { buildOrderedPhaseGroups, detectLanguage } from './phase-ordering.js';
 import { PhaseRunner } from './phase-runner.js';
+import { executeStepsWithErrorFeedbackViaLangGraph } from './step-feedback-runner.js';
 import type {
   ExecutorCollectedContext,
   ExecutorConfig,
   ExecutorSubStage,
   ExecutorTraceStage,
-  LangGraphRuntimeState,
   MCPClient,
   PhaseExecutionGroup,
-  SerializablePhaseExecutionGroup,
 } from './types.js';
 
 export class Executor {
@@ -876,131 +874,6 @@ export class Executor {
     );
   }
 
-  private async executeStepsWithErrorFeedbackViaLangGraph(
-    steps: ExecutionStep[],
-    context: {
-      task: AgentTask;
-      collectedContext: ExecutorCollectedContext;
-    },
-    onStepStart?: (step: ExecutionStep) => void,
-    onStepComplete?: (step: ExecutionStep, output: ExecutorOutput) => void,
-    onPhaseStart?: (phase: string, stepCount: number) => void,
-    onPhaseError?: (
-      phase: string,
-      errors: Array<{ step: ExecutionStep; error: string }>,
-    ) => Promise<ExecutionStep[]>,
-    onPhaseComplete?: (
-      phase: string,
-      results: ExecutorOutput[],
-    ) => Promise<Array<{ step: ExecutionStep; error: string }>>,
-    signal?: AbortSignal,
-  ): Promise<ExecutorOutput[]> {
-    const orderedPhaseGroups = buildOrderedPhaseGroups(steps, this.debugWarn.bind(this));
-    const serializablePhaseGroups: SerializablePhaseExecutionGroup[] = orderedPhaseGroups.map(
-      (group) => ({
-        phase: group.phase,
-        steps: group.steps,
-        dependencies: Array.from(group.dependencies),
-        firstSeenIndex: group.firstSeenIndex,
-        priority: group.priority,
-      }),
-    );
-
-    const RuntimeStateAnnotation = Annotation.Root({
-      runtime: Annotation<LangGraphRuntimeState>({
-        reducer: (_left, right) => right,
-        default: () => ({
-          phaseGroups: [],
-          phaseIndex: 0,
-          completedStepIds: [],
-          allResults: [],
-        }),
-      }),
-    });
-
-    const graph = new StateGraph(RuntimeStateAnnotation)
-      .addNode('select_phase', () => ({}))
-      .addNode('execute_phase', async (state) => {
-        const runtime = state.runtime as LangGraphRuntimeState;
-        if (runtime.phaseIndex >= runtime.phaseGroups.length) {
-          return {};
-        }
-
-        const phaseGroupData = runtime.phaseGroups[runtime.phaseIndex];
-        const phaseGroup: PhaseExecutionGroup = {
-          ...phaseGroupData,
-          dependencies: new Set(phaseGroupData.dependencies),
-        };
-        const completedStepIds = new Set(runtime.completedStepIds);
-        const allResults = [...runtime.allResults];
-
-        await this.executeSinglePhaseWithRecovery(
-          phaseGroup,
-          context,
-          completedStepIds,
-          allResults,
-          onStepStart,
-          onStepComplete,
-          onPhaseStart,
-          onPhaseError,
-          onPhaseComplete,
-          signal,
-        );
-
-        return {
-          runtime: {
-            ...runtime,
-            completedStepIds: Array.from(completedStepIds),
-            allResults,
-          },
-        };
-      })
-      .addNode('advance_phase', (state) => {
-        const runtime = state.runtime as LangGraphRuntimeState;
-        return {
-          runtime: {
-            ...runtime,
-            phaseIndex: runtime.phaseIndex + 1,
-          },
-        };
-      })
-      .addEdge(START, 'select_phase')
-      .addConditionalEdges('select_phase', (state) => {
-        const runtime = state.runtime as LangGraphRuntimeState;
-        return runtime.phaseIndex >= runtime.phaseGroups.length ? END : 'execute_phase';
-      })
-      .addEdge('execute_phase', 'advance_phase')
-      .addEdge('advance_phase', 'select_phase')
-      .compile({
-        checkpointer: this.config.langGraph?.useCheckpoint ? new MemorySaver() : undefined,
-        name: 'frontagent.phase.flow',
-      });
-
-    const initialState: LangGraphRuntimeState = {
-      phaseGroups: serializablePhaseGroups,
-      phaseIndex: 0,
-      completedStepIds: [],
-      allResults: [],
-    };
-
-    const runnableConfig = this.config.langGraph?.useCheckpoint
-      ? {
-          configurable: {
-            thread_id: `${this.config.langGraph?.threadIdPrefix ?? 'frontagent'}-${Date.now()}`,
-          },
-        }
-      : undefined;
-
-    const finalState = (await graph.invoke(
-      { runtime: initialState },
-      runnableConfig as unknown as Record<string, unknown>,
-    )) as {
-      runtime?: LangGraphRuntimeState;
-    };
-
-    return finalState.runtime?.allResults ?? [];
-  }
-
   async executeStepsWithErrorFeedback(
     steps: ExecutionStep[],
     context: {
@@ -1024,16 +897,39 @@ export class Executor {
       if (this.config.debug) {
         console.log('[Executor] Using LangGraph execution engine');
       }
-      return this.executeStepsWithErrorFeedbackViaLangGraph(
+      return executeStepsWithErrorFeedbackViaLangGraph({
         steps,
         context,
-        onStepStart,
-        onStepComplete,
-        onPhaseStart,
-        onPhaseError,
-        onPhaseComplete,
-        signal,
-      );
+        debugWarn: this.debugWarn.bind(this),
+        langGraph: this.config.langGraph,
+        executeSinglePhaseWithRecovery: (
+          phaseGroup,
+          executionContext,
+          completedStepIds,
+          allResults,
+          callbacks,
+        ) =>
+          this.executeSinglePhaseWithRecovery(
+            phaseGroup,
+            executionContext,
+            completedStepIds,
+            allResults,
+            callbacks.onStepStart,
+            callbacks.onStepComplete,
+            callbacks.onPhaseStart,
+            callbacks.onPhaseError,
+            callbacks.onPhaseComplete,
+            callbacks.signal,
+          ),
+        callbacks: {
+          onStepStart,
+          onStepComplete,
+          onPhaseStart,
+          onPhaseError,
+          onPhaseComplete,
+          signal,
+        },
+      });
     }
 
     const orderedPhaseGroups = buildOrderedPhaseGroups(steps, this.debugWarn.bind(this));

--- a/packages/core/src/executor/step-feedback-runner.test.ts
+++ b/packages/core/src/executor/step-feedback-runner.test.ts
@@ -1,0 +1,112 @@
+import type { AgentTask, ExecutionStep } from '@frontagent/shared';
+import { describe, expect, it, vi } from 'vitest';
+import type { ExecutorOutput } from '../types.js';
+import { executeStepsWithErrorFeedbackViaLangGraph } from './step-feedback-runner.js';
+import type { ExecutorCollectedContext, PhaseExecutionGroup } from './types.js';
+
+function makeStep(overrides: Partial<ExecutionStep> = {}): ExecutionStep {
+  return {
+    stepId: 'step-1',
+    description: 'Test step',
+    action: 'create_file',
+    tool: 'create_file',
+    params: { path: 'src/a.ts', content: 'export {}' },
+    dependencies: [],
+    validation: [],
+    status: 'pending',
+    phase: 'build',
+    ...overrides,
+  };
+}
+
+function makeOutput(stepId: string): ExecutorOutput {
+  return {
+    stepResult: { success: true, duration: 10, output: { stepId } },
+    validation: { pass: true, results: [] },
+    needsRollback: false,
+  };
+}
+
+function makeContext() {
+  return {
+    task: { id: 't1', type: 'create' as const, description: 'test' } as AgentTask,
+    collectedContext: {
+      files: new Map<string, string>(),
+    } as ExecutorCollectedContext,
+  };
+}
+
+describe('executeStepsWithErrorFeedbackViaLangGraph', () => {
+  it('delegates each ordered phase group and returns accumulated results', async () => {
+    const step1 = makeStep({ stepId: 's1', phase: 'build' });
+    const step2 = makeStep({ stepId: 's2', phase: 'build' });
+    const context = makeContext();
+    const signal = new AbortController().signal;
+    const onStepStart = vi.fn();
+    const onStepComplete = vi.fn();
+    const onPhaseStart = vi.fn();
+    const onPhaseError = vi.fn();
+    const onPhaseComplete = vi.fn();
+    const executeSinglePhaseWithRecovery = vi.fn(
+      async (
+        phaseGroup: PhaseExecutionGroup,
+        receivedContext: typeof context,
+        completedStepIds: Set<string>,
+        allResults: ExecutorOutput[],
+        callbacks: {
+          onStepStart?: (step: ExecutionStep) => void;
+          onStepComplete?: (step: ExecutionStep, output: ExecutorOutput) => void;
+          onPhaseStart?: (phase: string, stepCount: number) => void;
+          onPhaseError?: (
+            phase: string,
+            errors: Array<{ step: ExecutionStep; error: string }>,
+          ) => Promise<ExecutionStep[]>;
+          onPhaseComplete?: (
+            phase: string,
+            results: ExecutorOutput[],
+          ) => Promise<Array<{ step: ExecutionStep; error: string }>>;
+          signal?: AbortSignal;
+        },
+      ) => {
+        expect(receivedContext).toBe(context);
+        expect(phaseGroup.phase).toBe('build');
+        expect(phaseGroup.steps.map((step) => step.stepId)).toEqual(['s1', 's2']);
+        expect(phaseGroup.dependencies).toBeInstanceOf(Set);
+        expect(callbacks).toEqual({
+          onStepStart,
+          onStepComplete,
+          onPhaseStart,
+          onPhaseError,
+          onPhaseComplete,
+          signal,
+        });
+
+        completedStepIds.add('s1');
+        completedStepIds.add('s2');
+        allResults.push(makeOutput('s1'), makeOutput('s2'));
+      },
+    );
+
+    const results = await executeStepsWithErrorFeedbackViaLangGraph({
+      steps: [step1, step2],
+      context,
+      executeSinglePhaseWithRecovery,
+      debugWarn: vi.fn(),
+      langGraph: { enabled: true },
+      callbacks: {
+        onStepStart,
+        onStepComplete,
+        onPhaseStart,
+        onPhaseError,
+        onPhaseComplete,
+        signal,
+      },
+    });
+
+    expect(executeSinglePhaseWithRecovery).toHaveBeenCalledTimes(1);
+    expect(results.map((result) => result.stepResult.output)).toEqual([
+      { stepId: 's1' },
+      { stepId: 's2' },
+    ]);
+  });
+});

--- a/packages/core/src/executor/step-feedback-runner.ts
+++ b/packages/core/src/executor/step-feedback-runner.ts
@@ -1,0 +1,158 @@
+import type { AgentTask, ExecutionStep } from '@frontagent/shared';
+import { Annotation, END, MemorySaver, START, StateGraph } from '@langchain/langgraph';
+import type { ExecutorOutput } from '../types.js';
+import { buildOrderedPhaseGroups } from './phase-ordering.js';
+import type {
+  ExecutorCollectedContext,
+  ExecutorConfig,
+  LangGraphRuntimeState,
+  PhaseExecutionGroup,
+  SerializablePhaseExecutionGroup,
+} from './types.js';
+
+export interface StepFeedbackCallbacks {
+  onStepStart?: (step: ExecutionStep) => void;
+  onStepComplete?: (step: ExecutionStep, output: ExecutorOutput) => void;
+  onPhaseStart?: (phase: string, stepCount: number) => void;
+  onPhaseError?: (
+    phase: string,
+    errors: Array<{ step: ExecutionStep; error: string }>,
+  ) => Promise<ExecutionStep[]>;
+  onPhaseComplete?: (
+    phase: string,
+    results: ExecutorOutput[],
+  ) => Promise<Array<{ step: ExecutionStep; error: string }>>;
+  signal?: AbortSignal;
+}
+
+export type ExecuteSinglePhaseWithRecovery = (
+  phaseGroup: PhaseExecutionGroup,
+  context: {
+    task: AgentTask;
+    collectedContext: ExecutorCollectedContext;
+  },
+  completedStepIds: Set<string>,
+  allResults: ExecutorOutput[],
+  callbacks: StepFeedbackCallbacks,
+) => Promise<void>;
+
+export interface LangGraphStepFeedbackOptions {
+  steps: ExecutionStep[];
+  context: {
+    task: AgentTask;
+    collectedContext: ExecutorCollectedContext;
+  };
+  debugWarn: (...args: unknown[]) => void;
+  langGraph?: ExecutorConfig['langGraph'];
+  executeSinglePhaseWithRecovery: ExecuteSinglePhaseWithRecovery;
+  callbacks?: StepFeedbackCallbacks;
+}
+
+export async function executeStepsWithErrorFeedbackViaLangGraph({
+  steps,
+  context,
+  debugWarn,
+  langGraph,
+  executeSinglePhaseWithRecovery,
+  callbacks = {},
+}: LangGraphStepFeedbackOptions): Promise<ExecutorOutput[]> {
+  const orderedPhaseGroups = buildOrderedPhaseGroups(steps, debugWarn);
+  const serializablePhaseGroups: SerializablePhaseExecutionGroup[] = orderedPhaseGroups.map(
+    (group) => ({
+      phase: group.phase,
+      steps: group.steps,
+      dependencies: Array.from(group.dependencies),
+      firstSeenIndex: group.firstSeenIndex,
+      priority: group.priority,
+    }),
+  );
+
+  const RuntimeStateAnnotation = Annotation.Root({
+    runtime: Annotation<LangGraphRuntimeState>({
+      reducer: (_left, right) => right,
+      default: () => ({
+        phaseGroups: [],
+        phaseIndex: 0,
+        completedStepIds: [],
+        allResults: [],
+      }),
+    }),
+  });
+
+  const graph = new StateGraph(RuntimeStateAnnotation)
+    .addNode('select_phase', () => ({}))
+    .addNode('execute_phase', async (state) => {
+      const runtime = state.runtime as LangGraphRuntimeState;
+      if (runtime.phaseIndex >= runtime.phaseGroups.length) {
+        return {};
+      }
+
+      const phaseGroupData = runtime.phaseGroups[runtime.phaseIndex];
+      const phaseGroup: PhaseExecutionGroup = {
+        ...phaseGroupData,
+        dependencies: new Set(phaseGroupData.dependencies),
+      };
+      const completedStepIds = new Set(runtime.completedStepIds);
+      const allResults = [...runtime.allResults];
+
+      await executeSinglePhaseWithRecovery(
+        phaseGroup,
+        context,
+        completedStepIds,
+        allResults,
+        callbacks,
+      );
+
+      return {
+        runtime: {
+          ...runtime,
+          completedStepIds: Array.from(completedStepIds),
+          allResults,
+        },
+      };
+    })
+    .addNode('advance_phase', (state) => {
+      const runtime = state.runtime as LangGraphRuntimeState;
+      return {
+        runtime: {
+          ...runtime,
+          phaseIndex: runtime.phaseIndex + 1,
+        },
+      };
+    })
+    .addEdge(START, 'select_phase')
+    .addConditionalEdges('select_phase', (state) => {
+      const runtime = state.runtime as LangGraphRuntimeState;
+      return runtime.phaseIndex >= runtime.phaseGroups.length ? END : 'execute_phase';
+    })
+    .addEdge('execute_phase', 'advance_phase')
+    .addEdge('advance_phase', 'select_phase')
+    .compile({
+      checkpointer: langGraph?.useCheckpoint ? new MemorySaver() : undefined,
+      name: 'frontagent.phase.flow',
+    });
+
+  const initialState: LangGraphRuntimeState = {
+    phaseGroups: serializablePhaseGroups,
+    phaseIndex: 0,
+    completedStepIds: [],
+    allResults: [],
+  };
+
+  const runnableConfig = langGraph?.useCheckpoint
+    ? {
+        configurable: {
+          thread_id: `${langGraph?.threadIdPrefix ?? 'frontagent'}-${Date.now()}`,
+        },
+      }
+    : undefined;
+
+  const finalState = (await graph.invoke(
+    { runtime: initialState },
+    runnableConfig as unknown as Record<string, unknown>,
+  )) as {
+    runtime?: LangGraphRuntimeState;
+  };
+
+  return finalState.runtime?.allResults ?? [];
+}


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #183

## Summary

- Extracted the LangGraph step-feedback execution path from `Executor` into `packages/core/src/executor/step-feedback-runner.ts`.
- Kept `Executor.executeStepsWithErrorFeedback` as the public entry point and delegated LangGraph execution through an adapter.
- Added focused helper coverage and a short implementation plan under `docs/superpowers/plans`.

## Impact Scope

- Scoped to executor step-feedback execution: `executor.ts`, new `step-feedback-runner.ts`, new helper test, and the implementation plan.
- No changes to ContextManager, mcp-filesense, CodeQualitySubAgent, or dependency metadata.

## GitNexus Impact Summary

- Risk level: MEDIUM final staged detect_changes; pre-edit method analysis was HIGH for `executeStepsWithErrorFeedbackViaLangGraph` and LOW for `executeStepsWithErrorFeedback`.
- Critical skeleton changes: No critical contract surface changed; pre-push `contract:local` reported GitNexus advisory only.
- GitNexus impact: direct caller for the extracted LangGraph method is `Executor.executeStepsWithErrorFeedback`; affected flows are `ExecuteSteps -> GetPhasePriority`, `ExecuteStepsWithErrorFeedback -> DebugLog`, and `ExecuteStepsWithErrorFeedback -> ComparePhaseGroup`.
- Verification: `npx gitnexus detect-changes --scope staged --repo FrontAgent` reported 4 files, 11 symbols, 3 affected processes, MEDIUM risk.

## Verification

- `pnpm agent:bootstrap`
- `GITNEXUS_ANALYZE_TIMEOUT_MS=180000 pnpm quality:predev`
- RED: `pnpm --filter @frontagent/core test -- src/executor/step-feedback-runner.test.ts` failed before helper existed with missing module.
- `pnpm --filter @frontagent/core... build && pnpm --filter @frontagent/core test -- src/executor/step-feedback-runner.test.ts src/executor/executor.test.ts` passed: 20 tests.
- `pnpm typecheck` passed: 22/22 turbo tasks.
- `pnpm --filter @frontagent/core test -- src/executor` passed: 64 tests across 5 files.
- `pnpm quality:precommit` passed.
- Pre-commit hook reran `pnpm quality:precommit` and passed.
- Pre-push hook ran `pnpm quality:local` and passed, including `pnpm build` and VSIX packaging.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.