### PR TITLE
Clean Biome warnings in executor and shared tests

### DIFF
--- a/docs/superpowers/plans/2026-06-08-clean-biome-warnings.md
+++ b/docs/superpowers/plans/2026-06-08-clean-biome-warnings.md
@@ -1,0 +1,81 @@
+# Clean Biome Warnings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the existing Biome warnings in the executor and shared test files owned by issue #186.
+
+**Architecture:** Keep the change test-only by replacing broad `as any` casts with typed fixtures and helpers. Preserve the `escapeRegex` metacharacter assertion while avoiding Biome's template-placeholder string warning.
+
+**Tech Stack:** TypeScript, Vitest, Biome, pnpm, GitNexus CLI.
+
+---
+
+### Task 1: Replace Executor Test `as any` Casts
+
+**Files:**
+- Modify: `packages/core/src/executor/executor.test.ts`
+
+- [ ] **Step 1: Confirm lint baseline**
+
+Run:
+
+```bash
+pnpm biome check packages/core/src/executor/executor.test.ts packages/shared/src/utils.test.ts
+```
+
+Expected: Biome reports `lint/suspicious/noExplicitAny` warnings in `executor.test.ts` and `lint/suspicious/noTemplateCurlyInString` in `utils.test.ts`.
+
+- [ ] **Step 2: Add typed fixtures**
+
+Update `executor.test.ts` to import the relevant types and use helpers for `ExecutorConfig`, `ExecutorActionSkill`, `AgentTask`, and executor context objects. Keep runtime fixtures source-local; use `unknown`-based casts only where class-private fields prevent structural test doubles for `ExecutorConfig['hallucinationGuard']` and `ExecutorConfig['llmService']`.
+
+- [ ] **Step 3: Replace repeated inline casts**
+
+Replace repeated inline `{ task, collectedContext } as any` objects with a typed `makeExecutionContext()` helper, and type the action skill fixture as `ExecutorActionSkill`.
+
+### Task 2: Preserve Regex Coverage Without Template Warning
+
+**Files:**
+- Modify: `packages/shared/src/utils.test.ts`
+
+- [ ] **Step 1: Fix the metacharacter input literal**
+
+Build the input string without a literal `${}` sequence in a normal string, then keep the same expected escaped output.
+
+### Task 3: Verify And Prepare PR
+
+**Files:**
+- Verify: `packages/core/src/executor/executor.test.ts`
+- Verify: `packages/shared/src/utils.test.ts`
+- Verify: `docs/superpowers/plans/2026-06-08-clean-biome-warnings.md`
+
+- [ ] **Step 1: Run focused lint and tests**
+
+Run:
+
+```bash
+pnpm biome check packages/core/src/executor/executor.test.ts packages/shared/src/utils.test.ts
+pnpm --filter @frontagent/core test -- src/executor/executor.test.ts
+pnpm --filter @frontagent/shared test -- src/utils.test.ts
+```
+
+- [ ] **Step 2: Run typecheck and broader gates as feasible**
+
+Run:
+
+```bash
+pnpm --filter @frontagent/core typecheck
+pnpm --filter @frontagent/shared typecheck
+pnpm lint
+pnpm quality:precommit
+```
+
+- [ ] **Step 3: Run GitNexus diff inspection**
+
+Run:
+
+```bash
+npx gitnexus detect_changes --scope all -r /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-clean-biome-warnings
+```
+
+Expected: Changed files are limited to the two scoped tests and this plan.

--- a/packages/core/src/executor/executor.test.ts
+++ b/packages/core/src/executor/executor.test.ts
@@ -1,7 +1,8 @@
-import type { ExecutionStep } from '@frontagent/shared';
+import type { AgentTask, ExecutionStep } from '@frontagent/shared';
 import { describe, expect, it, vi } from 'vitest';
+import type { ExecutorActionSkill } from '../skills/index.js';
 import { createExecutor, Executor } from './executor.js';
