### PR TITLE
refactor(filesense): extract engine helper logic

### DIFF
--- a/docs/superpowers/plans/2026-06-08-filesense-engine-helpers.md
+++ b/docs/superpowers/plans/2026-06-08-filesense-engine-helpers.md
@@ -1,0 +1,66 @@
+# Filesense Engine Helpers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract filesense scoring and directory inference helper logic from `engine.ts` without changing public filesense behavior.
+
+**Architecture:** Keep filesystem and MCP-facing engine operations in `packages/mcp-filesense/src/engine.ts`. Move pure helper logic into `packages/mcp-filesense/src/engine-helpers.ts` so scoring and index-derived inference can be tested without creating workspaces.
+
+**Tech Stack:** TypeScript, Vitest, existing `@frontagent/mcp-filesense` package scripts.
+
+---
+
+### Task 1: Helper Module Extraction
+
+**Files:**
+- Create: `packages/mcp-filesense/src/engine-helpers.ts`
+- Create: `packages/mcp-filesense/src/engine-helpers.test.ts`
+- Modify: `packages/mcp-filesense/src/engine.ts`
+
+- [ ] **Step 1: Write failing helper tests**
+
+Add focused tests proving current helper behavior:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  inferDirectoryPurpose,
+  inferImportance,
+  scoreCandidate,
+} from './engine-helpers.js';
+```
+
+Cover high-importance entrypoint/config names, known directory purposes, content-derived directory purposes, and navigate candidate score ordering.
+
+- [ ] **Step 2: Verify tests fail before implementation**
+
+Run: `pnpm --filter @frontagent/mcp-filesense test -- engine-helpers.test.ts`
+
+Expected: FAIL because `./engine-helpers.js` does not exist.
+
+- [ ] **Step 3: Extract pure helpers**
+
+Move `inferImportance`, `inferDirectoryPurpose`, and `scoreCandidate` unchanged into `engine-helpers.ts`, export them, and import them from `engine.ts`.
+
+- [ ] **Step 4: Verify focused package behavior**
+
+Run:
+
+```bash
+pnpm --filter @frontagent/mcp-filesense test -- engine-helpers.test.ts
+pnpm --filter @frontagent/mcp-filesense test
+pnpm --filter @frontagent/mcp-filesense typecheck
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 5: Pre-PR impact and scope checks**
+
+Run:
+
+```bash
+npx gitnexus detect-changes --scope all --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/issue185-extract-filesense-engine-helpers
+git diff --stat origin/develop...HEAD
+```
+
+Expected: changed symbols are limited to filesense engine/helper/test and this plan.

