### PR TITLE
Refactor CodeQualitySubAgent prompt policy

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,

--- a/docs/superpowers/plans/2026-06-08-split-code-quality-subagent-policy.md
+++ b/docs/superpowers/plans/2026-06-08-split-code-quality-subagent-policy.md
@@ -1,0 +1,80 @@
+# Split Code Quality SubAgent Prompt Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the `CodeQualitySubAgent` LLM prompt-building boundary into a focused helper module while preserving review behavior and public exports.
+
+**Architecture:** Keep `CodeQualitySubAgent` responsible for A2A handling, LLM invocation, issue merging, rule fallback, and fact updates. Move only prompt payload assembly, SDD summary formatting, shared-facts summary formatting, and per-file truncation into `code-quality-prompt.ts`, with direct unit tests for the helper.
+
+**Tech Stack:** TypeScript, Vitest, existing `@frontagent/core` source layout.
+
+---
+
+### GitNexus Impact Summary
+
+- `evaluateWithLLM`: LOW risk, direct caller `CodeQualitySubAgent.handleRequest`, affected flow `code-quality-subagent-worker.ts:main`, affected module `Sub-agents`.
+- `buildSddSummary`, `summarizeSharedFacts`, `truncateFileContent`: LOW risk, direct caller `evaluateWithLLM`, same worker flow and module.
+- `CodeQualitySubAgent` class-level impact query was attempted after re-indexing but the GitNexus CLI could not disambiguate duplicate `FrontAgent` registry entries. Source-backed direct usage shows construction in `packages/core/src/agent/agent.ts` and `packages/core/src/sub-agents/code-quality-subagent-worker.ts`, plus barrel exports from `packages/core/src/index.ts` and `packages/core/src/sub-agents/index.ts`.
+
+### Task 1: Prompt-Building Helper
+
+**Files:**
+- Create: `packages/core/src/sub-agents/code-quality-prompt.ts`
+- Create: `packages/core/src/sub-agents/code-quality-prompt.test.ts`
+- Modify: `packages/core/src/sub-agents/code-quality-subagent.ts`
+
+- [x] **Step 1: Write failing helper tests**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { buildCodeQualityLlmReviewPrompt } from './code-quality-prompt.js';
+```
+
+Run:
+
+```bash
+pnpm --dir packages/core test -- src/sub-agents/code-quality-prompt.test.ts
+```
+
+Expected: fail because `code-quality-prompt.js` does not exist.
+
+- [x] **Step 2: Implement the helper module**
+
+Create a helper that exports `buildCodeQualityLlmReviewPrompt(payload, options)` and returns `{ system, userPrompt }`. It must preserve the current prompt strings, file slicing, file truncation marker, SDD summary fields, shared-facts limits, and JSON formatting.
+
+- [x] **Step 3: Wire `CodeQualitySubAgent.evaluateWithLLM` to the helper**
+
+Replace private prompt-building calls in `evaluateWithLLM` with the helper result and remove the obsolete private `buildSddSummary`, `summarizeSharedFacts`, and `truncateFileContent` methods. Replace the production TODO with a concrete note that the first split keeps rule fallback policy local and only extracts LLM prompt policy.
+
+- [x] **Step 4: Verify focused tests**
+
+Run:
+
+```bash
+pnpm --dir packages/core test -- src/sub-agents/code-quality-prompt.test.ts
+```
+
+Expected: exit 0.
+
+- [x] **Step 5: Verify touched sub-agent behavior and types**
+
+Run:
+
+```bash
+pnpm --dir packages/core test -- src/sub-agents/code-quality-prompt.test.ts src/agent/phase-checks.test.ts src/agent/agent.test.ts
+pnpm --dir packages/core typecheck
+```
+
+Expected: both commands exit 0.
+
+- [x] **Step 6: Final repository checks**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm quality:precommit
+npx gitnexus detect-changes --scope all
+```
+
+Expected: typecheck and precommit exit 0; detect-changes shows only the expected prompt helper, test, plan, and sub-agent changes.