-import type { ExecutorConfig } from './types.js';
+import type { ExecutorCollectedContext, ExecutorConfig } from './types.js';
 
 function makeStep(overrides: Partial<ExecutionStep> = {}): ExecutionStep {
   return {
@@ -21,9 +22,49 @@ function makeStep(overrides: Partial<ExecutionStep> = {}): ExecutionStep {
 function makeConfig(overrides: Partial<ExecutorConfig> = {}): ExecutorConfig {
   return {
     projectRoot: '/test',
-    hallucinationGuard: { enabled: false } as any,
-    llmService: { name: 'test', generateText: vi.fn(), generateObject: vi.fn() } as any,
+    hallucinationGuard: {
+      validateFilePath: vi.fn(),
+      validateCode: vi.fn(),
+    } as unknown as ExecutorConfig['hallucinationGuard'],
+    llmService: {
+      name: 'test',
+      generateText: vi.fn(),
+      generateObject: vi.fn(),
+    } as unknown as ExecutorConfig['llmService'],
     ...overrides,
+  };
+}
+
+function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    id: 't1',
+    type: 'create',
+    description: 'test',
+    ...overrides,
+  };
+}
+
+function makeCollectedContext(
+  overrides: Partial<ExecutorCollectedContext> = {},
+): ExecutorCollectedContext {
+  return {
+    files: new Map(),
+    ...overrides,
+  };
+}
+
+function makeExecutionContext(
+  overrides: {
+    task?: Partial<AgentTask>;
+    collectedContext?: Partial<ExecutorCollectedContext>;
+  } = {},
+): {
+  task: AgentTask;
+  collectedContext: ExecutorCollectedContext;
+} {
+  return {
+    task: makeTask(overrides.task),
+    collectedContext: makeCollectedContext(overrides.collectedContext),
   };
 }
 
@@ -73,10 +114,9 @@ describe('Executor', () => {
       const executor = new Executor(makeConfig());
       const skill = {
         name: 'test-skill',
-        match: vi.fn().mockReturnValue(true),
-        execute: vi.fn().mockResolvedValue({ success: true, output: 'ok', duration: 10 }),
-      };
-      executor.registerActionSkill(skill as any);
+        action: 'read_file',
+      } satisfies ExecutorActionSkill;
+      executor.registerActionSkill(skill);
       const snapshot = executor.getActionSkillSnapshot();
       expect(snapshot.actionSkills.length).toBeGreaterThan(0);
     });
@@ -101,10 +141,7 @@ describe('Executor', () => {
         params: {},
       });
 
-      const result = await executor.executeStep(step, {
-        task: { id: 't1', type: 'create', description: 'test' } as any,
-        collectedContext: { files: new Map(), metadata: {} } as any,
-      });
+      const result = await executor.executeStep(step, makeExecutionContext());
 
       expect(result.stepResult.success).toBe(true);
       expect(result.stepResult.output).toEqual(expect.objectContaining({ skipped: true }));
@@ -118,10 +155,7 @@ describe('Executor', () => {
         params: { path: '' },
       });
 
-      const result = await executor.executeStep(step, {
-        task: { id: 't1', type: 'create', description: 'test' } as any,
-        collectedContext: { files: new Map(), metadata: {} } as any,
-      });
+      const result = await executor.executeStep(step, makeExecutionContext());
 
       expect(result.stepResult.success).toBe(true);
       expect(result.stepResult.output).toEqual(expect.objectContaining({ skipped: true }));
@@ -135,10 +169,7 @@ describe('Executor', () => {
         params: {},
       });
 
-      const result = await executor.executeStep(step, {
-        task: { id: 't1', type: 'create', description: 'test' } as any,
-        collectedContext: { files: new Map(), metadata: {} } as any,
-      });
+      const result = await executor.executeStep(step, makeExecutionContext());
 
       expect(result).toHaveProperty('stepResult');
       expect(result).toHaveProperty('validation');
