### PR TITLE
Clean LLMService Biome warning

### DIFF
--- a/docs/superpowers/plans/2026-06-08-clean-llmservice-biome-warning.md
+++ b/docs/superpowers/plans/2026-06-08-clean-llmservice-biome-warning.md
@@ -21,7 +21,7 @@
 Run:
 
 ```bash
-npx gitnexus impact generateObject --direction upstream --file packages/core/src/llm/llm-service.ts --kind Method --include-tests --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-clean-llmservice-biome-warning
+npx gitnexus impact generateObject --direction upstream --file packages/core/src/llm/llm-service.ts --kind Method --include-tests --repo <worktree>
 ```
 
 Expected: report the blast radius. This issue edits only the test's local schema double, so production call behavior should remain unchanged.
@@ -75,9 +75,9 @@ Run:
 ```bash
 pnpm lint
 pnpm quality:precommit
-npx gitnexus detect_changes --scope all -r /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-clean-llmservice-biome-warning
+npx gitnexus detect_changes --scope all -r <worktree>
 ```
 
 Expected: checks pass; changed files are limited to `packages/core/src/llm/llm-service.test.ts` and this plan, excluding generated `.gitnexus/*` drift.
 
-Actual: `pnpm lint` and `pnpm quality:precommit` passed. After correcting this isolated worktree's private `core.worktree` Git metadata and refreshing GitNexus, `npx gitnexus detect_changes --scope all -r /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-clean-llmservice-biome-warning` reported 2 changed files, 1 changed test-local `parse` symbol, 0 affected processes, low risk.
+Actual: `pnpm lint` and `pnpm quality:precommit` passed. After correcting this isolated worktree's private `core.worktree` Git metadata and refreshing GitNexus, `npx gitnexus detect_changes --scope all -r <worktree>` reported 2 changed files, 1 changed test-local `parse` symbol, 0 affected processes, low risk.

--- a/docs/superpowers/plans/2026-06-08-clean-llmservice-biome-warning.md
+++ b/docs/superpowers/plans/2026-06-08-clean-llmservice-biome-warning.md
@@ -1,0 +1,83 @@
+# Clean LLMService Biome Warning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the remaining `noExplicitAny` warning in `packages/core/src/llm/llm-service.test.ts` without changing LLMService behavior.
+
+**Architecture:** Keep the change test-local. Replace the broad `as any` schema test double with a structural type that satisfies `z.ZodType<T>` for the backend delegation call.
+
+**Tech Stack:** TypeScript, Vitest, Biome, GitNexus, pnpm.
+
+---
+
+### Task 1: Type the LLMService test schema double
+
+**Files:**
+- Modify: `packages/core/src/llm/llm-service.test.ts`
+- Verify: `docs/superpowers/plans/2026-06-08-clean-llmservice-biome-warning.md`
+
+- [x] **Step 1: Run GitNexus impact analysis before editing**
+
+Run:
+
+```bash
+npx gitnexus impact generateObject --direction upstream --file packages/core/src/llm/llm-service.ts --kind Method --include-tests --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-clean-llmservice-biome-warning
+```
+
+Expected: report the blast radius. This issue edits only the test's local schema double, so production call behavior should remain unchanged.
+
+- [x] **Step 2: Replace the explicit-any cast**
+
+In `packages/core/src/llm/llm-service.test.ts`, import the Zod type and replace:
+
+```ts
+import type { LLMConfig } from '../types.js';
+```
+
+with:
+
+```ts
+import type { z } from 'zod';
+import type { LLMConfig } from '../types.js';
+```
+
+Then replace:
+
+```ts
+const schema = { parse: (v: unknown) => v } as any;
+```
+
+with:
+
+```ts
+const schema: z.ZodType<{ result: string }> = {
+  parse: (v: unknown) => v as { result: string },
+} as z.ZodType<{ result: string }>;
+```
+
+- [x] **Step 3: Run focused lint and tests**
+
+Run:
+
+```bash
+pnpm biome check packages/core/src/llm/llm-service.test.ts
+pnpm --filter @frontagent/core test -- src/llm/llm-service.test.ts
+```
+
+Expected: Biome reports no `noExplicitAny` warning for the file, and the focused LLMService tests pass.
+
+Actual: `pnpm biome check packages/core/src/llm/llm-service.test.ts` passed. The focused test required building fresh-worktree dependencies first (`@frontagent/shared`, `@frontagent/sdd`, and `@frontagent/hallucination-guard`), then `pnpm --filter @frontagent/core test -- src/llm/llm-service.test.ts` passed with 18 tests.
+
+- [x] **Step 4: Run broader verification and diff impact**
+
+Run:
+
+```bash
+pnpm lint
+pnpm quality:precommit
+npx gitnexus detect_changes --scope all -r /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-clean-llmservice-biome-warning
+```
+
+Expected: checks pass; changed files are limited to `packages/core/src/llm/llm-service.test.ts` and this plan, excluding generated `.gitnexus/*` drift.
+
+Actual: `pnpm lint` and `pnpm quality:precommit` passed. After correcting this isolated worktree's private `core.worktree` Git metadata and refreshing GitNexus, `npx gitnexus detect_changes --scope all -r /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-clean-llmservice-biome-warning` reported 2 changed files, 1 changed test-local `parse` symbol, 0 affected processes, low risk.

--- a/packages/core/src/llm/llm-service.test.ts
+++ b/packages/core/src/llm/llm-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { z } from 'zod';
 import type { LLMConfig } from '../types.js';
 import { LLMService, normalizeProviderBaseURL } from './llm-service.js';
 
@@ -157,7 +158,9 @@ describe('LLMService', () => {
 
   describe('generateObject with backend', () => {
     it('delegates to backend', async () => {
-      const schema = { parse: (v: unknown) => v } as any;
+      const schema = {
+        parse: (v: unknown) => v as { result: string },
+      } as z.ZodType<{ result: string }>;
       const backend = {
         name: 'test',
         generateText: vi.fn(),


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #200

## Summary

- Replaced the local `generateObject` test schema double's explicit `any` cast with a typed `z.ZodType<{ result: string }>` cast.
- Added a short implementation plan under `docs/superpowers/plans`.

## Impact Scope

- Test-only cleanup in `packages/core/src/llm/llm-service.test.ts`.
- No runtime `LLMService` behavior changes.

## GitNexus Impact Summary

- Risk level: LOW for final diff; upstream symbol impact for `LLMService.generateObject` is HIGH if runtime method changes.
- Critical skeleton changes: none.
- GitNexus impact: `npx gitnexus impact generateObject --direction upstream --file packages/core/src/llm/llm-service.ts --kind Method --include-tests -r <worktree>` reported 7 impacted symbols, 3 direct dependents, 3 affected processes (`main`, `executeImprovement`, `improveSkill`), risk HIGH. This PR does not edit that method; it only edits a test-local schema double.
- Verification: `npx gitnexus detect_changes --scope staged -r <worktree>` reported 2 files, 3 changed symbols (plan headings and test-local `parse`), 0 affected processes, low risk.

## Verification

- `pnpm agent:bootstrap`
- `pnpm quality:predev`
- `pnpm biome check packages/core/src/llm/llm-service.test.ts`
- `pnpm --filter @frontagent/core test -- src/llm/llm-service.test.ts`
- `pnpm --filter @frontagent/core typecheck`
- `pnpm lint`
- `pnpm quality:precommit`
- pre-push hook: `pnpm quality:local`

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.
