### PR TITLE
refactor: extract filesense index persistence helper

### DIFF
--- a/docs/superpowers/plans/2026-06-08-filesense-index-persistence.md
+++ b/docs/superpowers/plans/2026-06-08-filesense-index-persistence.md
@@ -1,0 +1,60 @@
+# Filesense Index Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the `mcp-filesense` directory index persistence decision from `engine.ts` into a focused helper module while preserving public Filesense behavior.
+
+**Architecture:** Keep high-blast-radius traversal and inference helpers in `engine.ts` unchanged. Add `packages/mcp-filesense/src/engine-indexing.ts` for the low-risk index persistence comparison/write path, and call it from the existing `writeDirectoryIndex` function.
+
+**Tech Stack:** TypeScript, Vitest, Node `fs` test workspaces, existing `@frontagent/mcp-filesense` package scripts.
+
+---
+
+## Scope
+
+- Modify: `packages/mcp-filesense/src/engine.ts`
+- Create: `packages/mcp-filesense/src/engine-indexing.ts`
+- Create: `packages/mcp-filesense/src/engine-indexing.test.ts`
+- Keep unchanged: core Agent/Executor/Planner files, MCP tool contracts, navigation behavior, high-impact helpers reported by GitNexus (`relativeToRoot`, `listTrackedEntries`, `inferSummary`, `writeJson`, `stableStringify`).
+
+## GitNexus Pre-Edit Impact
+
+- `init`: LOW, 0 direct dependents.
+- `syncIndexes`: LOW, direct dependents are `init`, `syncAndSummarize`, and `handleFilesenseTool`; one affected filesense tool process.
+- `writeDirectoryIndex`: LOW, direct caller is `syncIndexes`; affected process is `handleFilesenseTool`.
+- `comparableIndex`: LOW, direct caller is `writeDirectoryIndex`.
+- Not edited because impact is too broad: `relativeToRoot` CRITICAL; `listTrackedEntries`, `inferSummary`, `writeJson`, and `stableStringify` HIGH.
+
+## Tasks
+
+- [ ] Add a failing focused test in `packages/mcp-filesense/src/engine-indexing.test.ts` for `persistDirectoryIndex` returning `wroteIndex: false` and not calling the writer when the comparable index is unchanged.
+
+Run:
+
+```bash
+pnpm --filter @frontagent/mcp-filesense test -- src/engine-indexing.test.ts
+```
+
+Expected before implementation: FAIL because `./engine-indexing.js` does not exist.
+
+- [ ] Implement `persistDirectoryIndex` in `packages/mcp-filesense/src/engine-indexing.ts`.
+
+The helper accepts previous index data, next comparable index fields, `forceFull`, `filesHashed`, and an injected writer. It performs the stable comparable-index check, writes `IndexFile` only when needed, and preserves `last_full_sync` semantics.
+
+- [ ] Replace the comparison/write tail of `writeDirectoryIndex` in `packages/mcp-filesense/src/engine.ts` with a call to `persistDirectoryIndex`.
+
+Keep traversal, entry collection, hash reuse, summaries, and path helpers in place. Do not edit `relativeToRoot`, `listTrackedEntries`, `inferSummary`, `writeJson`, or `stableStringify`.
+
+- [ ] Run focused validation.
+
+```bash
+pnpm --filter @frontagent/mcp-filesense test -- src/engine-indexing.test.ts src/engine.test.ts
+pnpm --filter @frontagent/mcp-filesense typecheck
+```
+
+- [ ] Run final repository gates and GitNexus diff inspection.
+
+```bash
+pnpm quality:precommit
+npx gitnexus detect-changes -r FrontAgent
+```

