### PR TITLE
Refactor ContextManager module graph updates

### DIFF
--- a/docs/superpowers/plans/2026-06-08-contextmanager-module-graph.md
+++ b/docs/superpowers/plans/2026-06-08-contextmanager-module-graph.md
@@ -1,0 +1,24 @@
+# ContextManager Module Graph Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the module dependency graph update logic from `ContextManager` while preserving its public API and behavior.
+
+**Architecture:** Keep `ContextManager.updateModuleDependencyGraph` as the public entrypoint and delegate graph mutation to a focused helper in `packages/core/src/context/module-dependency-graph.ts`. The helper owns parsing module metadata, dependency resolution, and reverse dependency cleanup for successful file mutations.
+
+**Tech Stack:** TypeScript, Vitest, existing context helper functions.
+
+---
+
+### Task 1: Extract Module Graph Update Helper
+
+**Files:**
+- Create: `packages/core/src/context/module-dependency-graph.ts`
+- Modify: `packages/core/src/context/context-manager.ts`
+- Test: `packages/core/src/context/module-dependency-graph.test.ts`
+
+- [ ] Add `updateModuleDependencyGraphFromToolResult` that accepts a `ModuleDependencyGraph`, tool name, params, and result, returning `true` when the graph changed.
+- [ ] Move the current create/apply_patch success filtering, JS/TS path filtering, import/export parsing, dependency resolution, module upsert, dependency replacement, and reverse dependency cleanup into the helper.
+- [ ] Replace the body of `ContextManager.updateModuleDependencyGraph` with helper delegation and call `bumpFactsRevision` only when the helper returns `true`.
+- [ ] Add focused tests for unchanged non-code/failed tool results and reverse dependency replacement on repeated module updates.
+- [ ] Run `pnpm exec vitest run packages/core/src/context/module-dependency-graph.test.ts packages/core/src/context/context-manager.test.ts` and `pnpm typecheck`.

--- a/packages/core/src/context/context-manager.ts
+++ b/packages/core/src/context/context-manager.ts
@@ -14,15 +14,12 @@ import { serializeProjectFactsForLLM } from './fact-serializer.js';
 import {
   cloneStringArray,
   formatFilesenseNavigationContext,
-  inferModuleType,
   mapToRecord,
   normalizeFilesenseNavigation,
   parentDirectoriesForPath,
-  parseExports,
-  parseImports,
   recordToClonedStringArrayMap,
-  resolveImportPath,
 } from './helpers.js';
