### PR TITLE
refactor: split planner phase helpers

### DIFF
--- a/docs/superpowers/plans/2026-06-08-split-planner-phase-helpers.md
+++ b/docs/superpowers/plans/2026-06-08-split-planner-phase-helpers.md
@@ -1,0 +1,69 @@
+# Split Planner Phase Helpers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract Planner repository phase construction/injection helpers into a focused helper module without changing Planner public API or generated plan behavior.
+
+**Architecture:** Keep `Planner.plan()` and `createPlanner()` unchanged. Move repository-management phase detection, acceptance-step collection, and repository step construction into `packages/core/src/planner-phase-helpers.ts`, with `Planner` passing its existing `createStep()` factory into the helper.
+
+**Tech Stack:** TypeScript, Vitest, GitNexus CLI, pnpm workspace scripts.
+
+---
+
+### Task 1: Add Focused Helper Regression Tests
+
+**Files:**
+- Create: `packages/core/src/planner-phase-helpers.test.ts`
+- Read: `packages/core/src/planner.test.ts`
+
+- [x] **Step 1: Write failing extraction tests**
+
+Add helper-level tests for repository-management phase injection, query-task skip behavior, and duplicate repository-phase skip behavior.
+
+- [x] **Step 2: Run focused test and verify RED**
+
+Run: `pnpm --dir packages/core test src/planner-phase-helpers.test.ts`
+Expected: FAIL because `./planner-phase-helpers.js` does not exist yet.
+
+### Task 2: Extract Phase Construction Helpers
+
+**Files:**
+- Create: `packages/core/src/planner-phase-helpers.ts`
+- Modify: `packages/core/src/planner.ts`
+- Test: `packages/core/src/planner-phase-helpers.test.ts`, `packages/core/src/planner.test.ts`
+
+- [x] **Step 1: Create helper module**
+
+Implement `injectRepositoryManagementPhase(task, steps, stepFactory)` plus local helper functions for code-change detection, duplicate repository phase detection, acceptance-step detection, and repository-management step construction. Copy command strings exactly from `Planner` to preserve output behavior.
+
+- [x] **Step 2: Wire Planner to helper**
+
+Import `injectRepositoryManagementPhase` from `./planner-phase-helpers.js`. Replace the constructor callback with `injectRepositoryManagementPhase(task, steps, { createStep: (options) => this.createStep(options) })`, and remove the moved private helper methods from `Planner`.
+
+- [x] **Step 3: Run focused tests and verify GREEN**
+
+Run: `pnpm --dir packages/core test src/planner-phase-helpers.test.ts src/planner.test.ts`
+Expected: PASS.
+
+### Task 3: Final Verification and PR
+
+**Files:**
+- Read: final git diff only.
+
+- [x] **Step 1: Run required verification gates**
+
+Run: `pnpm --dir packages/core test src/planner-phase-helpers.test.ts src/planner.test.ts`
+Expected: PASS.
+
+Run: `pnpm typecheck`
+Expected: PASS.
+
+Run: `pnpm quality:precommit`
+Expected: PASS or document exact failure.
+
+Run: `npx gitnexus detect-changes --repo /Users/ceilf6/Desktop/myrepos/Wiki/AI/3-Application/FrontAgent-app`
+Expected: scoped changes in Planner and the new planner phase helper/test files.
+
+- [ ] **Step 2: Create PR**
+
+Push branch `improve/split-planner-phase-helpers` and open a PR to `develop` with `Closes #192` in the body.