--- a/packages/mcp-filesense/src/engine-helpers.test.ts
+++ b/packages/mcp-filesense/src/engine-helpers.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { inferDirectoryPurpose, inferImportance, scoreCandidate } from './engine-helpers.js';
+import type { ChildEntry, IndexFile, NavigateOptions } from './types.js';
+
+function child(overrides: Partial<ChildEntry> & Pick<ChildEntry, 'name'>): ChildEntry {
+  return {
+    name: overrides.name,
+    type: overrides.type ?? 'file',
+    path: overrides.path ?? overrides.name,
+    ext: overrides.ext ?? '',
+    size: overrides.size ?? 0,
+    mtimeMs: overrides.mtimeMs ?? 0,
+    hash: overrides.hash ?? null,
+    summary: overrides.summary ?? 'File',
+    importance: overrides.importance ?? 'normal',
+    status: overrides.status ?? 'active',
+  };
+}
+
+function index(name: string, children: ChildEntry[], directoryPath = name): IndexFile {
+  return {
+    schema_version: '1.0',
+    generated_at: '2026-06-08T00:00:00.000Z',
+    root_relative_path: directoryPath,
+    directory: { name, path: directoryPath },
+    children,
+    sync: {
+      child_count: children.length,
+      file_count: children.filter((entry) => entry.type === 'file').length,
+      dir_count: children.filter((entry) => entry.type === 'dir').length,
+      last_full_sync: null,
+      last_incremental_sync: null,
+    },
+  };
+}
+
+describe('engine helper inference', () => {
+  it('marks entrypoint and config-like files as high importance', () => {
+    expect(inferImportance('README.md')).toBe('high');
+    expect(inferImportance('package.json')).toBe('high');
+    expect(inferImportance('vite.config.ts')).toBe('high');
+    expect(inferImportance('feature.ts')).toBe('normal');
+  });
+
+  it('infers directory purpose from known directory names and root path', () => {
+    expect(inferDirectoryPurpose(index('project', [], '.'))).toContain('Project root');
+    expect(inferDirectoryPurpose(index('src', []))).toBe('Primary application source directory.');
+    expect(inferDirectoryPurpose(index('components', []))).toContain('component');
+    expect(inferDirectoryPurpose(index('__tests__', []))).toBe('Automated test directory.');
+  });
+
+  it('infers directory purpose from child composition when name is generic', () => {
+    expect(
+      inferDirectoryPurpose(
+        index('features', [
+          child({ name: 'button.tsx', ext: '.tsx' }),
+          child({ name: 'index.ts', ext: '.ts' }),
+        ]),
+      ),
+    ).toBe('Source directory for related implementation files.');
+
+    expect(inferDirectoryPurpose(index('guides', [child({ name: 'usage.md', ext: '.md' })]))).toBe(
+      'Documentation-focused directory.',
+    );
+
+    expect(
+      inferDirectoryPurpose(
+        index('groups', [
+          child({ name: 'alpha', type: 'dir' }),
+          child({ name: 'beta', type: 'dir' }),
+        ]),
+      ),
+    ).toBe('Grouping directory for related subdirectories.');
+  });
+});
+
+describe('scoreCandidate', () => {
+  it('prioritizes important source directories and convention files by intent', () => {
+    const srcDir = child({ name: 'src', type: 'dir', summary: 'Directory' });
+    const readme = child({ name: 'README.md', importance: 'high', ext: '.md' });
+    const feature = child({ name: 'feature.ts', ext: '.ts' });
+
+    expect(scoreCandidate(srcDir, undefined)).toBe(70);
+    expect(scoreCandidate(readme, 'find_conventions')).toBe(105);
+    expect(scoreCandidate(readme, 'locate')).toBe(100);
+    expect(scoreCandidate(feature, 'locate')).toBe(40);
+  });
+
+  it('accepts every navigate intent without changing base scores', () => {
+    const feature = child({ name: 'feature.ts', ext: '.ts' });
+    const intents: Array<NavigateOptions['intent']> = [
+      'understand_structure',
+      'prepare_refactor',
+      'prepare_create',
+      'validate_freshness',
+    ];
+
+    expect(intents.map((intent) => scoreCandidate(feature, intent))).toEqual([40, 40, 40, 40]);
+  });
+});

