### PR TITLE
Extract MemoryStore preload and recall helpers

### DIFF
--- a/docs/superpowers/plans/2026-06-08-memory-preload-recall-helpers.md
+++ b/docs/superpowers/plans/2026-06-08-memory-preload-recall-helpers.md
@@ -1,0 +1,98 @@
+# Memory Preload Recall Helpers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `MemoryStore` preload rendering and recall budget selection helpers without changing public memory behavior or persisted file formats.
+
+**Architecture:** Add a focused memory formatting module beside `store.ts` for pure preload formatting, truncation, and recall budget selection. Keep `MemoryStore` responsible for filesystem, gateway access, scoring, and session deduplication.
+
+**Tech Stack:** TypeScript, Vitest, existing `packages/core` memory types.
+
+---
+
+### Task 1: Helper Module Tests
+
+**Files:**
+- Create: `packages/core/src/memory/preload-recall-helpers.test.ts`
+- Create: `packages/core/src/memory/preload-recall-helpers.ts`
+
+- [ ] **Step 1: Add failing preload formatting and budget tests**
+
+Add tests for:
+
+```ts
+buildPreload({
+  budget: 800,
+  maxTopicFiles: 10,
+  gatewayMemories,
+  topics,
+});
+```
+
+Expected behaviors:
+- Gateway memories render before local topic sections.
+- Empty gateway/topic input returns `null`.
+- Long gateway preload output is truncated within the configured budget.
+- Recall candidates over the remaining budget are skipped and injected keys are reported only for selected results.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+pnpm --dir packages/core exec vitest run src/memory/preload-recall-helpers.test.ts
+```
+
+Expected: FAIL because `preload-recall-helpers.js` does not exist.
+
+- [ ] **Step 3: Implement helper module**
+
+Create `packages/core/src/memory/preload-recall-helpers.ts` with:
+- `PRELOAD_HEADER`
+- `buildPreload`
+- `selectRecallResultsWithinBudget`
+- private pure helpers for gateway section rendering, topic section rendering, part measurement, separator length, and truncation.
+
+- [ ] **Step 4: Verify helper tests pass**
+
+Run:
+
+```bash
+pnpm --dir packages/core exec vitest run src/memory/preload-recall-helpers.test.ts
+```
+
+Expected: PASS.
+
+### Task 2: MemoryStore Delegation
+
+**Files:**
+- Modify: `packages/core/src/memory/store.ts`
+- Test: `packages/core/src/memory/store.test.ts`
+
+- [ ] **Step 1: Delegate preload formatting to helper**
+
+Keep index/topic filesystem loading inside `MemoryStore`, then call `buildPreload` with sorted loaded topics and active gateway memories.
+
+- [ ] **Step 2: Delegate recall budget handling to helper**
+
+Keep scoring and dedup filtering inside `MemoryStore`, then call `selectRecallResultsWithinBudget` and add only returned injected keys to the session set.
+
+- [ ] **Step 3: Run focused memory tests**
+
+Run:
+
+```bash
+pnpm --dir packages/core exec vitest run src/memory/store.test.ts src/memory/preload-recall-helpers.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run typecheck**
+
+Run:
+
+```bash
+pnpm typecheck
+```
+
+Expected: PASS.