--- a/packages/core/src/planner-phase-helpers.test.ts
+++ b/packages/core/src/planner-phase-helpers.test.ts
@@ -1,0 +1,164 @@
+import type { AgentTask, ExecutionStep, ValidationRule } from '@frontagent/shared';
+import { describe, expect, it } from 'vitest';
+import { injectRepositoryManagementPhase } from './planner-phase-helpers.js';
+
+function createTask(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    id: 'task-1',
+    type: 'create',
+    description: 'create and verify a file',
+    context: { workingDirectory: '/project' },
+    ...overrides,
+  };
+}
+
+let stepIndex = 0;
+
+const repositoryManagementCommands = [
+  'git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "Skip repo management: not a git repository"; exit 0; }; command -v gh >/dev/null 2>&1 || { echo "Skip repo management: gh CLI not installed"; exit 0; }; gh auth status >/dev/null 2>&1 || { echo "Skip repo management: gh not authenticated"; exit 0; }; if [ -z "$(git status --porcelain)" ]; then echo "Skip repo management: no file changes"; exit 0; fi; echo "Repo management precheck passed"',
+  'branch="$(git rev-parse --abbrev-ref HEAD)"; if [ "$branch" = "HEAD" ]; then new_branch="codex/auto-$(date +%Y%m%d-%H%M%S)"; git switch -c "$new_branch"; branch="$new_branch"; fi; case "$branch" in codex/*) ;; *) target_branch="codex/$' +
+    '{branch}"; git switch -c "$target_branch" 2>/dev/null || git switch "$target_branch"; branch="$target_branch";; esac; echo "Using branch: $branch"',
+  'git add -A; if git diff --cached --quiet; then echo "No staged changes, skip commit"; exit 0; fi; git commit -m "chore: automate repository management after acceptance"',
+  'branch="$(git rev-parse --abbrev-ref HEAD)"; if [ "$branch" = "HEAD" ]; then echo "Skip push: detached HEAD"; exit 0; fi; git remote get-url origin >/dev/null 2>&1 || { echo "Skip push: missing origin remote"; exit 0; }; git push -u origin "$branch"',
+  'branch="$(git rev-parse --abbrev-ref HEAD)"; if [ "$branch" = "HEAD" ]; then echo "Skip PR: detached HEAD"; exit 0; fi; command -v gh >/dev/null 2>&1 || { echo "Skip PR: gh CLI not installed"; exit 0; }; gh auth status >/dev/null 2>&1 || { echo "Skip PR: gh not authenticated"; exit 0; }; if gh pr view "$branch" >/dev/null 2>&1; then gh pr edit "$branch" --title "chore: automated update by FrontAgent" --body "Automated PR update after acceptance phase passed."; else gh pr create --head "$branch" --title "chore: automated update by FrontAgent" --body "Automated PR created by FrontAgent after acceptance phase passed."; fi',
+] as const;
+
+function createStep(options: {
+  description: string;
+  action: ExecutionStep['action'];
+  tool: string;
+  params: Record<string, unknown>;
+  dependencies?: string[];
+  validation?: ValidationRule[];
+  phase?: string;
+}): ExecutionStep {
+  stepIndex += 1;
+  return {
+    stepId: `step-${stepIndex}`,
+    description: options.description,
+    action: options.action,
+    tool: options.tool,
+    params: options.params,
+    dependencies: options.dependencies ?? [],
+    validation: options.validation ?? [],
+    status: 'pending',
+    phase: options.phase,
+  };
+}
+
+describe('planner phase helpers', () => {
+  it('adds repository management steps after acceptance commands for code changes', () => {
+    const createFile = createStep({
+      description: 'create file',
+      action: 'create_file',
+      tool: 'create_file',
+      params: { path: 'src/new.ts' },
+      phase: '阶段2-创建',
+    });
+    const typecheck = createStep({
+      description: 'typecheck',
+      action: 'run_command',
+      tool: 'run_command',
+      params: { command: 'pnpm typecheck' },
+      phase: '阶段4-验证',
+      dependencies: [createFile.stepId],
+    });
+
+    const result = injectRepositoryManagementPhase(createTask(), [createFile, typecheck], {
+      createStep,
+    });
+
+    const repoSteps = result.filter((step) => step.phase === '阶段7-仓库管理');
+    expect(repoSteps).toHaveLength(5);
+    expect(repoSteps[0].dependencies).toEqual([typecheck.stepId]);
+    expect(repoSteps.map((step) => step.description)).toEqual([
+      '检查 Git/GH 环境并确认仓库存在可提交变更',
+      '确保当前分支符合 codex/* 规范',
+      '提交验收后的代码变更',
+      '推送分支到远程 origin',
+      '使用 gh 自动创建或更新 Pull Request',
+    ]);
+    expect(
+      repoSteps.map((step) => ({
+        action: step.action,
+        tool: step.tool,
+        phase: step.phase,
+        command: step.params.command,
+        dependencies: step.dependencies,
+      })),
+    ).toEqual([
+      {
+        action: 'run_command',
+        tool: 'run_command',
+        phase: '阶段7-仓库管理',
+        command: repositoryManagementCommands[0],
+        dependencies: [typecheck.stepId],
+      },
+      {
+        action: 'run_command',
+        tool: 'run_command',
+        phase: '阶段7-仓库管理',
+        command: repositoryManagementCommands[1],
+        dependencies: [repoSteps[0].stepId],
+      },
+      {
+        action: 'run_command',
+        tool: 'run_command',
+        phase: '阶段7-仓库管理',
+        command: repositoryManagementCommands[2],
+        dependencies: [repoSteps[1].stepId],
+      },
+      {
+        action: 'run_command',
+        tool: 'run_command',
+        phase: '阶段7-仓库管理',
+        command: repositoryManagementCommands[3],
+        dependencies: [repoSteps[2].stepId],
+      },
+      {
+        action: 'run_command',
+        tool: 'run_command',
+        phase: '阶段7-仓库管理',
+        command: repositoryManagementCommands[4],
+        dependencies: [repoSteps[3].stepId],
+      },
+    ]);
+  });
+
+  it('does not inject repository management for query tasks or existing repo phases', () => {
+    const patch = createStep({
+      description: 'patch file',
+      action: 'apply_patch',
+      tool: 'apply_patch',
+      params: { path: 'src/app.ts' },
+      phase: '阶段2-修改',
+    });
+    const test = createStep({
+      description: 'test',
+      action: 'run_command',
+      tool: 'run_command',
+      params: { command: 'pnpm test' },
+      phase: '阶段4-验证',
+      dependencies: [patch.stepId],
+    });
+    const existingRepo = createStep({
+      description: 'commit',
+      action: 'run_command',
+      tool: 'run_command',
+      params: { command: 'git commit -m "x"' },
+      phase: '阶段7-仓库管理',
+      dependencies: [test.stepId],
+    });
+
+    expect(
+      injectRepositoryManagementPhase(createTask({ type: 'query' }), [patch, test], {
+        createStep,
+      }),
+    ).toEqual([patch, test]);
+    expect(
+      injectRepositoryManagementPhase(createTask(), [patch, test, existingRepo], {
+        createStep,
+      }),
+    ).toEqual([patch, test, existingRepo]);
+  });
+});