--- a/packages/mcp-filesense/src/engine-helpers.ts
+++ b/packages/mcp-filesense/src/engine-helpers.ts
@@ -1,0 +1,51 @@
+import type { ChildEntry, IndexFile, NavigateOptions } from './types.js';
+
+export function inferImportance(name: string): 'high' | 'normal' {
+  if (/^(readme|package|tsconfig|index|main|app)\./i.test(name)) return 'high';
+  if (/\.(config|rc)\./i.test(name)) return 'high';
+  return 'normal';
+}
+
+export function inferDirectoryPurpose(index: IndexFile): string {
+  const dirName = index.directory.name.toLowerCase();
+  if (index.directory.path === '.')
+    return 'Project root directory containing source code, configuration, and supporting files.';
+  if (dirName === 'src') return 'Primary application source directory.';
+  if (dirName === 'docs')
+    return 'Documentation directory for project guides and reference material.';
+  if (dirName === 'test' || dirName === 'tests' || dirName === '__tests__')
+    return 'Automated test directory.';
+  if (dirName === 'scripts') return 'Automation scripts directory.';
+  if (dirName === 'components') return 'Reusable component directory.';
+  if (dirName === 'lib') return 'Shared library code directory.';
+  if (dirName === 'api' || dirName === 'services') return 'API/service layer directory.';
+  if (dirName === 'hooks') return 'Custom React hooks directory.';
+  if (dirName === 'utils' || dirName === 'helpers') return 'Utility functions directory.';
+  if (dirName === 'pages' || dirName === 'views') return 'Page/view components directory.';
+  if (dirName === 'store' || dirName === 'stores') return 'State management directory.';
+  if (dirName === 'styles') return 'Stylesheets directory.';
+  if (dirName === 'assets') return 'Static assets directory.';
+  if (dirName === 'types') return 'TypeScript type definitions directory.';
+
+  const fileCount = index.children.filter((c) => c.type === 'file').length;
+  const dirCount = index.children.filter((c) => c.type === 'dir').length;
+  if (fileCount === 0 && dirCount > 0) return 'Grouping directory for related subdirectories.';
+  const hasTS = index.children.some((c) => ['.ts', '.tsx', '.js', '.jsx'].includes(c.ext));
+  if (hasTS) return 'Source directory for related implementation files.';
+  if (index.children.some((c) => c.ext === '.md')) return 'Documentation-focused directory.';
+  return 'Directory for related project files.';
+}
+
+export function scoreCandidate(entry: ChildEntry, intent: NavigateOptions['intent']): number {
+  let score = entry.importance === 'high' ? 80 : 40;
+  const name = entry.name.toLowerCase();
+  if (
+    entry.type === 'dir' &&
+    ['src', 'components', 'pages', 'views', 'hooks', 'api', 'services'].includes(name)
+  )
+    score += 30;
+  if (intent === 'find_conventions' && (name === 'readme.md' || name.includes('config')))
+    score += 25;
+  if (intent === 'locate' && entry.importance === 'high') score += 20;
+  return score;
+}