--- a/packages/core/src/memory/preload-recall-helpers.test.ts
+++ b/packages/core/src/memory/preload-recall-helpers.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import type { OpenMemoryGatewayRecord } from './open-memory-gateway.js';
+import {
+  buildPreload,
+  PRELOAD_HEADER,
+  selectRecallResultsWithinBudget,
+} from './preload-recall-helpers.js';
+import type { MemoryTopic, RecalledMemory } from './types.js';
+
+function makeTopic(
+  overrides: Partial<MemoryTopic['meta']>,
+  entries: MemoryTopic['entries'],
+): MemoryTopic {
+  return {
+    meta: {
+      id: 'patterns',
+      title: 'Patterns',
+      summary: 'patterns',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      charCount: 0,
+      ...overrides,
+    },
+    entries,
+  };
+}
+
+function makeGatewayMemory(overrides: Partial<OpenMemoryGatewayRecord>): OpenMemoryGatewayRecord {
+  return {
+    id: 'mem_20240101_active123',
+    status: 'active',
+    scope: 'personal',
+    source: 'manual',
+    tags: [],
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    content: 'Gateway active memory content.',
+    path: '/gateway/memory/active/mem_20240101_active123.md',
+    ...overrides,
+  };
+}
+
+describe('memory preload and recall helpers', () => {
+  it('builds preload with gateway memories before local topics', () => {
+    const topic = makeTopic({ title: 'Patterns' }, [
+      {
+        key: 'src/App.tsx',
+        content: 'Use memo for expensive computed props.',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        tags: ['react'],
+      },
+    ]);
+    const gatewayMemory = makeGatewayMemory({
+      id: 'mem_1',
+      tags: ['preference'],
+      updatedAt: '2024-01-02T00:00:00.000Z',
+      content: 'Preserve compact editor controls.',
+    });
+
+    const preload = buildPreload({
+      budget: 800,
+      maxTopicFiles: 10,
+      gatewayMemories: [gatewayMemory],
+      topics: [topic],
+    });
+
+    expect(preload).toContain(PRELOAD_HEADER);
+    expect(preload).toContain('## Open Memory Gateway Active Memories');
+    expect(preload).toContain('Preserve compact editor controls.');
+    expect(preload).toContain('### Patterns');
+    expect(preload).toContain('- **src/App.tsx**: Use memo for expensive computed props.');
+    expect(preload!.indexOf('Preserve compact editor controls.')).toBeLessThan(
+      preload!.indexOf('Use memo for expensive computed props.'),
+    );
+  });
+
+  it('truncates preload content to the configured budget', () => {
+    const preload = buildPreload({
+      budget: 120,
+      maxTopicFiles: 10,
+      gatewayMemories: [
+        makeGatewayMemory({
+          id: 'mem_long',
+          content: 'Gateway active memory content. '.repeat(20),
+        }),
+      ],
+      topics: [],
+    });
+
+    expect(preload).not.toBeNull();
+    expect(preload!.length).toBeLessThanOrEqual(120);
+    expect(preload).toContain('...(truncated)');
+  });
+
+  it('returns null when no gateway memories or topic entries are available', () => {
+    const preload = buildPreload({
+      budget: 800,
+      maxTopicFiles: 10,
+      gatewayMemories: [],
+      topics: [makeTopic({ title: 'Empty' }, [])],
+    });
+
+    expect(preload).toBeNull();
+  });
+
+  it('selects recall results within budget and reports injected keys', () => {
+    const candidates: RecalledMemory[] = [
+      { topicId: 'patterns', entryKey: 'small', content: 'Short content', score: 0.9 },
+      { topicId: 'patterns', entryKey: 'large', content: 'x'.repeat(100), score: 0.8 },
+    ];
+
+    const selected = selectRecallResultsWithinBudget(candidates, 20);
+
+    expect(selected.results).toEqual([candidates[0]]);
+    expect(selected.injectedKeys).toEqual(['patterns::small']);
+  });
+});