--- a/packages/core/src/planner-phase-helpers.ts
+++ b/packages/core/src/planner-phase-helpers.ts
@@ -1,0 +1,171 @@
+import type { AgentTask, ExecutionStep } from '@frontagent/shared';
+import type { PlannerStepFactory } from './skills/index.js';
+
+/**
+ * 在验收阶段成功后追加仓库管理阶段（Git + GitHub CLI）
+ */
+export function injectRepositoryManagementPhase(
+  task: AgentTask,
+  steps: ExecutionStep[],
+  stepFactory: PlannerStepFactory,
+): ExecutionStep[] {
+  if (!shouldInjectRepositoryManagementPhase(task, steps)) {
+    return steps;
+  }
+
+  if (hasRepositoryManagementPhase(steps)) {
+    return steps;
+  }
+
+  const acceptanceStepIds = collectAcceptanceStepIds(steps);
+  if (acceptanceStepIds.length === 0) {
+    return steps;
+  }
+
+  const repoSteps = createRepositoryManagementSteps(acceptanceStepIds, stepFactory);
+  return [...steps, ...repoSteps];
+}
+
+function shouldInjectRepositoryManagementPhase(task: AgentTask, steps: ExecutionStep[]): boolean {
+  const hasCodeChanges = steps.some(
+    (step) => step.action === 'create_file' || step.action === 'apply_patch',
+  );
+  if (!hasCodeChanges) {
+    return false;
+  }
+
+  if (task.type === 'query') {
+    return false;
+  }
+
+  return true;
+}
+
+function hasRepositoryManagementPhase(steps: ExecutionStep[]): boolean {
+  return steps.some((step) => {
+    const phase = (step.phase ?? '').toLowerCase();
+    const command =
+      typeof step.params.command === 'string' ? step.params.command.toLowerCase() : '';
+
+    return (
+      phase.includes('仓库管理') ||
+      phase.includes('repository') ||
+      phase.includes('repo') ||
+      command.includes('gh pr') ||
+      command.includes('git push') ||
+      command.includes('git commit')
+    );
+  });
+}
+
+function collectAcceptanceStepIds(steps: ExecutionStep[]): string[] {
+  return steps.filter((step) => isAcceptanceStep(step)).map((step) => step.stepId);
+}
+
+function isAcceptanceStep(step: ExecutionStep): boolean {
+  const phase = (step.phase ?? '').toLowerCase();
+  const action = step.action;
+  const command = typeof step.params.command === 'string' ? step.params.command.toLowerCase() : '';
+
+  if (
+    phase.includes('验收') ||
+    phase.includes('验证') ||
+    phase.includes('accept') ||
+    phase.includes('valid')
+  ) {
+    return true;
+  }
+
+  if (
+    action === 'browser_navigate' ||
+    action === 'browser_screenshot' ||
+    action === 'get_page_structure' ||
+    action === 'browser_click' ||
+    action === 'browser_type'
+  ) {
+    return true;
+  }
+
+  if (action === 'run_command') {
+    return (
+      command.includes('typecheck') ||
+      command.includes('tsc') ||
+      command.includes('build') ||
+      command.includes('test') ||
+      command.includes('lint') ||
+      command.includes('validate')
+    );
+  }
+
+  return false;
+}
+
+function createRepositoryManagementSteps(
+  acceptanceStepIds: string[],
+  stepFactory: PlannerStepFactory,
+): ExecutionStep[] {
+  const phase = '阶段7-仓库管理';
+
+  const precheck = stepFactory.createStep({
+    description: '检查 Git/GH 环境并确认仓库存在可提交变更',
+    action: 'run_command',
+    tool: 'run_command',
+    phase,
+    params: {
+      command:
+        'git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "Skip repo management: not a git repository"; exit 0; }; command -v gh >/dev/null 2>&1 || { echo "Skip repo management: gh CLI not installed"; exit 0; }; gh auth status >/dev/null 2>&1 || { echo "Skip repo management: gh not authenticated"; exit 0; }; if [ -z "$(git status --porcelain)" ]; then echo "Skip repo management: no file changes"; exit 0; fi; echo "Repo management precheck passed"',
+    },
+    dependencies: acceptanceStepIds,
+  });
+
+  const ensureBranch = stepFactory.createStep({
+    description: '确保当前分支符合 codex/* 规范',
+    action: 'run_command',
+    tool: 'run_command',
+    phase,
+    params: {
+      command:
+        'branch="$(git rev-parse --abbrev-ref HEAD)"; if [ "$branch" = "HEAD" ]; then new_branch="codex/auto-$(date +%Y%m%d-%H%M%S)"; git switch -c "$new_branch"; branch="$new_branch"; fi; case "$branch" in codex/*) ;; *) target_branch="codex/$' +
+        '{branch}"; git switch -c "$target_branch" 2>/dev/null || git switch "$target_branch"; branch="$target_branch";; esac; echo "Using branch: $branch"',
+    },
+    dependencies: [precheck.stepId],
+  });
+
+  const commit = stepFactory.createStep({
+    description: '提交验收后的代码变更',
+    action: 'run_command',
+    tool: 'run_command',
+    phase,
+    params: {
+      command:
+        'git add -A; if git diff --cached --quiet; then echo "No staged changes, skip commit"; exit 0; fi; git commit -m "chore: automate repository management after acceptance"',
+    },
+    dependencies: [ensureBranch.stepId],
+  });
+
+  const push = stepFactory.createStep({
+    description: '推送分支到远程 origin',
+    action: 'run_command',
+    tool: 'run_command',
+    phase,
+    params: {
+      command:
+        'branch="$(git rev-parse --abbrev-ref HEAD)"; if [ "$branch" = "HEAD" ]; then echo "Skip push: detached HEAD"; exit 0; fi; git remote get-url origin >/dev/null 2>&1 || { echo "Skip push: missing origin remote"; exit 0; }; git push -u origin "$branch"',
+    },
+    dependencies: [commit.stepId],
+  });
+
+  const managePr = stepFactory.createStep({
+    description: '使用 gh 自动创建或更新 Pull Request',
+    action: 'run_command',
+    tool: 'run_command',
+    phase,
+    params: {
+      command:
+        'branch="$(git rev-parse --abbrev-ref HEAD)"; if [ "$branch" = "HEAD" ]; then echo "Skip PR: detached HEAD"; exit 0; fi; command -v gh >/dev/null 2>&1 || { echo "Skip PR: gh CLI not installed"; exit 0; }; gh auth status >/dev/null 2>&1 || { echo "Skip PR: gh not authenticated"; exit 0; }; if gh pr view "$branch" >/dev/null 2>&1; then gh pr edit "$branch" --title "chore: automated update by FrontAgent" --body "Automated PR update after acceptance phase passed."; else gh pr create --head "$branch" --title "chore: automated update by FrontAgent" --body "Automated PR created by FrontAgent after acceptance phase passed."; fi',
+    },
+    dependencies: [push.stepId],
+  });
+
+  return [precheck, ensureBranch, commit, push, managePr];
+}