--- a/packages/mcp-filesense/src/engine.ts
+++ b/packages/mcp-filesense/src/engine.ts
@@ -6,6 +6,7 @@
 import { createHash } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { inferDirectoryPurpose, inferImportance, scoreCandidate } from './engine-helpers.js';
 import type {
   CheckSummary,
   ChildEntry,
@@ -362,42 +363,6 @@ function inferSummary(name: string): string {
   if (ext === '.html') return 'HTML document';
   if (!ext) return 'File without extension';
   return `${ext.slice(1).toUpperCase()} file`;
-}
-
-function inferImportance(name: string): 'high' | 'normal' {
-  if (/^(readme|package|tsconfig|index|main|app)\./i.test(name)) return 'high';
-  if (/\.(config|rc)\./i.test(name)) return 'high';
-  return 'normal';
-}
-
-function inferDirectoryPurpose(index: IndexFile): string {
-  const dirName = index.directory.name.toLowerCase();
-  if (index.directory.path === '.')
-    return 'Project root directory containing source code, configuration, and supporting files.';
-  if (dirName === 'src') return 'Primary application source directory.';
-  if (dirName === 'docs')
-    return 'Documentation directory for project guides and reference material.';
-  if (dirName === 'test' || dirName === 'tests' || dirName === '__tests__')
-    return 'Automated test directory.';
-  if (dirName === 'scripts') return 'Automation scripts directory.';
-  if (dirName === 'components') return 'Reusable component directory.';
-  if (dirName === 'lib') return 'Shared library code directory.';
-  if (dirName === 'api' || dirName === 'services') return 'API/service layer directory.';
-  if (dirName === 'hooks') return 'Custom React hooks directory.';
-  if (dirName === 'utils' || dirName === 'helpers') return 'Utility functions directory.';
-  if (dirName === 'pages' || dirName === 'views') return 'Page/view components directory.';
-  if (dirName === 'store' || dirName === 'stores') return 'State management directory.';
-  if (dirName === 'styles') return 'Stylesheets directory.';
-  if (dirName === 'assets') return 'Static assets directory.';
-  if (dirName === 'types') return 'TypeScript type definitions directory.';
-
-  const fileCount = index.children.filter((c) => c.type === 'file').length;
-  const dirCount = index.children.filter((c) => c.type === 'dir').length;
-  if (fileCount === 0 && dirCount > 0) return 'Grouping directory for related subdirectories.';
-  const hasTS = index.children.some((c) => ['.ts', '.tsx', '.js', '.jsx'].includes(c.ext));
-  if (hasTS) return 'Source directory for related implementation files.';
-  if (index.children.some((c) => c.ext === '.md')) return 'Documentation-focused directory.';
-  return 'Directory for related project files.';
 }
 
 function inferAgentHints(index: IndexFile): string[] {
@@ -844,20 +809,6 @@ function detectProjectType(indexes: IndexFile[]): string | undefined {
   )
     return 'Frontend source project';
   return undefined;
-}
-
-function scoreCandidate(entry: ChildEntry, intent: NavigateOptions['intent']): number {
-  let score = entry.importance === 'high' ? 80 : 40;
-  const name = entry.name.toLowerCase();
-  if (
-    entry.type === 'dir' &&
-    ['src', 'components', 'pages', 'views', 'hooks', 'api', 'services'].includes(name)
-  )
-    score += 30;
-  if (intent === 'find_conventions' && (name === 'readme.md' || name.includes('config')))
-    score += 25;
-  if (intent === 'locate' && entry.importance === 'high') score += 20;
-  return score;
 }
 
 export async function navigate(


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #185

## Summary

- Extracted filesense importance inference, directory purpose inference, and navigate candidate scoring into `engine-helpers.ts`.
- Added focused helper tests for scoring and inference behavior.
- Kept `engine.ts` public behavior intact by importing the extracted pure helpers at existing call sites.

## Impact Scope

- Filesense engine helper internals only.
- No changes to core ContextManager, Executor, CodeQualitySubAgent, dependency metadata, or MCP tool contracts.

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: mcp-boundary files touched: `packages/mcp-filesense/src/engine.ts`, `packages/mcp-filesense/src/engine-helpers.ts`, `packages/mcp-filesense/src/engine-helpers.test.ts`.
- GitNexus impact: detect_changes reported 5 files, 8 symbols, 0 affected processes, LOW risk; impact analysis pre-edit direct callers were `writeDirectoryIndex` and `navigate` for `inferImportance`, `buildNotesFile` and `navigate` for `inferDirectoryPurpose`, and `navigate` for `scoreCandidate`; affected flows included `handleFilesenseTool`, `summarize`, `navigate`, and `syncAndSummarize`. Post-change `detect_changes` via `npx gitnexus detect-changes --scope compare --base-ref origin/develop` reported 5 files, 8 symbols, 0 affected processes, low risk.
- Verification: focused filesense tests/typecheck, `pnpm quality:precommit`, and `pnpm quality:local` passed.

## Verification

- `pnpm --filter @frontagent/mcp-filesense test -- engine-helpers.test.ts` (red before extraction: missing module; green after extraction: 5 passed)
- `pnpm --filter @frontagent/mcp-filesense test` (2 files, 29 tests passed)
- `pnpm --filter @frontagent/mcp-filesense typecheck` (passed)
- `pnpm exec biome check packages/mcp-filesense/src/engine.ts packages/mcp-filesense/src/engine-helpers.ts packages/mcp-filesense/src/engine-helpers.test.ts` (passed)
- `pnpm quality:precommit` (passed; repo lint still reports existing warnings)
- `pnpm quality:local` (passed via pre-push hook)

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.