--- a/packages/core/src/memory/preload-recall-helpers.ts
+++ b/packages/core/src/memory/preload-recall-helpers.ts
@@ -1,0 +1,137 @@
+import type { OpenMemoryGatewayRecord } from './open-memory-gateway.js';
+import type { MemoryTopic, RecalledMemory } from './types.js';
+
+export const PRELOAD_HEADER = '## 项目记忆 (跨会话持久化)';
+
+export interface BuildPreloadInput {
+  budget: number;
+  maxTopicFiles: number;
+  gatewayMemories: OpenMemoryGatewayRecord[];
+  topics: Iterable<MemoryTopic>;
+}
+
+export interface RecallBudgetSelection {
+  results: RecalledMemory[];
+  injectedKeys: string[];
+}
+
+export function buildPreload(input: BuildPreloadInput): string | null {
+  const parts: string[] = [PRELOAD_HEADER];
+  let charCount = measurePreloadParts(parts);
+
+  const gatewaySection = renderGatewayForPreload(input.gatewayMemories, input.budget);
+  if (gatewaySection && charCount < input.budget) {
+    parts.push(gatewaySection);
+    charCount = measurePreloadParts(parts);
+  }
+
+  const topicIterator = input.topics[Symbol.iterator]();
+  let loaded = 0;
+  while (loaded < input.maxTopicFiles && charCount < input.budget) {
+    const nextTopic = topicIterator.next();
+    if (nextTopic.done) break;
+    const topic = nextTopic.value;
+    if (topic.entries.length === 0) continue;
+
+    const section = renderTopicForPreload(topic);
+    const sectionLength = section.length + sectionSeparatorLength(parts);
+    if (charCount + sectionLength > input.budget) {
+      const remaining = input.budget - charCount - sectionSeparatorLength(parts);
+      if (remaining > 200) {
+        parts.push(truncatePreloadSection(section, remaining));
+      }
+      break;
+    }
+
+    parts.push(section);
+    charCount = measurePreloadParts(parts);
+    loaded++;
+  }
+
+  return parts.length > 1 ? parts.join('\n\n') : null;
+}
+
+export function selectRecallResultsWithinBudget(
+  candidates: RecalledMemory[],
+  budget: number,
+): RecallBudgetSelection {
+  const results: RecalledMemory[] = [];
+  const injectedKeys: string[] = [];
+  let remaining = budget;
+
+  for (const candidate of candidates) {
+    if (remaining <= 0) break;
+    if (candidate.content.length > remaining) continue;
+
+    results.push(candidate);
+    remaining -= candidate.content.length;
+    injectedKeys.push(`${candidate.topicId}::${candidate.entryKey}`);
+  }
+
+  return { results, injectedKeys };
+}
+
+function renderGatewayForPreload(
+  memories: OpenMemoryGatewayRecord[],
+  preloadBudget: number,
+): string | null {
+  if (memories.length === 0) return null;
+
+  const lines: string[] = [];
+  const title = '## Open Memory Gateway Active Memories';
+  const marker = '\n...(truncated)';
+  const remainingBudget = remainingPreloadBudgetAfterHeader(preloadBudget);
+  let charCount = 0;
+
+  if (title.length > remainingBudget) {
+    return null;
+  }
+
+  lines.push(title);
+  charCount = title.length;
+  for (const memory of memories) {
+    const line = `- **${memory.id}**: ${memory.content}`;
+    const lineLength = line.length + 1;
+    const remaining = remainingBudget - charCount - 1;
+
+    if (charCount + lineLength <= remainingBudget) {
+      lines.push(line);
+      charCount += lineLength;
+      continue;
+    }
+
+    if (remaining > marker.length) {
+      lines.push(truncatePreloadSection(line, remaining));
+    }
+    break;
+  }
+  return lines.join('\n');
+}
+
+function remainingPreloadBudgetAfterHeader(preloadBudget: number): number {
+  return preloadBudget - PRELOAD_HEADER.length - 2;
+}
+
+function renderTopicForPreload(topic: MemoryTopic): string {
+  const lines: string[] = [`### ${topic.meta.title}`];
+  for (const entry of topic.entries) {
+    lines.push(`- **${entry.key}**: ${entry.content}`);
+  }
+  return lines.join('\n');
+}
+
+function measurePreloadParts(parts: string[]): number {
+  return parts.join('\n\n').length;
+}
+
+function sectionSeparatorLength(parts: string[]): number {
+  return parts.length > 0 ? 2 : 0;
+}
+
+function truncatePreloadSection(section: string, budget: number): string {
+  const marker = '\n...(truncated)';
+  if (budget <= marker.length) {
+    return section.slice(0, Math.max(0, budget));
+  }
+  return `${section.slice(0, budget - marker.length)}${marker}`;
+}

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -3,6 +3,7 @@ import { basename, join } from 'node:path';
 import { logger } from '@frontagent/shared';
 import type { ProjectFactsSnapshot } from '../types.js';
 import { OpenMemoryGatewayAdapter, type OpenMemoryGatewayRecord } from './open-memory-gateway.js';