--- a/packages/core/src/sub-agents/code-quality-prompt.test.ts
+++ b/packages/core/src/sub-agents/code-quality-prompt.test.ts
@@ -1,0 +1,160 @@
+import type { SDDConfig } from '@frontagent/shared';
+import { describe, expect, it } from 'vitest';
+import type { ProjectFactsSnapshot } from '../types.js';
+import { buildCodeQualityLlmReviewPrompt } from './code-quality-prompt.js';
+
+describe('buildCodeQualityLlmReviewPrompt', () => {
+  it('builds the existing review prompt while limiting and truncating files', () => {
+    const result = buildCodeQualityLlmReviewPrompt(
+      {
+        taskId: 'task-123',
+        phase: 'implement',
+        files: [
+          { path: 'src/a.ts', content: '1234567890' },
+          { path: 'src/b.ts', content: 'short' },
+          { path: 'src/c.ts', content: 'excluded' },
+        ],
+      },
+      { maxFilesForLLM: 2, maxCharsPerFileForLLM: 8 },
+    );
+
+    expect(result.system).toBe(
+      [
+        'You are a strict code quality review sub-agent.',
+        'Evaluate generated code against SDD constraints and maintainability.',
+        'Output only actionable issues.',
+        'Set severity=error only for clear correctness or hard-constraint violations.',
+      ].join(' '),
+    );
+    expect(result.userPrompt).toContain('Task ID: task-123');
+    expect(result.userPrompt).toContain('Phase: implement');
+    expect(result.userPrompt).toContain('No SDD config provided.');
+    expect(result.userPrompt).toContain('No shared facts provided.');
+    expect(result.userPrompt).toContain('Return concrete issues with filePath/line/rule/message.');
+
+    const filesJson = extractFilesJson(result.userPrompt);
+    expect(JSON.parse(filesJson)).toEqual([
+      { path: 'src/a.ts', content: '12345678\n/* truncated */' },
+      { path: 'src/b.ts', content: 'short' },
+    ]);
+    expect(result.userPrompt).not.toContain('src/c.ts');
+  });
+
+  it('summarizes SDD constraints and shared project facts with existing limits', () => {
+    const result = buildCodeQualityLlmReviewPrompt(
+      {
+        taskId: 'task-456',
+        phase: 'review',
+        files: [{ path: 'src/app.ts', content: 'export const app = true;' }],
+        sddConfig: makeSddConfig(),
+        sharedFacts: makeSharedFacts(),
+      },
+      { maxFilesForLLM: 6, maxCharsPerFileForLLM: 12000 },
+    );
+
+    expect(result.userPrompt).toContain('maxFileLines=300');
+    expect(result.userPrompt).toContain('maxFunctionLines=40');
+    expect(result.userPrompt).toContain('maxParameters=3');
+    expect(result.userPrompt).toContain('forbiddenPatterns=console\\.log, debugger');
+    expect(result.userPrompt).toContain('forbiddenPackages=left-pad, lodash');
+
+    expect(result.userPrompt).toContain('revision=7');
+    expect(result.userPrompt).toContain('existingFiles(21)=file-1.ts');
+    expect(result.userPrompt).toContain('file-20.ts');
+    expect(result.userPrompt).not.toContain('file-21.ts');
+    expect(result.userPrompt).toContain('installedPackages(31)=pkg-1');
+    expect(result.userPrompt).toContain('pkg-30');
+    expect(result.userPrompt).not.toContain('pkg-31');
+    expect(result.userPrompt).toContain('missingPackages(21)=missing-1');
+    expect(result.userPrompt).toContain('missing-20');
+    expect(result.userPrompt).not.toContain('missing-21');
+    expect(result.userPrompt).toContain('moduleCount=2');
+    expect(result.userPrompt).toContain('recentErrors=[runtime] error-2 | [runtime] error-3 | [runtime] error-4 | [runtime] error-5 | [runtime] error-6');
+    expect(result.userPrompt).not.toContain('error-1');
+  });
+});
+
+function extractFilesJson(userPrompt: string): string {
+  const start = userPrompt.indexOf('Files to review:\n');
+  const end = userPrompt.indexOf('\n\nReturn concrete issues', start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return userPrompt.slice(start + 'Files to review:\n'.length, end);
+}
+
+function makeSddConfig(): SDDConfig {
+  return {
+    version: '1',
+    project: { name: 'demo', type: 'web' },
+    techStack: {
+      framework: 'react',
+      version: '19',
+      language: 'typescript',
+      forbiddenPackages: ['left-pad', 'lodash'],
+    },
+    directoryStructure: {},
+    moduleBoundaries: [],
+    namingConventions: {
+      components: 'PascalCase',
+      hooks: 'useCamelCase',
+      utils: 'camelCase',
+      constants: 'SCREAMING_SNAKE_CASE',
+      types: 'PascalCase',
+    },
+    codeQuality: {
+      maxFileLines: 300,
+      maxFunctionLines: 40,
+      maxParameters: 3,
+      requireJsdoc: false,
+      forbiddenPatterns: ['console\\.log', 'debugger'],
+    },
+    modificationRules: {
+      protectedFiles: [],
+      protectedDirectories: [],
+      requireApproval: [],
+    },
+  };
+}
+
+function makeSharedFacts(): ProjectFactsSnapshot {
+  return {
+    revision: 7,
+    filesystem: {
+      existingFiles: Array.from({ length: 21 }, (_, index) => `file-${index + 1}.ts`),
+      existingDirectories: [],
+      nonExistentPaths: [],
+      directoryContents: {},
+    },
+    dependencies: {
+      installedPackages: Array.from({ length: 31 }, (_, index) => `pkg-${index + 1}`),
+      missingPackages: Array.from({ length: 21 }, (_, index) => `missing-${index + 1}`),
+    },
+    project: {
+      devServerRunning: false,
+    },
+    moduleDependencyGraph: {
+      modules: {
+        'src/a.ts': {
+          path: 'src/a.ts',
+          imports: [],
+          exports: [],
+          lastModified: 1,
+        },
+        'src/b.ts': {
+          path: 'src/b.ts',
+          imports: [],
+          exports: [],
+          lastModified: 1,
+        },
+      },
+      dependencies: {},
+      reverseDependencies: {},
+    },
+    errors: Array.from({ length: 6 }, (_, index) => ({
+      stepId: `step-${index + 1}`,
+      type: 'runtime',
+      message: `error-${index + 1}`,
+      timestamp: index + 1,
+    })),
+  };
+}

--- a/packages/core/src/sub-agents/code-quality-prompt.test.ts
+++ b/packages/core/src/sub-agents/code-quality-prompt.test.ts
@@ -69,7 +69,9 @@ describe('buildCodeQualityLlmReviewPrompt', () => {
     expect(result.userPrompt).toContain('missing-20');
     expect(result.userPrompt).not.toContain('missing-21');
     expect(result.userPrompt).toContain('moduleCount=2');
-    expect(result.userPrompt).toContain('recentErrors=[runtime] error-2 | [runtime] error-3 | [runtime] error-4 | [runtime] error-5 | [runtime] error-6');
+    expect(result.userPrompt).toContain(
+      'recentErrors=[runtime] error-2 | [runtime] error-3 | [runtime] error-4 | [runtime] error-5 | [runtime] error-6',
+    );
     expect(result.userPrompt).not.toContain('error-1');
   });
 });