--- a/packages/core/src/planner.test.ts
+++ b/packages/core/src/planner.test.ts
@@ -589,6 +589,42 @@ describe('Planner edge cases', () => {
     expect(repoSteps.length).toBeGreaterThan(0);
   });
 
+  it('keeps injected repository management steps dependent on acceptance output', async () => {
+    const planner = createPlanner({ useLLM: true });
+    mockLLMGeneratePlan(planner, async () => ({
+      summary: '创建并验证',
+      steps: [
+        {
+          description: '创建文件',
+          action: 'create_file',
+          tool: 'create_file',
+          phase: '阶段2-创建',
+          params: defaultParams({ path: 'src/new.ts', codeDescription: '新文件' }),
+          reasoning: '创建',
+          needsCodeGeneration: true,
+        },
+        {
+          description: '运行类型检查',
+          action: 'run_command',
+          tool: 'run_command',
+          phase: '阶段4-验证',
+          params: defaultParams({ command: 'pnpm typecheck' }),
+          reasoning: '验证类型',
+          needsCodeGeneration: false,
+        },
+      ],
+      risks: [],
+      alternatives: [],
+    }));
+
+    const result = await planner.plan(createTask({ type: 'create' }), emptyContext(), []);
+
+    const typecheckStep = result.plan!.steps.find((s) => s.params.command === 'pnpm typecheck');
+    const repoSteps = result.plan!.steps.filter((s) => s.phase === '阶段7-仓库管理');
+    expect(repoSteps).toHaveLength(5);
+    expect(repoSteps[0].dependencies).toEqual([typecheckStep!.stepId]);
+  });
+
   it('does not duplicate repository management phase if LLM already included it', async () => {
     const planner = createPlanner({ useLLM: true });
     mockLLMGeneratePlan(planner, async () => ({

--- a/packages/core/src/planner.ts
+++ b/packages/core/src/planner.ts
@@ -14,6 +14,7 @@ import type {
 } from '@frontagent/shared';
 import { generateId, logger } from '@frontagent/shared';
 import { type GeneratedPlan, LLMService } from './llm.js';
+import { injectRepositoryManagementPhase } from './planner-phase-helpers.js';
 import {
   createDefaultPlannerSkillRegistry,
   type PhaseInjectionSkill,
@@ -51,7 +52,9 @@ export class Planner {
     generateRefactorSteps: (task, context) => this.generateRefactorSteps(task, context),
     generateTestSteps: (task) => this.generateTestSteps(task),
     injectRepositoryManagementPhase: (task, steps) =>
-      this.injectRepositoryManagementPhase(task, steps),
+      injectRepositoryManagementPhase(task, steps, {
+        createStep: (options) => this.createStep(options),
+      }),
   });
 
   constructor(config: PlannerConfig) {
@@ -368,188 +371,6 @@ export class Planner {
       default:
         return [];
     }
-  }
-
-  /**
-   * 在验收阶段成功后追加仓库管理阶段（Git + GitHub CLI）
-   */
-  private injectRepositoryManagementPhase(
-    task: AgentTask,
-    steps: ExecutionStep[],
-  ): ExecutionStep[] {
-    if (!this.shouldInjectRepositoryManagementPhase(task, steps)) {
-      return steps;
-    }
-
-    if (this.hasRepositoryManagementPhase(steps)) {
-      return steps;
-    }
-
-    const acceptanceStepIds = this.collectAcceptanceStepIds(steps);
-    if (acceptanceStepIds.length === 0) {
-      return steps;
-    }
-
-    const repoSteps = this.createRepositoryManagementSteps(acceptanceStepIds);
-    return [...steps, ...repoSteps];
-  }
-
-  /**
-   * 是否应该注入仓库管理阶段
-   */
-  private shouldInjectRepositoryManagementPhase(task: AgentTask, steps: ExecutionStep[]): boolean {
-    // 仅在存在代码落盘步骤时启用（create_file / apply_patch）
-    const hasCodeChanges = steps.some(
-      (step) => step.action === 'create_file' || step.action === 'apply_patch',
-    );
-    if (!hasCodeChanges) {
-      return false;
-    }
-
-    // 纯查询任务不触发仓库管理
-    if (task.type === 'query') {
-      return false;
-    }
-
-    return true;
-  }
-
-  /**
-   * 检测计划中是否已有仓库管理阶段
-   */
-  private hasRepositoryManagementPhase(steps: ExecutionStep[]): boolean {
-    return steps.some((step) => {
-      const phase = (step.phase ?? '').toLowerCase();
-      const command =
-        typeof step.params.command === 'string' ? step.params.command.toLowerCase() : '';
-
-      return (
-        phase.includes('仓库管理') ||
-        phase.includes('repository') ||
-        phase.includes('repo') ||
-        command.includes('gh pr') ||
-        command.includes('git push') ||
-        command.includes('git commit')
-      );
-    });
-  }
-
-  /**
-   * 收集验收阶段步骤 ID。仓库管理步骤会依赖这些步骤，确保验收成功后才执行。
-   */
-  private collectAcceptanceStepIds(steps: ExecutionStep[]): string[] {
-    return steps.filter((step) => this.isAcceptanceStep(step)).map((step) => step.stepId);
-  }
-
-  /**
-   * 判断步骤是否属于验收阶段
-   */
-  private isAcceptanceStep(step: ExecutionStep): boolean {
-    const phase = (step.phase ?? '').toLowerCase();
-    const action = step.action;
-    const command =
-      typeof step.params.command === 'string' ? step.params.command.toLowerCase() : '';
-
-    if (
-      phase.includes('验收') ||
-      phase.includes('验证') ||
-      phase.includes('accept') ||
-      phase.includes('valid')
-    ) {
-      return true;
-    }
-
-    if (
-      action === 'browser_navigate' ||
-      action === 'browser_screenshot' ||
-      action === 'get_page_structure' ||
-      action === 'browser_click' ||
-      action === 'browser_type'
-    ) {
-      return true;
-    }
-
-    if (action === 'run_command') {
-      return (
-        command.includes('typecheck') ||
-        command.includes('tsc') ||
-        command.includes('build') ||
-        command.includes('test') ||
-        command.includes('lint') ||
-        command.includes('validate')
-      );
-    }
-
-    return false;
-  }
-
-  /**
-   * 创建阶段7-仓库管理步骤
-   */
-  private createRepositoryManagementSteps(acceptanceStepIds: string[]): ExecutionStep[] {
-    const phase = '阶段7-仓库管理';
-
-    const precheck = this.createStep({
-      description: '检查 Git/GH 环境并确认仓库存在可提交变更',
-      action: 'run_command',
-      tool: 'run_command',
-      phase,
-      params: {
-        command:
-          'git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "Skip repo management: not a git repository"; exit 0; }; command -v gh >/dev/null 2>&1 || { echo "Skip repo management: gh CLI not installed"; exit 0; }; gh auth status >/dev/null 2>&1 || { echo "Skip repo management: gh not authenticated"; exit 0; }; if [ -z "$(git status --porcelain)" ]; then echo "Skip repo management: no file changes"; exit 0; fi; echo "Repo management precheck passed"',
-      },
-      dependencies: acceptanceStepIds,
-    });
-
-    const ensureBranch = this.createStep({
-      description: '确保当前分支符合 codex/* 规范',
-      action: 'run_command',
-      tool: 'run_command',
-      phase,
-      params: {
-        command:
-          'branch="$(git rev-parse --abbrev-ref HEAD)"; if [ "$branch" = "HEAD" ]; then new_branch="codex/auto-$(date +%Y%m%d-%H%M%S)"; git switch -c "$new_branch"; branch="$new_branch"; fi; case "$branch" in codex/*) ;; *) target_branch="codex/${branch}"; git switch -c "$target_branch" 2>/dev/null || git switch "$target_branch"; branch="$target_branch";; esac; echo "Using branch: $branch"',
-      },
-      dependencies: [precheck.stepId],
-    });
-
-    const commit = this.createStep({
-      description: '提交验收后的代码变更',
-      action: 'run_command',
-      tool: 'run_command',
-      phase,
-      params: {
-        command:
-          'git add -A; if git diff --cached --quiet; then echo "No staged changes, skip commit"; exit 0; fi; git commit -m "chore: automate repository management after acceptance"',
-      },
-      dependencies: [ensureBranch.stepId],
-    });
-
-    const push = this.createStep({
-      description: '推送分支到远程 origin',
-      action: 'run_command',
-      tool: 'run_command',
-      phase,
-      params: {
-        command:
-          'branch="$(git rev-parse --abbrev-ref HEAD)"; if [ "$branch" = "HEAD" ]; then echo "Skip push: detached HEAD"; exit 0; fi; git remote get-url origin >/dev/null 2>&1 || { echo "Skip push: missing origin remote"; exit 0; }; git push -u origin "$branch"',
-      },
-      dependencies: [commit.stepId],
-    });
-
-    const managePr = this.createStep({
-      description: '使用 gh 自动创建或更新 Pull Request',
-      action: 'run_command',
-      tool: 'run_command',
-      phase,
-      params: {
-        command:
-          'branch="$(git rev-parse --abbrev-ref HEAD)"; if [ "$branch" = "HEAD" ]; then echo "Skip PR: detached HEAD"; exit 0; fi; command -v gh >/dev/null 2>&1 || { echo "Skip PR: gh CLI not installed"; exit 0; }; gh auth status >/dev/null 2>&1 || { echo "Skip PR: gh not authenticated"; exit 0; }; if gh pr view "$branch" >/dev/null 2>&1; then gh pr edit "$branch" --title "chore: automated update by FrontAgent" --body "Automated PR update after acceptance phase passed."; else gh pr create --head "$branch" --title "chore: automated update by FrontAgent" --body "Automated PR created by FrontAgent after acceptance phase passed."; fi',
-      },
-      dependencies: [push.stepId],
-    });
-
-    return [precheck, ensureBranch, commit, push, managePr];
   }
 
   /**


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #192

## Summary

- Extract repository-management phase construction/injection helpers from `Planner` into `packages/core/src/planner-phase-helpers.ts`.
- Keep `Planner` public API and generated repository-management commands/dependencies unchanged.
- Add focused helper tests plus a planner-level contract test for injected repository phase dependencies.

## Impact Scope

- Scoped to planner phase injection/construction behavior.
- No Agent, MemoryStore, executor lint cleanup, or PR #187-#191 areas touched.

## GitNexus Impact Summary

- Risk level: MEDIUM
- Critical skeleton changes: `packages/core/src/planner.ts` constructor wiring for repository phase injection.
- GitNexus impact: pre-edit `npx gitnexus impact Planner --file packages/core/src/planner.ts --kind Class --direction upstream --include-tests` reported HIGH overall because Agent imports/callers include `FrontAgent.execute`, `FrontAgent.planOnly`, constructor, skill registration, and SDD config updates. The edited `Planner.generatePlan` method impact was LOW with direct caller `Planner.plan` and affected flows `FrontAgent.execute`, `FrontAgent.planOnly`; moved repository helper methods were LOW with one internal caller. Final `detect_changes --scope compare --base-ref origin/develop` reported 5 files, 2 symbols (`Planner`, `constructor`), 1 affected flow (`RunScenario → PlannerSkillRegistry`), risk MEDIUM.
- Verification: `pnpm --dir packages/core test src/planner-phase-helpers.test.ts src/planner.test.ts`, `pnpm typecheck`, `pnpm quality:precommit`, pre-push `pnpm quality:local`, and GitNexus `detect_changes`.

## Verification

- `pnpm --dir packages/core test src/planner-phase-helpers.test.ts src/planner.test.ts` PASS (30 tests)
- `pnpm typecheck` PASS (22 turbo tasks)
- `pnpm quality:precommit` PASS
- pre-push `pnpm quality:local` PASS, including `contract:local`, `quality:ci`, and build
- GitNexus `detect_changes --scope compare --base-ref origin/develop`: MEDIUM, 1 affected flow

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.