### PR TITLE
Refactor FrontAgent execution callback wiring

### DIFF
--- a/docs/superpowers/plans/2026-06-08-decompose-frontagent-orchestration.md
+++ b/docs/superpowers/plans/2026-06-08-decompose-frontagent-orchestration.md
@@ -1,0 +1,70 @@
+# Decompose FrontAgent Orchestration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract one precise FrontAgent orchestration responsibility while preserving the public API and runtime behavior.
+
+**Architecture:** Move execute-step callback construction from `FrontAgent.executeSteps` into a focused agent helper. `FrontAgent` will still own dependencies and execution, while the helper owns callback assembly for step started, step completed, phase started, phase error, and phase complete handlers.
+
+**Tech Stack:** TypeScript, Vitest, pnpm, GitNexus.
+
+---
+
+### Task 1: Extract Execute Callback Wiring
+
+**Files:**
+- Create: `packages/core/src/agent/execution-callbacks.ts`
+- Create: `packages/core/src/agent/execution-callbacks.test.ts`
+- Modify: `packages/core/src/agent/agent.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/src/agent/execution-callbacks.test.ts` with a test that calls `createExecutionCallbacks`, invokes `onStepStarted` and `onPhaseStarted`, and asserts the emitted event payloads are unchanged from the inline `FrontAgent.executeSteps` behavior.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run packages/core/src/agent/execution-callbacks.test.ts`
+
+Expected: FAIL because `./execution-callbacks.js` does not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `packages/core/src/agent/execution-callbacks.ts` exporting `createExecutionCallbacks`. The helper should accept the existing callback dependencies, task, execution plan, execution context, validations, and optional abort signal, then return named callbacks:
+
+```ts
+{
+  onStepStarted,
+  onStepComplete,
+  onPhaseStarted,
+  onPhaseError,
+  onPhaseComplete,
+}
+```
+
+The helper must delegate completed/error/phase-complete behavior to the existing `createOnStepComplete`, `createOnPhaseError`, and `createOnPhaseComplete` functions.
+
+- [ ] **Step 4: Replace inline callback construction in `agent.ts`**
+
+Modify only `FrontAgent.executeSteps` wiring so it calls `createExecutionCallbacks(...)` and passes the returned callbacks to `executor.executeStepsWithErrorFeedback` in the same argument order.
+
+- [ ] **Step 5: Verify focused tests**
+
+Run:
+
+```bash
+pnpm vitest run packages/core/src/agent/execution-callbacks.test.ts packages/core/src/agent/agent.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Verify broader contracts**
+
+Run:
+
+```bash
+pnpm typecheck
+npx gitnexus detect-changes --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-decompose-frontagent-orchestration
+pnpm quality:precommit
+```
+
+Expected: PASS, with GitNexus showing only the callback helper extraction and plan/test files.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -39,6 +39,7 @@ import type {
 import { WorkflowIntegration } from '../workflow-integration.js';
 import { buildFinalOutput } from './answer-generation.js';
 import { detectDevServerPort } from './dev-server-detection.js';
+import { createExecutionCallbacks } from './execution-callbacks.js';
 import { mergeRetrievalQuery, normalizeSearchQuery } from './helpers.js';
 import { persistMemory, preloadMemory } from './memory-lifecycle.js';
 import {
@@ -46,11 +47,6 @@ import {
   retrieveRagContext,
   rewriteRagQueryForRetrieval,
 } from './rag-retrieval.js';
-import {
-  createOnPhaseComplete,
-  createOnPhaseError,
-  createOnStepComplete,
-} from './step-callbacks.js';
 
 /**
  * FrontAgent 主类
@@ -861,6 +857,14 @@ export class FrontAgent {
       phaseCheckDeps: this.phaseCheckDeps,
       subAgentConfig: this.config.subAgents,
     };
+    const callbacks = createExecutionCallbacks({
+      deps: callbackDeps,
+      task,
+      executionPlan,
+      executionContext,
+      validations,
+      signal,
+    });
 
     await this.executor.executeStepsWithErrorFeedback(
       executionPlan.steps,
@@ -874,15 +878,11 @@ export class FrontAgent {
           filesenseContext: executionContext.collectedContext.filesenseContext,
         },
       },
-      (step) => {
-        this.emit({ type: 'step_started', step });
-      },
-      createOnStepComplete(callbackDeps, task, executionContext, validations),
-      (phase, stepCount) => {
-        this.emit({ type: 'phase_started', phase, stepCount });
-      },
-      createOnPhaseError(callbackDeps, task, signal),
-      createOnPhaseComplete(callbackDeps, task, executionPlan, executionContext, signal),
+      callbacks.onStepStarted,
+      callbacks.onStepComplete,
+      callbacks.onPhaseStarted,
+      callbacks.onPhaseError,
+      callbacks.onPhaseComplete,
       signal,
     );
   }

--- a/packages/core/src/agent/execution-callbacks.test.ts
+++ b/packages/core/src/agent/execution-callbacks.test.ts
@@ -1,0 +1,137 @@
+import type { AgentTask, ExecutionPlan, ExecutionStep, ValidationResult } from '@frontagent/shared';
+import { describe, expect, it, vi } from 'vitest';
+import type { ExecutorOutput } from '../types.js';
+import { createExecutionCallbacks } from './execution-callbacks.js';
+
+function makeTask(): AgentTask {
+  return {
+    id: 'task-1',
+    type: 'code',
+    description: 'Build feature',
+    context: { workingDirectory: '/repo' },
+  };
+}
+
+function makeStep(overrides: Partial<ExecutionStep> = {}): ExecutionStep {
+  return {
+    stepId: 'step-1',
+    description: 'Create file',
+    action: 'create_file',
+    tool: 'create_file',
+    params: { path: 'src/a.ts', content: 'export const a = 1;' },
+    dependencies: [],
+    validation: [],
+    status: 'pending',
+    phase: 'build',
+    ...overrides,
+  };
+}
+
+function makeExecutionPlan(step: ExecutionStep): ExecutionPlan {
+  return {
+    steps: [step],
+    estimatedDuration: 1,
+    requiredTools: ['create_file'],
+    risks: [],
+  };
+}
+
+function makeDeps() {
+  const contextManager = {
+    updateFileSystemFacts: vi.fn(),
+    updateDependencyFacts: vi.fn(),
+    updateProjectFacts: vi.fn(),
+    updateModuleDependencyGraph: vi.fn(),
+    updateFilesenseNavigation: vi.fn(),
+    getContext: vi.fn(),
+    addErrorFact: vi.fn(),
+    addExecutedStep: vi.fn(),
+    validateModuleDependencies: vi.fn(() => []),
+    serializeFactsForLLM: vi.fn(() => ''),
+  };
+
+  return {
+    contextManager,
+    executor: { callTool: vi.fn() },
+    llmService: { analyzeErrorsAndGenerateRecovery: vi.fn() },
+    emit: vi.fn(),
+    emitStatus: vi.fn(),
+    debugLog: vi.fn(),
+    debugWarn: vi.fn(),
+    throwIfAborted: vi.fn(),
+    phaseCheckDeps: {
+      config: { projectRoot: '/repo', llm: { provider: 'openai', model: 'gpt-4' } },
+      executor: { callTool: vi.fn() },
+      contextManager,
+      sddConfig: undefined,
+      a2aBus: undefined,
+      codeQualitySubAgent: undefined,
+      debugLog: vi.fn(),
+      debugWarn: vi.fn(),
+      enqueueFactsUpdate: vi.fn(),
+    },
+  };
+}
+
+describe('createExecutionCallbacks', () => {
+  it('emits the same step and phase started events as FrontAgent executeSteps wiring', () => {
+    const deps = makeDeps();
+    const task = makeTask();
+    const step = makeStep();
+    const validations: ValidationResult[] = [];
+
+    const callbacks = createExecutionCallbacks({
+      deps,
+      task,
+      executionPlan: makeExecutionPlan(step),
+      executionContext: { collectedContext: { files: new Map<string, string>() } },
+      validations,
+    });
+
+    callbacks.onStepStarted(step);
+    callbacks.onPhaseStarted('build', 1);
+
+    expect(deps.emit).toHaveBeenCalledWith({ type: 'step_started', step });
+    expect(deps.emit).toHaveBeenCalledWith({
+      type: 'phase_started',
+      phase: 'build',
+      stepCount: 1,
+    });
+  });
+
+  it('delegates step completion side effects to the existing step callback behavior', () => {
+    const deps = makeDeps();
+    const task = makeTask();
+    const step = makeStep();
+    const validations: ValidationResult[] = [];
+    const files = new Map<string, string>();
+
+    const callbacks = createExecutionCallbacks({
+      deps,
+      task,
+      executionPlan: makeExecutionPlan(step),
+      executionContext: { collectedContext: { files } },
+      validations,
+    });
+
+    const output = {
+      stepId: step.stepId,
+      stepResult: {
+        success: true,
+        output: { content: 'export const a = 1;' },
+      },
+      validation: { valid: true, errors: [], warnings: [] },
+    } as ExecutorOutput;
+
+    callbacks.onStepComplete(step, output);
+
+    expect(files.get('src/a.ts')).toBe('export const a = 1;');
+    expect(validations).toEqual([output.validation]);
+    expect(deps.contextManager.addExecutedStep).toHaveBeenCalledWith(task.id, step);
+    expect(deps.emit).toHaveBeenCalledWith({
+      type: 'step_completed',
+      step,
+      result: output.stepResult,
+    });
+  });
+});

--- a/packages/core/src/agent/execution-callbacks.ts
+++ b/packages/core/src/agent/execution-callbacks.ts
@@ -1,0 +1,55 @@
+import type { AgentTask, ExecutionPlan, ExecutionStep, ValidationResult } from '@frontagent/shared';
+import type { ContextManager } from '../context.js';
+import type { ExecutorOutput } from '../types.js';
+import {
+  createOnPhaseComplete,
+  createOnPhaseError,
+  createOnStepComplete,
+  type StepCallbackDeps,
+} from './step-callbacks.js';
+
+type AgentExecutionContext = NonNullable<ReturnType<ContextManager['getContext']>>;
+
+export interface CreateExecutionCallbacksInput {
+  deps: StepCallbackDeps;
+  task: AgentTask;
+  executionPlan: ExecutionPlan;
+  executionContext: AgentExecutionContext;
+  validations: ValidationResult[];
+  signal?: AbortSignal;
+}
+
+export interface ExecutionCallbacks {
+  onStepStarted(step: ExecutionStep): void;
+  onStepComplete(step: ExecutionStep, output: ExecutorOutput): void;
+  onPhaseStarted(phase: string, stepCount: number): void;
+  onPhaseError(
+    phase: string,
+    errors: Array<{ step: ExecutionStep; error: string }>,
+  ): Promise<ExecutionStep[]>;
+  onPhaseComplete(
+    phase: string,
+    phaseResults: ExecutorOutput[],
+  ): Promise<Array<{ step: ExecutionStep; error: string }>>;
+}
+
+export function createExecutionCallbacks({
+  deps,
+  task,
+  executionPlan,
+  executionContext,
+  validations,
+  signal,
+}: CreateExecutionCallbacksInput): ExecutionCallbacks {
+  return {
+    onStepStarted: (step) => {
+      deps.emit({ type: 'step_started', step });
+    },
+    onStepComplete: createOnStepComplete(deps, task, executionContext, validations),
+    onPhaseStarted: (phase, stepCount) => {
+      deps.emit({ type: 'phase_started', phase, stepCount });
+    },
+    onPhaseError: createOnPhaseError(deps, task, signal),
+    onPhaseComplete: createOnPhaseComplete(deps, task, executionPlan, executionContext, signal),
+  };
+}


### PR DESCRIPTION
## Linked Issue Or Context

Closes #194

## Summary

- Extracted `FrontAgent.executeSteps` callback construction into `packages/core/src/agent/execution-callbacks.ts`.
- Kept `FrontAgent` responsible for dependency ownership and executor invocation while the helper assembles step/phase callbacks.
- Added focused tests for started-event payloads and step-complete side effects delegated through the existing callback behavior.

## Impact Scope

- `packages/core/src/agent/agent.ts`
- `packages/core/src/agent/execution-callbacks.ts`
- `packages/core/src/agent/execution-callbacks.test.ts`
- `docs/superpowers/plans/2026-06-08-decompose-frontagent-orchestration.md`

## GitNexus Impact Summary

- Risk level: HIGH
- Critical skeleton changes: yes, agent-core files changed: `agent.ts`, `execution-callbacks.ts`, `execution-callbacks.test.ts`.
- GitNexus impact: `gitnexus detect_changes --scope staged` reported 4 changed files, 3 changed indexed symbols, and 7 affected execution flows. Pre-edit `gitnexus impact` for `FrontAgent` and `executeSteps` was LOW; `gitnexus context executeSteps` showed the direct caller is `FrontAgent.execute`.
- Verification: focused agent tests, `pnpm typecheck`, `pnpm quality:precommit`, `pnpm quality:local`, and pre-push `pnpm quality:local` all passed.

## Verification

- `pnpm --dir packages/core test -- src/agent/execution-callbacks.test.ts` -> 1 file, 2 tests passed.
- `pnpm --dir packages/core test -- src/agent/execution-callbacks.test.ts src/agent/agent.test.ts` -> 2 files, 10 tests passed.
- `pnpm typecheck` -> 22 turbo typecheck tasks passed.
- `npx gitnexus detect-changes --scope staged --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/issue194-decompose-orchestration-clone` -> HIGH risk, 4 files, 3 changed indexed symbols, 7 affected flows.
- `pnpm quality:precommit` -> passed.
- `pnpm quality:local` -> passed.
- `git push` pre-push hook reran `pnpm quality:local` -> passed.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.