--- a/packages/core/src/sub-agents/code-quality-prompt.ts
+++ b/packages/core/src/sub-agents/code-quality-prompt.ts
@@ -1,0 +1,98 @@
+import type { SDDConfig } from '@frontagent/shared';
+import type { ProjectFactsSnapshot } from '../types.js';
+import type { CodeQualityReviewFile } from './code-quality-subagent.js';
+
+export interface CodeQualityPromptRequest {
+  taskId: string;
+  phase: string;
+  files: CodeQualityReviewFile[];
+  sddConfig?: SDDConfig;
+  sharedFacts?: ProjectFactsSnapshot;
+}
+
+export interface CodeQualityPromptOptions {
+  maxFilesForLLM: number;
+  maxCharsPerFileForLLM: number;
+}
+
+export interface CodeQualityLlmReviewPrompt {
+  system: string;
+  userPrompt: string;
+}
+
+export function buildCodeQualityLlmReviewPrompt(
+  payload: CodeQualityPromptRequest,
+  options: CodeQualityPromptOptions,
+): CodeQualityLlmReviewPrompt {
+  const filesForLLM = payload.files.slice(0, options.maxFilesForLLM).map((file) => ({
+    path: file.path,
+    content: truncateFileContent(file.content, options.maxCharsPerFileForLLM),
+  }));
+
+  const userPrompt = [
+    `Task ID: ${payload.taskId}`,
+    `Phase: ${payload.phase}`,
+    '',
+    'SDD constraints summary:',
+    buildSddSummary(payload.sddConfig),
+    '',
+    'Shared project facts snapshot:',
+    summarizeSharedFacts(payload.sharedFacts),
+    '',
+    'Files to review:',
+    JSON.stringify(filesForLLM, null, 2),
+    '',
+    'Return concrete issues with filePath/line/rule/message.',
+  ].join('\n');
+
+  return {
+    system: [
+      'You are a strict code quality review sub-agent.',
+      'Evaluate generated code against SDD constraints and maintainability.',
+      'Output only actionable issues.',
+      'Set severity=error only for clear correctness or hard-constraint violations.',
+    ].join(' '),
+    userPrompt,
+  };
+}
+
+function buildSddSummary(sddConfig?: SDDConfig): string {
+  if (!sddConfig) {
+    return 'No SDD config provided.';
+  }
+
+  return [
+    `maxFileLines=${sddConfig.codeQuality.maxFileLines}`,
+    `maxFunctionLines=${sddConfig.codeQuality.maxFunctionLines}`,
+    `maxParameters=${sddConfig.codeQuality.maxParameters}`,
+    `forbiddenPatterns=${sddConfig.codeQuality.forbiddenPatterns.join(', ') || '(none)'}`,
+    `forbiddenPackages=${sddConfig.techStack.forbiddenPackages.join(', ') || '(none)'}`,
+  ].join('\n');
+}
+
+function summarizeSharedFacts(sharedFacts?: ProjectFactsSnapshot): string {
+  if (!sharedFacts) {
+    return 'No shared facts provided.';
+  }
+
+  const existingFiles = sharedFacts.filesystem.existingFiles.slice(0, 20);
+  const missingPackages = sharedFacts.dependencies.missingPackages.slice(0, 20);
+  const installedPackages = sharedFacts.dependencies.installedPackages.slice(0, 30);
+  const recentErrors = sharedFacts.errors.slice(-5);
+
+  return [
+    `revision=${sharedFacts.revision}`,
+    `existingFiles(${sharedFacts.filesystem.existingFiles.length})=${existingFiles.join(', ') || '(none)'}`,
+    `installedPackages(${sharedFacts.dependencies.installedPackages.length})=${installedPackages.join(', ') || '(none)'}`,
+    `missingPackages(${sharedFacts.dependencies.missingPackages.length})=${missingPackages.join(', ') || '(none)'}`,
+    `moduleCount=${Object.keys(sharedFacts.moduleDependencyGraph.modules).length}`,
+    `recentErrors=${recentErrors.map((err) => `[${err.type}] ${err.message}`).join(' | ') || '(none)'}`,
+  ].join('\n');
+}
+
+function truncateFileContent(content: string, maxCharsPerFileForLLM: number): string {
+  if (content.length <= maxCharsPerFileForLLM) {
+    return content;
+  }
+  return `${content.slice(0, maxCharsPerFileForLLM)}\n/* truncated */`;
+}