+import { updateModuleDependencyGraphFromToolResult } from './module-dependency-graph.js';
 
 /**
  * 上下文管理器
@@ -606,65 +603,16 @@ export class ContextManager {
     const context = this.contexts.get(taskId);
     if (!context) return;
 
-    const { moduleDependencyGraph } = context.facts;
-
-    // 只处理成功的 create_file 和 apply_patch 操作
-    if (!result.success) return;
-    if (toolName !== 'create_file' && toolName !== 'apply_patch') return;
-
-    const path = params.path as string;
-    const content = (params.content as string) || (result.content as string) || '';
-
-    // 只处理 TS/JS 文件
-    if (!/\.(tsx?|jsx?|mjs|cjs)$/.test(path)) return;
-
-    // 解析导入和导出
-    const imports = parseImports(content);
-    const { exports: exportedSymbols, defaultExport } = parseExports(content);
-
-    // 创建模块信息
-    const moduleInfo: ModuleInfo = {
-      path,
-      type: inferModuleType(path),
-      exports: exportedSymbols,
-      defaultExport,
-      imports,
-      createdAt: Date.now(),
-    };
-
-    // 更新模块映射
-    moduleDependencyGraph.modules.set(path, moduleInfo);
-
-    // 更新依赖关系
-    const resolvedDeps: string[] = [];
-    for (const importPath of imports) {
-      const resolved = resolveImportPath(importPath, path, '');
-      if (resolved) {
-        resolvedDeps.push(resolved);
-      }
+    if (
+      updateModuleDependencyGraphFromToolResult(
+        context.facts.moduleDependencyGraph,
+        toolName,
+        params,
+        result,
+      )
+    ) {
+      this.bumpFactsRevision(context.facts);
     }
-    moduleDependencyGraph.dependencies.set(path, resolvedDeps);
-
-    // 清理旧的反向依赖（如果模块被重复更新）
-    for (const [depPath, reverseDeps] of moduleDependencyGraph.reverseDependencies.entries()) {
-      const nextReverseDeps = reverseDeps.filter((reversePath) => reversePath !== path);
-      if (nextReverseDeps.length > 0) {
-        moduleDependencyGraph.reverseDependencies.set(depPath, nextReverseDeps);
-      } else {
-        moduleDependencyGraph.reverseDependencies.delete(depPath);
-      }
-    }
-
-    // 更新反向依赖
-    for (const dep of resolvedDeps) {
-      const reverseDeps = moduleDependencyGraph.reverseDependencies.get(dep) || [];
-      if (!reverseDeps.includes(path)) {
-        reverseDeps.push(path);
-        moduleDependencyGraph.reverseDependencies.set(dep, reverseDeps);
-      }
-    }
-
-    this.bumpFactsRevision(context.facts);
   }
 
   /**

--- a/packages/core/src/context/module-dependency-graph.test.ts
+++ b/packages/core/src/context/module-dependency-graph.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import type { ModuleDependencyGraph } from '../types.js';
+import { updateModuleDependencyGraphFromToolResult } from './module-dependency-graph.js';
+
+function makeGraph(): ModuleDependencyGraph {
+  return {
+    modules: new Map(),
+    dependencies: new Map(),
+    reverseDependencies: new Map(),
+  };
+}
+
+describe('updateModuleDependencyGraphFromToolResult', () => {
+  it('ignores failed results', () => {
+    const graph = makeGraph();
+
+    const changed = updateModuleDependencyGraphFromToolResult(
+      graph,
+      'create_file',
+      { path: 'src/app.ts', content: 'export const app = true;' },
+      { success: false },
+    );
+
+    expect(changed).toBe(false);
+    expect(graph.modules.size).toBe(0);
+    expect(graph.dependencies.size).toBe(0);
+    expect(graph.reverseDependencies.size).toBe(0);
+  });
+
+  it('ignores unsupported tools and non-module files', () => {
+    const graph = makeGraph();
+
+    expect(
+      updateModuleDependencyGraphFromToolResult(
+        graph,
+        'read_file',
+        { path: 'src/app.ts', content: 'export const app = true;' },
+        { success: true },
+      ),
+    ).toBe(false);
+    expect(
+      updateModuleDependencyGraphFromToolResult(
+        graph,
+        'create_file',
+        { path: 'README.md', content: '# docs' },
+        { success: true },
+      ),
+    ).toBe(false);
+    expect(graph.modules.size).toBe(0);
+  });
+
+  it('records module metadata and reverse dependencies for created code files', () => {
+    const graph = makeGraph();
+
+    const changed = updateModuleDependencyGraphFromToolResult(
+      graph,
+      'create_file',
+      {
+        path: 'src/components/App.tsx',
+        content: "import { format } from '../utils/format';\nexport default function App() {}",
+      },
+      { success: true },
+    );
+
+    expect(changed).toBe(true);
+    expect(graph.modules.get('src/components/App.tsx')).toMatchObject({
+      path: 'src/components/App.tsx',
+      type: 'component',
+      imports: ['../utils/format'],
+      defaultExport: 'App',
+    });
+    expect(graph.dependencies.get('src/components/App.tsx')).toEqual(['src/utils/format.tsx']);
+    expect(graph.reverseDependencies.get('src/utils/format.tsx')).toEqual([
+      'src/components/App.tsx',
+    ]);
+  });
+
+  it('replaces stale reverse dependencies when a module is updated', () => {
+    const graph = makeGraph();
+
+    updateModuleDependencyGraphFromToolResult(
+      graph,
+      'create_file',
+      {
+        path: 'src/App.tsx',
+        content: "import { oldValue } from './old';\nexport const app = oldValue;",
+      },
+      { success: true },
+    );
+    updateModuleDependencyGraphFromToolResult(
+      graph,
+      'apply_patch',
+      {
+        path: 'src/App.tsx',
+        content: "import { nextValue } from './next';\nexport const app = nextValue;",
+      },
+      { success: true },
+    );
+
+    expect(graph.dependencies.get('src/App.tsx')).toEqual(['src/next.tsx']);
+    expect(graph.reverseDependencies.has('src/old.tsx')).toBe(false);
+    expect(graph.reverseDependencies.get('src/next.tsx')).toEqual(['src/App.tsx']);
+  });
+
+  it('uses result content when params omit content', () => {
+    const graph = makeGraph();
+
+    updateModuleDependencyGraphFromToolResult(
+      graph,
+      'apply_patch',
+      { path: 'src/store/auth.ts' },
+      { success: true, content: 'export const authStore = {};' },
+    );
+
+    expect(graph.modules.get('src/store/auth.ts')).toMatchObject({
+      exports: ['authStore'],
+      type: 'store',
+    });
+  });
+});

--- a/packages/core/src/context/module-dependency-graph.ts
+++ b/packages/core/src/context/module-dependency-graph.ts
@@ -1,0 +1,77 @@
+import type { ModuleDependencyGraph, ModuleInfo } from '../types.js';
+import { inferModuleType, parseExports, parseImports, resolveImportPath } from './helpers.js';
+
+export interface ModuleGraphToolResult {
+  success?: boolean;
+  content?: string;
+  [key: string]: unknown;
+}
+
+const MODULE_FILE_EXTENSION_PATTERN = /\.(tsx?|jsx?|mjs|cjs)$/;
+
+export function updateModuleDependencyGraphFromToolResult(
+  moduleDependencyGraph: ModuleDependencyGraph,
+  toolName: string,
+  params: Record<string, unknown>,
+  result: ModuleGraphToolResult,
+): boolean {
+  if (!result.success) return false;
+  if (toolName !== 'create_file' && toolName !== 'apply_patch') return false;
+
+  const path = params.path as string;
+  const content = (params.content as string) || (result.content as string) || '';
+
+  if (!MODULE_FILE_EXTENSION_PATTERN.test(path)) return false;
+
+  const imports = parseImports(content);
+  const { exports: exportedSymbols, defaultExport } = parseExports(content);
+
+  const moduleInfo: ModuleInfo = {
+    path,
+    type: inferModuleType(path),
+    exports: exportedSymbols,
+    defaultExport,
+    imports,
+    createdAt: Date.now(),
+  };
+
+  moduleDependencyGraph.modules.set(path, moduleInfo);
+
+  const resolvedDeps = imports
+    .map((importPath) => resolveImportPath(importPath, path, ''))
+    .filter((resolved): resolved is string => Boolean(resolved));
+  moduleDependencyGraph.dependencies.set(path, resolvedDeps);
+
+  removeReverseDependenciesForModule(moduleDependencyGraph, path);
+  addReverseDependenciesForModule(moduleDependencyGraph, path, resolvedDeps);
+
+  return true;
+}
+
+function removeReverseDependenciesForModule(
+  moduleDependencyGraph: ModuleDependencyGraph,
+  path: string,
+): void {
+  for (const [depPath, reverseDeps] of moduleDependencyGraph.reverseDependencies.entries()) {
+    const nextReverseDeps = reverseDeps.filter((reversePath) => reversePath !== path);
+    if (nextReverseDeps.length > 0) {
+      moduleDependencyGraph.reverseDependencies.set(depPath, nextReverseDeps);
+    } else {
+      moduleDependencyGraph.reverseDependencies.delete(depPath);
+    }
+  }
+}
+
+function addReverseDependenciesForModule(
+  moduleDependencyGraph: ModuleDependencyGraph,
+  path: string,
+  resolvedDeps: string[],
+): void {
+  for (const dep of resolvedDeps) {
+    const reverseDeps = moduleDependencyGraph.reverseDependencies.get(dep) || [];
+    if (!reverseDeps.includes(path)) {
+      reverseDeps.push(path);
+      moduleDependencyGraph.reverseDependencies.set(dep, reverseDeps);
+    }
+  }
+}


### PR DESCRIPTION
## Linked Issue Or Context

Closes #199

## Summary

- Extracted ContextManager module dependency graph mutation into `updateModuleDependencyGraphFromToolResult`.
- Kept `ContextManager.updateModuleDependencyGraph` as the public API and delegated parsing/dependency/reverse-dependency updates to the helper.
- Added focused helper tests for ignored tool results, module metadata capture, result-content fallback, and stale reverse dependency replacement.

## Impact Scope

- Context module graph internals only.
- No MemoryStore, Planner, Executor, Agent, MCP boundary, or public API changes.

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: none; touched `packages/core/src/context/` helper/test files and one plan doc.
- GitNexus impact: `impact updateModuleDependencyGraph --direction upstream` reported 1 direct dependent (`packages/core/src/context/context-manager.test.ts`), 0 affected processes, 0 affected modules, LOW risk. `context updateModuleDependencyGraph` showed calls to context helper parsers/resolvers and `bumpFactsRevision`. `detect-changes --scope staged` reported 4 files, 2 indexed symbols (`ContextManager`, `updateModuleDependencyGraph`), 0 affected processes, low risk.
- Verification: `pnpm agent:bootstrap`; `pnpm quality:predev`; `pnpm exec vitest run packages/core/src/context/module-dependency-graph.test.ts packages/core/src/context/context-manager.test.ts`; `pnpm typecheck`; `pnpm quality:precommit`; push hook `pnpm quality:local` passed.

## Verification

- `pnpm exec vitest run packages/core/src/context/module-dependency-graph.test.ts packages/core/src/context/context-manager.test.ts`
- `pnpm typecheck`
- `pnpm quality:precommit`
- `pnpm quality:local` via pre-push hook

Note: `biome check .` reports an existing warning in `packages/core/src/llm/llm-service.test.ts:160` (`noExplicitAny`), but the lint command exits successfully.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.