+import { buildPreload, selectRecallResultsWithinBudget } from './preload-recall-helpers.js';
 import type {
   MemoryConfig,
   MemoryEntry,
@@ -24,8 +25,6 @@ import {
   SNAPSHOTS_DIR_NAME,
   TOPICS_DIR_NAME,
 } from './types.js';
-
-const PRELOAD_HEADER = '## 项目记忆 (跨会话持久化)';
 
 /**
  * Durable memory store backed by human-readable Markdown files and JSON snapshots.
@@ -296,97 +295,28 @@ export class MemoryStore {
    * within the configured budget.
    */
   preload(): string | null {
-    const parts: string[] = [PRELOAD_HEADER];
-    let charCount = parts[0].length;
-
-    const gatewaySection = this.renderGatewayForPreload();
-    if (gatewaySection && charCount < this.preloadBudget) {
-      parts.push(gatewaySection);
-      charCount = measurePreloadParts(parts);
-    }
-
     const index = this.loadIndex();
     if (!index || index.topics.length === 0) {
-      return parts.length > 1 ? parts.join('\n\n') : null;
+      return buildPreload({
+        budget: this.preloadBudget,
+        maxTopicFiles: this.maxTopicFiles,
+        gatewayMemories: this.listGatewayActiveMemories(),
+        topics: [],
+      });
     }
     this.index = index;
 
-    // Load topic files within budget
     const sortedTopics = [...index.topics].sort(
       (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
     );
+    const topics = this.iterPreloadTopics(sortedTopics);
 
-    let loaded = 0;
-    for (const topicMeta of sortedTopics) {
-      if (loaded >= this.maxTopicFiles) break;
-      if (charCount >= this.preloadBudget) break;
-
-      const topic = this.loadTopic(topicMeta.id);
-      if (!topic || topic.entries.length === 0) continue;
-
-      const section = this.renderTopicForPreload(topic);
-      const sectionLength = section.length + sectionSeparatorLength(parts);
-      if (charCount + sectionLength > this.preloadBudget) {
-        const remaining = this.preloadBudget - charCount - sectionSeparatorLength(parts);
-        if (remaining > 200) {
-          parts.push(truncatePreloadSection(section, remaining));
-          charCount = measurePreloadParts(parts);
-        }
-        break;
-      }
-
-      parts.push(section);
-      charCount = measurePreloadParts(parts);
-      loaded++;
-    }
-
-    return parts.length > 1 ? parts.join('\n\n') : null;
-  }
-
-  private renderGatewayForPreload(): string | null {
-    const memories = this.listGatewayActiveMemories();
-    if (memories.length === 0) return null;
-
-    const lines: string[] = [];
-    const title = '## Open Memory Gateway Active Memories';
-    const marker = '\n...(truncated)';
-    let charCount = 0;
-
-    if (title.length > this.remainingPreloadBudgetAfterHeader()) {
-      return null;
-    }
-
-    lines.push(title);
-    charCount = title.length;
-    for (const memory of memories) {
-      const line = `- **${memory.id}**: ${memory.content}`;
-      const lineLength = line.length + 1;
-      const remaining = this.remainingPreloadBudgetAfterHeader() - charCount - 1;
-
-      if (charCount + lineLength <= this.remainingPreloadBudgetAfterHeader()) {
-        lines.push(line);
-        charCount += lineLength;
-        continue;
-      }
-
-      if (remaining > marker.length) {
-        lines.push(truncatePreloadSection(line, remaining));
-      }
-      break;
-    }
-    return lines.join('\n');
-  }
-
-  private remainingPreloadBudgetAfterHeader(): number {
-    return this.preloadBudget - PRELOAD_HEADER.length - 2;
-  }
-
-  private renderTopicForPreload(topic: MemoryTopic): string {
-    const lines: string[] = [`### ${topic.meta.title}`];
-    for (const entry of topic.entries) {
-      lines.push(`- **${entry.key}**: ${entry.content}`);
-    }
-    return lines.join('\n');
+    return buildPreload({
+      budget: this.preloadBudget,
+      maxTopicFiles: this.maxTopicFiles,
+      gatewayMemories: this.listGatewayActiveMemories(),
+      topics,
+    });
   }
 
   // ---------------------------------------------------------------------------
@@ -454,21 +384,21 @@ export class MemoryStore {
 
     candidates.sort((a, b) => b.score - a.score);
 
-    const results: RecalledMemory[] = [];
-    let budget = this.recallBudget;
-
-    for (const candidate of candidates) {
-      if (budget <= 0) break;
-      if (candidate.content.length > budget) continue;
-
-      results.push(candidate);
-      budget -= candidate.content.length;
-
-      const dedupKey = `${candidate.topicId}::${candidate.entryKey}`;
+    const selected = selectRecallResultsWithinBudget(candidates, this.recallBudget);
+    for (const dedupKey of selected.injectedKeys) {
       this.injectedKeys.add(dedupKey);
     }
 
-    return results;
+    return selected.results;
+  }
+
+  private *iterPreloadTopics(topicMetas: MemoryTopicMeta[]): Iterable<MemoryTopic> {
+    for (const topicMeta of topicMetas) {
+      const topic = this.loadTopic(topicMeta.id);
+      if (topic) {
+        yield topic;
+      }
+    }
   }
 
   /**
@@ -795,22 +725,6 @@ export class MemoryStore {
       return false;
     }
   }
-}
-
-function measurePreloadParts(parts: string[]): number {
-  return parts.join('\n\n').length;
-}
-
-function sectionSeparatorLength(parts: string[]): number {
-  return parts.length > 0 ? 2 : 0;
-}
-
-function truncatePreloadSection(section: string, budget: number): string {
-  const marker = '\n...(truncated)';
-  if (budget <= marker.length) {
-    return section.slice(0, Math.max(0, budget));
-  }
-  return `${section.slice(0, budget - marker.length)}${marker}`;
 }
 
 function renderGatewayCapture(input: PersistenceInput): string {


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #193

## Summary

- Extracted MemoryStore preload formatting, gateway/topic truncation, and recall budget selection into `packages/core/src/memory/preload-recall-helpers.ts`.
- Kept MemoryStore responsible for filesystem loading, gateway access, scoring, and session deduplication.
- Added focused helper tests for preload ordering, truncation/null output, and recall budget selection.

## Impact Scope

- Memory boundary only: `packages/core/src/memory/store.ts` plus new helper/test files.
- No Planner, Agent, executor lint cleanup, Open Memory Gateway migration, or storage format changes.
- Persisted memory index/topic/snapshot file formats are unchanged.

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: memory-boundary files (`packages/core/src/memory/store.ts`, `packages/core/src/memory/preload-recall-helpers.ts`, `packages/core/src/memory/preload-recall-helpers.test.ts`).
- GitNexus impact: `detect_changes --scope staged` reported 4 files, 4 symbols, 0 affected processes, LOW risk; `impact MemoryStore --direction upstream` reported HIGH aggregate class impact via FrontAgent execute/planOnly construction/access; `impact preload` reported LOW with direct caller `store.test.ts`; `impact recall` reported LOW with direct callers `FrontAgent.getMemoryRecall` and `store.test.ts`; private preload helper impacts route through `MemoryStore.preload` and tests.
- Verification: staged `detect_changes` before commit; pre-push `quality:local` passed after contract check refreshed GitNexus index.

## Verification

- `pnpm --dir packages/core exec vitest run src/memory/preload-recall-helpers.test.ts` (RED first: failed on missing helper module; GREEN: 4 passed)
- `pnpm --dir packages/core exec vitest run src/memory/store.test.ts src/memory/preload-recall-helpers.test.ts` (54 passed)
- `pnpm exec biome check packages/core/src/memory/store.ts packages/core/src/memory/preload-recall-helpers.ts packages/core/src/memory/preload-recall-helpers.test.ts docs/superpowers/plans/2026-06-08-memory-preload-recall-helpers.md` (changed files clean)
- `pnpm typecheck` (22/22 Turbo tasks successful)
- `pnpm test` (22/22 Turbo test tasks successful)
- `pnpm quality:precommit` (passed; Biome emitted existing warnings in executor tests and schema-version info)
- pre-push `pnpm quality:local` (passed: contract, quality:ci, build, VSIX package)

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.