--- a/packages/core/src/sub-agents/code-quality-subagent.ts
+++ b/packages/core/src/sub-agents/code-quality-subagent.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import type { A2AAgent, A2ARequest, A2AResponse } from '../a2a.js';
 import type { LLMService } from '../llm.js';
 import type { ProjectFactsSnapshot, ProjectFactsUpdate } from '../types.js';
+import { buildCodeQualityLlmReviewPrompt } from './code-quality-prompt.js';
 
 export interface CodeQualityReviewFile {
   path: string;
@@ -58,7 +59,7 @@ export class CodeQualitySubAgent
   readonly capabilities = ['code_quality.review_generated_files'];
 
   // === 配置区
-  // TODO: 等未来token便宜之后取消规则函数与无关配置
+  // First split extracts LLM prompt policy; rule fallback policy remains local.
   private readonly llmService?: LLMService; // 启动LLM评估
   private readonly enableRuleFallback: boolean; // 规则函数检查
   private readonly maxFilesForLLM: number; // LLM评估最多文件数
@@ -164,38 +165,14 @@ export class CodeQualitySubAgent
       ),
     });
 
-    const filesForLLM = payload.files.slice(0, this.maxFilesForLLM).map((file) => ({
-      path: file.path,
-      content: this.truncateFileContent(file.content),
-    }));
-
-    const sddSummary = this.buildSddSummary(payload.sddConfig);
-    const sharedFactsSummary = this.summarizeSharedFacts(payload.sharedFacts);
-
-    const userPrompt = [
-      `Task ID: ${payload.taskId}`,
-      `Phase: ${payload.phase}`,
-      '',
-      'SDD constraints summary:',
-      sddSummary,
-      '',
-      'Shared project facts snapshot:',
-      sharedFactsSummary,
-      '',
-      'Files to review:',
-      JSON.stringify(filesForLLM, null, 2),
-      '',
-      'Return concrete issues with filePath/line/rule/message.',
-    ].join('\n');
+    const prompt = buildCodeQualityLlmReviewPrompt(payload, {
+      maxFilesForLLM: this.maxFilesForLLM,
+      maxCharsPerFileForLLM: this.maxCharsPerFileForLLM,
+    });
 
     const llmResult = await this.llmService.generateObject({
-      system: [
-        'You are a strict code quality review sub-agent.',
-        'Evaluate generated code against SDD constraints and maintainability.',
-        'Output only actionable issues.',
-        'Set severity=error only for clear correctness or hard-constraint violations.',
-      ].join(' '),
-      messages: [{ role: 'user', content: userPrompt }],
+      system: prompt.system,
+      messages: [{ role: 'user', content: prompt.userPrompt }],
       schema: reviewSchema,
       temperature: 0.1,
       maxTokens: 3000,
@@ -283,40 +260,6 @@ export class CodeQualitySubAgent
     }
 
     return issues;
-  }
-
-  private buildSddSummary(sddConfig?: SDDConfig): string {
-    if (!sddConfig) {
-      return 'No SDD config provided.';
-    }
-
-    return [
-      `maxFileLines=${sddConfig.codeQuality.maxFileLines}`,
-      `maxFunctionLines=${sddConfig.codeQuality.maxFunctionLines}`,
-      `maxParameters=${sddConfig.codeQuality.maxParameters}`,
-      `forbiddenPatterns=${sddConfig.codeQuality.forbiddenPatterns.join(', ') || '(none)'}`,
-      `forbiddenPackages=${sddConfig.techStack.forbiddenPackages.join(', ') || '(none)'}`,
-    ].join('\n');
-  }
-
-  private summarizeSharedFacts(sharedFacts?: ProjectFactsSnapshot): string {
-    if (!sharedFacts) {
-      return 'No shared facts provided.';
-    }
-
-    const existingFiles = sharedFacts.filesystem.existingFiles.slice(0, 20);
-    const missingPackages = sharedFacts.dependencies.missingPackages.slice(0, 20);
-    const installedPackages = sharedFacts.dependencies.installedPackages.slice(0, 30);
-    const recentErrors = sharedFacts.errors.slice(-5);
-
-    return [
-      `revision=${sharedFacts.revision}`,
-      `existingFiles(${sharedFacts.filesystem.existingFiles.length})=${existingFiles.join(', ') || '(none)'}`,
-      `installedPackages(${sharedFacts.dependencies.installedPackages.length})=${installedPackages.join(', ') || '(none)'}`,
-      `missingPackages(${sharedFacts.dependencies.missingPackages.length})=${missingPackages.join(', ') || '(none)'}`,
-      `moduleCount=${Object.keys(sharedFacts.moduleDependencyGraph.modules).length}`,
-      `recentErrors=${recentErrors.map((err) => `[${err.type}] ${err.message}`).join(' | ') || '(none)'}`,
-    ].join('\n');
   }
 
   private buildFactUpdates(
@@ -414,13 +357,6 @@ export class CodeQualitySubAgent
     }
 
     return specifier.split('/')[0];
