### PR TITLE
Extract VS Code webview style section renderer

### DIFF
--- a/apps/vscode/src/webview-html.test.ts
+++ b/apps/vscode/src/webview-html.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getWebviewHtml, nonce } from './webview-html.js';
+import { getWebviewHtml, nonce, renderWebviewStyleSection } from './webview-html.js';
 
 describe('VS Code webview HTML nonce handling', () => {
   it('generates base64url nonces from cryptographic bytes', () => {
@@ -23,5 +23,14 @@ describe('VS Code webview HTML nonce handling', () => {
     expect(styleNonce).not.toBe(scriptNonce);
     expect(csp).toContain(`style-src vscode-webview://frontagent.test 'nonce-${styleNonce}'`);
     expect(csp).toContain(`script-src 'nonce-${scriptNonce}'`);
+  });
+
+  it('renders the style section through a focused renderer', () => {
+    const html = getWebviewHtml({ cspSource: 'vscode-webview://frontagent.test' } as never);
+    const styleNonce = html.match(/<style nonce="([^"]+)"/)?.[1];
+    const styleSection = html.match(/ {2}<style nonce="[^"]+">[\s\S]*? {2}<\/style>/)?.[0];
+
+    expect(styleNonce).toBeDefined();
+    expect(styleSection).toBe(renderWebviewStyleSection(styleNonce ?? ''));
   });
 });

--- a/apps/vscode/src/webview-html.ts
+++ b/apps/vscode/src/webview-html.ts
@@ -9,22 +9,8 @@ export function nonce(): string {
     .replace(/=+$/, '');
 }
 
-export function getWebviewHtml(webview: vscode.Webview): string {
-  const scriptNonce = nonce();
-  const styleNonce = nonce();
-  const csp = [
-    `default-src 'none'`,
-    `style-src ${webview.cspSource} 'nonce-${styleNonce}'`,
-    `script-src 'nonce-${scriptNonce}'`,
-  ].join('; ');
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="${csp}">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <style nonce="${styleNonce}">
+export function renderWebviewStyleSection(styleNonce: string): string {
+  return `  <style nonce="${styleNonce}">
     :root {
       color-scheme: light dark;
       --gap: 10px;
@@ -503,7 +489,25 @@ export function getWebviewHtml(webview: vscode.Webview): string {
         46%, 100% { opacity: 0; }
       }
     }
-  </style>
+  </style>`;
+}
+
+export function getWebviewHtml(webview: vscode.Webview): string {
+  const scriptNonce = nonce();
+  const styleNonce = nonce();
+  const csp = [
+    `default-src 'none'`,
+    `style-src ${webview.cspSource} 'nonce-${styleNonce}'`,
+    `script-src 'nonce-${scriptNonce}'`,
+  ].join('; ');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="${csp}">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+${renderWebviewStyleSection(styleNonce)}
 </head>
 <body>
   <div class="shell">

--- a/docs/superpowers/plans/2026-06-08-vscode-webview-section-renderers.md
+++ b/docs/superpowers/plans/2026-06-08-vscode-webview-section-renderers.md
@@ -1,0 +1,97 @@
+# VS Code Webview Section Renderers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve Issue #202 by extracting one cohesive VS Code webview HTML section renderer while preserving current rendered output and CSP nonce behavior.
+
+**Architecture:** Keep `getWebviewHtml(webview)` as the public HTML entry point. Extract only the CSS `<style>` section into `renderWebviewStyleSection(styleNonce)` in `apps/vscode/src/webview-html.ts`, so nonce wiring remains explicit and future CSS changes can be reviewed independently.
+
+**Tech Stack:** TypeScript, VS Code webview HTML, Vitest.
+
+---
+
+### Task 1: Add a Focused Renderer Contract Test
+
+**Files:**
+- Modify: `apps/vscode/src/webview-html.test.ts`
+- Read: `apps/vscode/src/webview-html.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add an import for `renderWebviewStyleSection`, then add this test in the existing `describe` block:
+
+```ts
+it('renders the style section through a focused renderer', () => {
+  const html = getWebviewHtml({ cspSource: 'vscode-webview://frontagent.test' } as never);
+  const styleNonce = html.match(/<style nonce="([^"]+)"/)?.[1];
+  const styleSection = html.match(/  <style nonce="[^"]+">[\s\S]*?  <\/style>/)?.[0];
+
+  expect(styleNonce).toBeDefined();
+  expect(styleSection).toBe(renderWebviewStyleSection(styleNonce ?? ''));
+});
+```
+
+- [ ] **Step 2: Run focused test and verify RED**
+
+Run: `pnpm --dir apps/vscode test src/webview-html.test.ts`
+Expected: FAIL because `renderWebviewStyleSection` is not exported yet.
+
+### Task 2: Extract the CSS Section Renderer
+
+**Files:**
+- Modify: `apps/vscode/src/webview-html.ts`
+- Test: `apps/vscode/src/webview-html.test.ts`
+
+- [ ] **Step 1: Add the renderer**
+
+Move the existing `<style nonce="${styleNonce}">...</style>` string into:
+
+```ts
+export function renderWebviewStyleSection(styleNonce: string): string {
+  return `  <style nonce="${styleNonce}">
+    ...
+  </style>`;
+}
+```
+
+- [ ] **Step 2: Replace the inline section**
+
+In `getWebviewHtml`, replace only the original inline style section with:
+
+```ts
+${renderWebviewStyleSection(styleNonce)}
+```
+
+- [ ] **Step 3: Run focused test and verify GREEN**
+
+Run: `pnpm --dir apps/vscode test src/webview-html.test.ts`
+Expected: PASS.
+
+### Task 3: Verify and Prepare PR
+
+**Files:**
+- Read: final diff only
+
+- [ ] **Step 1: Run scoped and required gates**
+
+Run:
+
+```bash
+pnpm --dir apps/vscode test
+pnpm typecheck
+pnpm quality:precommit
+```
+
+- [ ] **Step 2: Run GitNexus detect changes**
+
+Run:
+
+```bash
+npx gitnexus detect-changes --repo "/Users/ceilf6/Desktop/myrepos/Wiki/AI/3-Application/FrontAgent-app" --scope all
+```
+
+Expected: scoped changes in `apps/vscode/src/webview-html.ts`, `apps/vscode/src/webview-html.test.ts`, and this plan.
+
+- [ ] **Step 3: Open PR**
+
+Push `improve/vscode-webview-section-renderers` and open a PR to `develop` with `Closes #202` and the GitNexus impact summary.


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #202

## Summary

- Extracted the VS Code webview `<style>` section into `renderWebviewStyleSection(styleNonce)`.
- Kept `getWebviewHtml(webview)` as the public entry point and preserved the existing CSP nonce wiring.
- Added a focused webview test asserting the generated HTML style section is rendered by the section helper.
- Added the required plan document under `docs/superpowers/plans/`.

## Impact Scope

- Scoped to VS Code webview HTML generation and its focused tests.
- No visual redesign, no script/body behavior changes, and no generated HTML nonce behavior changes.

## GitNexus Impact Summary

- Risk level: MEDIUM for staged diff; pre-edit symbol impact for `getWebviewHtml` was LOW.
- Critical skeleton changes: No.
- GitNexus impact: Before editing, `getWebviewHtml` upstream impact reported 1 direct affected file (`apps/vscode/src/webview-html.test.ts`) and no affected processes/modules. Final staged `detect_changes` (`detect-changes`) reported 3 files, 6 symbols, 2 affected flows: `ResolveWebviewView -> Nonce` and `ResolveWebviewView -> RenderWebviewStyleSection`.
- Verification: GitNexus index was refreshed to commit `e21e0ba`; staged detect_changes (`detect-changes`) was run with `--scope staged` against this worktree.

## Verification

- `pnpm agent:bootstrap`
- `pnpm quality:predev`
- `pnpm --dir apps/vscode test src/webview-html.test.ts` (RED before implementation, GREEN after)
- `pnpm --dir apps/vscode test`
- `pnpm typecheck`
- `pnpm quality:precommit`
- `npx gitnexus detect-changes --repo "/Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-vscode-webview-section-renderers" --scope staged`
- `git push` pre-push hook ran `pnpm quality:local`, including `pnpm quality:ci` and VSIX packaging

Note: `pnpm lint` reports one pre-existing warning in `packages/core/src/llm/llm-service.test.ts:160` (`noExplicitAny`); no webview lint warnings remain.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