@@ -149,10 +180,7 @@ describe('Executor', () => {
   describe('executeSteps', () => {
     it('returns empty results for empty steps', async () => {
       const executor = new Executor(makeConfig());
-      const results = await executor.executeSteps([], {
-        task: { id: 't1', type: 'create', description: 'test' } as any,
-        collectedContext: { files: new Map(), metadata: {} } as any,
-      });
+      const results = await executor.executeSteps([], makeExecutionContext());
       expect(results).toEqual([]);
     });
 
@@ -166,12 +194,9 @@ describe('Executor', () => {
         params: { path: 'a.ts' },
       });
 
-      await expect(
-        executor.executeSteps([step], {
-          task: { id: 't1', type: 'create', description: 'test' } as any,
-          collectedContext: { files: new Map(), metadata: {} } as any,
-        }),
-      ).rejects.toThrow('Circular dependency detected or missing dependency');
+      await expect(executor.executeSteps([step], makeExecutionContext())).rejects.toThrow(
+        'Circular dependency detected or missing dependency',
+      );
     });
 
     it('calls onStepComplete callback', async () => {
@@ -184,14 +209,7 @@ describe('Executor', () => {
 
       const onStepComplete = vi.fn();
 
-      await executor.executeSteps(
-        [step],
-        {
-          task: { id: 't1', type: 'create', description: 'test' } as any,
-          collectedContext: { files: new Map(), metadata: {} } as any,
-        },
-        onStepComplete,
-      );
+      await executor.executeSteps([step], makeExecutionContext(), onStepComplete);
 
       expect(onStepComplete).toHaveBeenCalledWith(step, expect.any(Object));
     });
@@ -200,10 +218,7 @@ describe('Executor', () => {
   describe('executeStepsWithErrorFeedback', () => {
     it('returns empty results for empty steps', async () => {
       const executor = new Executor(makeConfig());
-      const results = await executor.executeStepsWithErrorFeedback([], {
-        task: { id: 't1', type: 'create', description: 'test' } as any,
-        collectedContext: { files: new Map(), metadata: {} } as any,
-      });
+      const results = await executor.executeStepsWithErrorFeedback([], makeExecutionContext());
       expect(results).toEqual([]);
     });
 
@@ -220,10 +235,7 @@ describe('Executor', () => {
 
       await executor.executeStepsWithErrorFeedback(
         [step],
-        {
-          task: { id: 't1', type: 'create', description: 'test' } as any,
-          collectedContext: { files: new Map(), metadata: {} } as any,
-        },
+        makeExecutionContext(),
         onStepStart,
         onStepComplete,
       );
@@ -246,10 +258,7 @@ describe('Executor', () => {
       await expect(
         executor.executeStepsWithErrorFeedback(
           [step],
-          {
-            task: { id: 't1', type: 'create', description: 'test' } as any,
-            collectedContext: { files: new Map(), metadata: {} } as any,
-          },
+          makeExecutionContext(),
           undefined,
           undefined,
           undefined,
@@ -270,10 +279,7 @@ describe('Executor', () => {
         params: { path: 'a.ts' },
       });
 
-      await executor.executeStepsWithErrorFeedback([step], {
-        task: { id: 't1', type: 'create', description: 'test' } as any,
-        collectedContext: { files: new Map(), metadata: {} } as any,
-      });
+      await executor.executeStepsWithErrorFeedback([step], makeExecutionContext());
 
       expect(step.status).toBe('skipped');
     });
@@ -293,10 +299,7 @@ describe('Executor', () => {
         params: {},
       });
 
-      await executor.executeStepsWithErrorFeedback([step], {
-        task: { id: 't1', type: 'create', description: 'test' } as any,
-        collectedContext: { files: new Map(), metadata: {} } as any,
-      });
+      await executor.executeStepsWithErrorFeedback([step], makeExecutionContext());
 
       expect(onStepTrace).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/packages/shared/src/utils.test.ts
+++ b/packages/shared/src/utils.test.ts
@@ -136,7 +136,10 @@ describe('matchGlob', () => {
 
 describe('escapeRegex', () => {
   it('escapes all regex metacharacters', () => {
-    expect(escapeRegex('.*+?^${}()|[]\\')).toBe('\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\');
+    const templatePlaceholderChars = '$' + '{}';
+    expect(escapeRegex(`.*+?^${templatePlaceholderChars}()|[]\\`)).toBe(
+      '\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\',
+    );
   });
 
   it('leaves normal strings unchanged', () => {


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #186

## Summary

- Replaced broad `as any` casts in `packages/core/src/executor/executor.test.ts` with typed test helpers and `unknown`-based fixture casts only for class-private config dependencies.
- Updated the shared `escapeRegex` metacharacter test to avoid Biome's `noTemplateCurlyInString` warning while preserving `$`, `{`, and `}` coverage.
- Added a short implementation plan under `docs/superpowers/plans`.

## Impact Scope

- Test-only changes in `packages/core/src/executor/executor.test.ts` and `packages/shared/src/utils.test.ts`.
- No production source changes.

## GitNexus Impact Summary

- Risk level: low
- Critical skeleton changes: none
- GitNexus impact: `npx gitnexus detect_changes --scope compare --base-ref origin/develop -r /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-clean-biome-warnings` reported 3 files, 4 symbols, 0 affected processes.
- Verification: Impact analysis before edits: `makeConfig` LOW, `makeStep` LOW; `Executor` CRITICAL, so production `Executor` was not edited.

## Verification

- `pnpm agent:bootstrap` passed.
- `pnpm quality:predev` passed.
- `pnpm biome check packages/core/src/executor/executor.test.ts packages/shared/src/utils.test.ts --max-diagnostics 100` passed with no diagnostics for these files.
- `pnpm --filter @frontagent/core test -- src/executor/executor.test.ts` passed: 19 tests.
- `pnpm --filter @frontagent/shared test -- src/utils.test.ts` passed: 26 tests.
- `pnpm --filter @frontagent/core typecheck` passed.
- `pnpm --filter @frontagent/shared typecheck` passed.
- `pnpm quality:precommit` passed.
- `git push` pre-push hook ran `pnpm quality:local` and passed.

Note: full `pnpm lint` still reports two unrelated warnings outside this issue scope (`packages/core/src/llm/llm-service.test.ts` and `packages/core/src/planner.ts`); this PR leaves them untouched.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.