-  }
-
-  private truncateFileContent(content: string): string {
-    if (content.length <= this.maxCharsPerFileForLLM) {
-      return content;
-    }
-    return `${content.slice(0, this.maxCharsPerFileForLLM)}\n/* truncated */`;
   }
 
   private mergeIssues(


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #184

## Summary

- Extracts CodeQualitySubAgent LLM prompt-building into `code-quality-prompt.ts`.
- Keeps rule fallback policy, A2A handling, issue merging, and fact updates in `CodeQualitySubAgent`.
- Adds focused prompt helper tests covering existing system prompt text, file limit/truncation, SDD summary, and shared facts summary limits.
- Follow-up: aligns `biome.json` schema with the branch/CI Biome CLI version (`2.4.16`) so CI lint can run. Existing executor/shared warnings remain untouched for #186.

## Impact Scope

- Prompt-building split for the code quality sub-agent.
- Public exports are preserved; no ContextManager, Executor, mcp-filesense, or dependency metadata changes.
- `biome.json` is outside the original code-quality owned scope, but it is included as a minimal CI unblocker: `package.json`/`pnpm-lock.yaml` on this branch and `origin/develop` resolve `@biomejs/biome` to `2.4.16`, while the schema was still `2.4.15`.

## GitNexus Impact Summary

- Risk level: medium by final `detect-changes`; LOW by method-level pre-edit impact for `evaluateWithLLM`, `buildSddSummary`, `summarizeSharedFacts`, and `truncateFileContent`.
- Critical skeleton changes: no.
- GitNexus impact: direct prompt-method caller is `CodeQualitySubAgent.handleRequest`; affected flow is `code-quality-subagent-worker.ts:main`. Final compare detected affected flows: `Main -> IsDebug`, `Main -> ConvertMessages`, `Main -> BuildCallSettings`, `Main -> BuildSddSummary`, `Main -> SummarizeSharedFacts`.
- Follow-up GitNexus check: `npx gitnexus detect-changes --scope all --repo FrontAgent` reported no symbol/flow changes for the schema/test-format patch.

## Verification

- `pnpm agent:bootstrap` passed.
- `pnpm quality:predev` passed.
- TDD red: `pnpm --dir packages/core test -- src/sub-agents/code-quality-prompt.test.ts` failed on missing `./code-quality-prompt.js` before implementation.
- `pnpm --dir packages/core test -- src/sub-agents/code-quality-prompt.test.ts` passed: 2 tests.
- `pnpm --dir packages/core test -- src/sub-agents/code-quality-prompt.test.ts src/agent/phase-checks.test.ts src/agent/agent.test.ts` passed: 27 tests.
- `pnpm --dir packages/core typecheck` passed.
- `pnpm typecheck` passed: 22 Turbo tasks.
- `pnpm test` passed: 22 Turbo tasks; core 24 files / 508 tests.
- `pnpm test:workflows` passed: 23 tests.
- Follow-up root cause check: `pnpm exec biome --version` returned `Version: 2.4.16`; branch `package.json`, `pnpm-lock.yaml`, and `origin/develop` all resolve `@biomejs/biome` to `2.4.16`; `biome.json` schema was `2.4.15`.
- Follow-up `pnpm lint` passed with 28 existing warnings and 0 errors.
- Follow-up `pnpm quality:precommit` passed.
- Follow-up `pnpm quality:local` passed, including Contract Guard local mode, `quality:ci`, build, and VSIX packaging.
- Follow-up normal `git push` passed through the pre-push `quality:local` hook; no `--no-verify` was used.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.