--- a/packages/mcp-filesense/src/engine-indexing.test.ts
+++ b/packages/mcp-filesense/src/engine-indexing.test.ts
@@ -3,22 +3,23 @@ import { persistDirectoryIndex } from './engine-indexing.js';
 import type { IndexFile } from './types.js';
 
 describe('persistDirectoryIndex', () => {
+  const previous: IndexFile = {
+    $schema: '../schemas/FILES.schema.json',
+    schema_version: '1.0',
+    generated_at: '2026-06-08T00:00:00.000Z',
+    root_relative_path: '.',
+    directory: { name: 'workspace', path: '.' },
+    children: [],
+    sync: {
+      child_count: 0,
+      file_count: 0,
+      dir_count: 0,
+      last_full_sync: '2026-06-08T00:00:00.000Z',
+      last_incremental_sync: '2026-06-08T00:00:00.000Z',
+    },
+  };
+
   it('skips writing when the comparable index is unchanged', async () => {
-    const previous: IndexFile = {
-      $schema: '../schemas/FILES.schema.json',
-      schema_version: '1.0',
-      generated_at: '2026-06-08T00:00:00.000Z',
-      root_relative_path: '.',
-      directory: { name: 'workspace', path: '.' },
-      children: [],
-      sync: {
-        child_count: 0,
-        file_count: 0,
-        dir_count: 0,
-        last_full_sync: '2026-06-08T00:00:00.000Z',
-        last_incremental_sync: '2026-06-08T00:00:00.000Z',
-      },
-    };
     const writes: Array<{ targetPath: string; value: unknown }> = [];
 
     const result = await persistDirectoryIndex({
@@ -46,5 +47,115 @@ describe('persistDirectoryIndex', () => {
 
     expect(result).toEqual({ filesHashed: 0, wroteIndex: false });
     expect(writes).toHaveLength(0);
+  });
+
+  it('writes a full index and preserves previous full sync during incremental sync', async () => {
+    const writes: Array<{ targetPath: string; value: IndexFile }> = [];
+
+    const result = await persistDirectoryIndex({
+      indexPath: '/workspace/FILES.json',
+      previous,
+      nextComparable: {
+        $schema: previous.$schema,
+        schema_version: previous.schema_version,
+        root_relative_path: previous.root_relative_path,
+        directory: previous.directory,
+        children: [
+          {
+            name: 'app.ts',
+            type: 'file',
+            path: 'app.ts',
+            ext: '.ts',
+            size: 18,
+            mtimeMs: 10,
+            hash: 'sha1:abc',
+            summary: 'TypeScript source file',
+            importance: 'normal',
+            status: 'active',
+          },
+        ],
+        sync: {
+          child_count: 1,
+          file_count: 1,
+          dir_count: 0,
+        },
+      },
+      forceFull: false,
+      filesHashed: 1,
+      writeJson: async (targetPath, value) => {
+        writes.push({ targetPath, value: value as IndexFile });
+      },
+      now: () => '2026-06-08T01:00:00.000Z',
+    });
+
+    expect(result).toEqual({ filesHashed: 1, wroteIndex: true });
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toEqual({
+      targetPath: '/workspace/FILES.json',
+      value: {
+        $schema: previous.$schema,
+        schema_version: previous.schema_version,
+        generated_at: '2026-06-08T01:00:00.000Z',
+        root_relative_path: previous.root_relative_path,
+        directory: previous.directory,
+        children: [
+          {
+            name: 'app.ts',
+            type: 'file',
+            path: 'app.ts',
+            ext: '.ts',
+            size: 18,
+            mtimeMs: 10,
+            hash: 'sha1:abc',
+            summary: 'TypeScript source file',
+            importance: 'normal',
+            status: 'active',
+          },
+        ],
+        sync: {
+          child_count: 1,
+          file_count: 1,
+          dir_count: 0,
+          last_full_sync: '2026-06-08T00:00:00.000Z',
+          last_incremental_sync: '2026-06-08T01:00:00.000Z',
+        },
+      },
+    });
+  });
+
+  it('sets full and incremental sync timestamps on forced first writes', async () => {
+    const writes: IndexFile[] = [];
+
+    const result = await persistDirectoryIndex({
+      indexPath: '/workspace/FILES.json',
+      previous: null,
+      nextComparable: {
+        $schema: previous.$schema,
+        schema_version: previous.schema_version,
+        root_relative_path: previous.root_relative_path,
+        directory: previous.directory,
+        children: [],
+        sync: {
+          child_count: 0,
+          file_count: 0,
+          dir_count: 0,
+        },
+      },
+      forceFull: true,
+      filesHashed: 0,
+      writeJson: async (_targetPath, value) => {
+        writes.push(value as IndexFile);
+      },
+      now: () => '2026-06-08T02:00:00.000Z',
+    });
+
+    expect(result).toEqual({ filesHashed: 0, wroteIndex: true });
+    expect(writes[0]?.sync).toEqual({
+      child_count: 0,
+      file_count: 0,
+      dir_count: 0,
+      last_full_sync: '2026-06-08T02:00:00.000Z',
+      last_incremental_sync: '2026-06-08T02:00:00.000Z',
+    });
   });
 });

--- a/packages/mcp-filesense/src/engine-indexing.test.ts
+++ b/packages/mcp-filesense/src/engine-indexing.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { persistDirectoryIndex } from './engine-indexing.js';
+import type { IndexFile } from './types.js';
+
+describe('persistDirectoryIndex', () => {
+  it('skips writing when the comparable index is unchanged', async () => {
+    const previous: IndexFile = {
+      $schema: '../schemas/FILES.schema.json',
+      schema_version: '1.0',
+      generated_at: '2026-06-08T00:00:00.000Z',
+      root_relative_path: '.',
+      directory: { name: 'workspace', path: '.' },
+      children: [],
+      sync: {
+        child_count: 0,
+        file_count: 0,
+        dir_count: 0,
+        last_full_sync: '2026-06-08T00:00:00.000Z',
+        last_incremental_sync: '2026-06-08T00:00:00.000Z',
+      },
+    };
+    const writes: Array<{ targetPath: string; value: unknown }> = [];
+
+    const result = await persistDirectoryIndex({
+      indexPath: '/workspace/FILES.json',
+      previous,
+      nextComparable: {
+        $schema: previous.$schema,
+        schema_version: previous.schema_version,
+        root_relative_path: previous.root_relative_path,
+        directory: previous.directory,
+        children: previous.children,
+        sync: {
+          child_count: previous.sync.child_count,
+          file_count: previous.sync.file_count,
+          dir_count: previous.sync.dir_count,
+        },
+      },
+      forceFull: false,
+      filesHashed: 0,
+      writeJson: async (targetPath, value) => {
+        writes.push({ targetPath, value });
+      },
+      now: () => '2026-06-08T01:00:00.000Z',
+    });
+
+    expect(result).toEqual({ filesHashed: 0, wroteIndex: false });
+    expect(writes).toHaveLength(0);
+  });
+});

--- a/packages/mcp-filesense/src/engine-indexing.test.ts
+++ b/packages/mcp-filesense/src/engine-indexing.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { persistDirectoryIndex } from './engine-indexing.js';
 import type { IndexFile } from './types.js';
 
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value);
+}
+
 describe('persistDirectoryIndex', () => {
   const previous: IndexFile = {
     $schema: '../schemas/FILES.schema.json',
@@ -39,6 +43,7 @@ describe('persistDirectoryIndex', () => {
       },
       forceFull: false,
       filesHashed: 0,
+      stableStringify,
       writeJson: async (targetPath, value) => {
         writes.push({ targetPath, value });
       },
@@ -82,6 +87,7 @@ describe('persistDirectoryIndex', () => {
       },
       forceFull: false,
       filesHashed: 1,
+      stableStringify,
       writeJson: async (targetPath, value) => {
         writes.push({ targetPath, value: value as IndexFile });
       },
@@ -143,6 +149,7 @@ describe('persistDirectoryIndex', () => {
       },
       forceFull: true,
       filesHashed: 0,
+      stableStringify,
       writeJson: async (_targetPath, value) => {
         writes.push(value as IndexFile);
       },

--- a/packages/mcp-filesense/src/engine-indexing.ts
+++ b/packages/mcp-filesense/src/engine-indexing.ts
@@ -15,6 +15,7 @@ export interface PersistDirectoryIndexOptions {
   nextComparable: ComparableIndex;
   forceFull: boolean;
   filesHashed: number;
+  stableStringify: (value: unknown) => string;
   writeJson: (targetPath: string, value: unknown) => Promise<void>;
   now?: () => string;
 }
@@ -34,26 +35,13 @@ function comparableIndex(index: IndexFile): ComparableIndex {
   };
 }
 
-function stableStringify(value: unknown): string {
-  return JSON.stringify(sortKeys(value));
-}
-
-function sortKeys(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(sortKeys);
-  if (typeof value !== 'object' || value === null) return value;
-  const output: Record<string, unknown> = {};
-  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-    output[key] = sortKeys((value as Record<string, unknown>)[key]);
-  }
-  return output;
-}
-
 export async function persistDirectoryIndex({
   indexPath,
   previous,
   nextComparable,
   forceFull,
   filesHashed,
+  stableStringify,
   writeJson,
   now = () => new Date().toISOString(),
 }: PersistDirectoryIndexOptions): Promise<{ filesHashed: number; wroteIndex: boolean }> {

--- a/packages/mcp-filesense/src/engine-indexing.ts
+++ b/packages/mcp-filesense/src/engine-indexing.ts
@@ -1,0 +1,86 @@
+import type { ChildEntry, IndexFile } from './types.js';
+
+export interface ComparableIndex {
+  $schema?: string;
+  schema_version: string;
+  root_relative_path: string;
+  directory: { name: string; path: string };
+  children: ChildEntry[];
+  sync: { child_count: number; file_count: number; dir_count: number };
+}
+
+export interface PersistDirectoryIndexOptions {
+  indexPath: string;
+  previous: IndexFile | null;
+  nextComparable: ComparableIndex;
+  forceFull: boolean;
+  filesHashed: number;
+  writeJson: (targetPath: string, value: unknown) => Promise<void>;
+  now?: () => string;
+}
+
+function comparableIndex(index: IndexFile): ComparableIndex {
+  return {
+    $schema: index.$schema,
+    schema_version: index.schema_version,
+    root_relative_path: index.root_relative_path,
+    directory: index.directory,
+    children: index.children,
+    sync: {
+      child_count: index.sync.child_count,
+      file_count: index.sync.file_count,
+      dir_count: index.sync.dir_count,
+    },
+  };
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortKeys(value));
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (typeof value !== 'object' || value === null) return value;
+  const output: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    output[key] = sortKeys((value as Record<string, unknown>)[key]);
+  }
+  return output;
+}
+
+export async function persistDirectoryIndex({
+  indexPath,
+  previous,
+  nextComparable,
+  forceFull,
+  filesHashed,
+  writeJson,
+  now = () => new Date().toISOString(),
+}: PersistDirectoryIndexOptions): Promise<{ filesHashed: number; wroteIndex: boolean }> {
+  const previousComparable = previous ? comparableIndex(previous) : null;
+
+  if (
+    previousComparable &&
+    stableStringify(previousComparable) === stableStringify(nextComparable)
+  ) {
+    return { filesHashed, wroteIndex: false };
+  }
+
+  const timestamp = now();
+  const nextIndex: IndexFile = {
+    $schema: nextComparable.$schema,
+    schema_version: nextComparable.schema_version,
+    generated_at: timestamp,
+    root_relative_path: nextComparable.root_relative_path,
+    directory: nextComparable.directory,
+    children: nextComparable.children,
+    sync: {
+      ...nextComparable.sync,
+      last_full_sync: forceFull ? timestamp : (previous?.sync.last_full_sync ?? null),
+      last_incremental_sync: timestamp,
+    },
+  };
+
+  await writeJson(indexPath, nextIndex);
+  return { filesHashed, wroteIndex: true };
+}

--- a/packages/mcp-filesense/src/engine.ts
+++ b/packages/mcp-filesense/src/engine.ts
@@ -7,6 +7,7 @@ import { createHash } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { inferDirectoryPurpose, inferImportance, scoreCandidate } from './engine-helpers.js';
+import { type ComparableIndex, persistDirectoryIndex } from './engine-indexing.js';
 import type {
   CheckSummary,
   ChildEntry,
@@ -457,30 +458,6 @@ function buildNotesFile(
 
 // ─── Core Operations ───────────────────────────────────────────────────────────
 
-interface ComparableIndex {
-  $schema?: string;
-  schema_version: string;
-  root_relative_path: string;
-  directory: { name: string; path: string };
-  children: ChildEntry[];
-  sync: { child_count: number; file_count: number; dir_count: number };
-}
-
-function comparableIndex(index: IndexFile): ComparableIndex {
-  return {
-    $schema: index.$schema,
-    schema_version: index.schema_version,
-    root_relative_path: index.root_relative_path,
-    directory: index.directory,
-    children: index.children,
-    sync: {
-      child_count: index.sync.child_count,
-      file_count: index.sync.file_count,
-      dir_count: index.sync.dir_count,
-    },
-  };
-}
-
 async function writeDirectoryIndex(
   root: string,
   dirPath: string,
@@ -544,7 +521,6 @@ async function writeDirectoryIndex(
   children.sort((a, b) => a.name.localeCompare(b.name));
   const relativePath = relativeToRoot(root, dirPath);
   const nextSchema = relativeSchemaRef(dirPath, schemaPathsForRoot(root, config).indexSchemaPath);
-  const previousComparable = previous ? comparableIndex(previous) : null;
   const nextComparable: ComparableIndex = {
     $schema: nextSchema,
     schema_version: config.schemaVersion,
@@ -558,30 +534,14 @@ async function writeDirectoryIndex(
     },
   };
 
-  if (
-    previousComparable &&
-    stableStringify(previousComparable) === stableStringify(nextComparable)
-  ) {
-    return { filesHashed, wroteIndex: false };
-  }
-
-  const timestamp = new Date().toISOString();
-  const nextIndex: IndexFile = {
-    $schema: nextSchema,
-    schema_version: config.schemaVersion,
-    generated_at: timestamp,
-    root_relative_path: relativePath,
-    directory: { name: path.basename(dirPath), path: relativePath },
-    children,
-    sync: {
-      ...nextComparable.sync,
-      last_full_sync: forceFull ? timestamp : (previous?.sync.last_full_sync ?? null),
-      last_incremental_sync: timestamp,
-    },
-  };
-
-  await writeJson(indexPath, nextIndex);
-  return { filesHashed, wroteIndex: true };
+  return persistDirectoryIndex({
+    indexPath,
+    previous,
+    nextComparable,
+    forceFull,
+    filesHashed,
+    writeJson,
+  });
 }
 
 // ─── Public API ────────────────────────────────────────────────────────────────

--- a/packages/mcp-filesense/src/engine.ts
+++ b/packages/mcp-filesense/src/engine.ts
@@ -540,6 +540,7 @@ async function writeDirectoryIndex(
     nextComparable,
     forceFull,
     filesHashed,
+    stableStringify,
     writeJson,
   });
 }


### PR DESCRIPTION
## Linked Issue Or Context

Closes #203

## Summary

- Extracted the Filesense directory index comparison/write path into `packages/mcp-filesense/src/engine-indexing.ts`.
- Kept traversal, navigation, summary inference, and high-impact helpers in `engine.ts` unchanged; `persistDirectoryIndex` now receives the existing canonical `stableStringify` from `engine.ts` instead of duplicating stable serialization logic.
- Added focused helper tests covering unchanged no-write, incremental write timestamp preservation, and forced first-write timestamps.

## Impact Scope

- Scoped to `packages/mcp-filesense/src/engine.ts`, `packages/mcp-filesense/src/engine-indexing.ts`, matching helper test, and the required implementation plan under `docs/superpowers/plans`.
- Public Filesense MCP tool contracts are preserved; `syncIndexes` still returns the same summary shape and `writeDirectoryIndex` still controls child collection/hash reuse while delegating persistence with the existing serializer injected.

## GitNexus Impact Summary

- Risk level: MEDIUM
- Critical skeleton changes: mcp-boundary files under `packages/mcp-filesense/src/` only; no core Agent/Executor/Planner changes.
- GitNexus impact: pre-edit impact was LOW for `init`, `syncIndexes`, `writeDirectoryIndex`, and `comparableIndex`; `relativeToRoot` was CRITICAL and `listTrackedEntries`, `inferSummary`, `writeJson`, and `stableStringify` were HIGH, so those helpers were not edited. `gitnexus query` surfaced Filesense `handleFilesenseTool` flows. `gitnexus context` showed `writeDirectoryIndex` is called by `syncIndexes`. `gitnexus detect_changes (detect-changes) --scope compare --base-ref origin/develop` reported 4 files, 1 changed symbol (`writeDirectoryIndex`), 1 affected flow (`WriteDirectoryIndex -> RelativeToRoot`), risk MEDIUM.
- Verification: `pnpm agent:bootstrap`, `pnpm quality:predev`, focused mcp-filesense tests/typecheck, `pnpm quality:precommit`, and `pnpm quality:local` passed.

## Verification

- `pnpm --filter @frontagent/mcp-filesense test -- src/engine-indexing.test.ts` failed first as expected before implementation because `./engine-indexing.js` was missing.
- `pnpm --filter @frontagent/mcp-filesense test -- src/engine-indexing.test.ts` passed after helper implementation.
- `pnpm --filter @frontagent/mcp-filesense test -- src/engine-indexing.test.ts src/engine.test.ts` passed: 25 tests.
- `pnpm --filter @frontagent/mcp-filesense typecheck` passed.
- `pnpm quality:precommit` passed; Biome still reports an existing unrelated warning in `packages/core/src/llm/llm-service.test.ts:160`.
- `pnpm quality:local` passed, including local Contract Guard, CI-equivalent tests, build, and VSIX packaging; the same unrelated Biome warning remains non-fatal.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.