### PR TITLE
refactor: extract executor progress enforcement

### DIFF
--- a/docs/superpowers/plans/2026-06-08-executor-progress-enforcement.md
+++ b/docs/superpowers/plans/2026-06-08-executor-progress-enforcement.md
@@ -1,0 +1,78 @@
+# Executor Progress Enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract native `Executor.executeSteps` progress enforcement into a focused executor helper while preserving public API and execution behavior.
+
+**Architecture:** Keep `Executor` responsible for public orchestration and step execution, and move dependency readiness, status transitions, callback dispatch, completed-step tracking, and rollback skipping into `packages/core/src/executor/progress-enforcement.ts`. The helper receives an `executeStep` dependency so it has no MCP, security, trace, or skills knowledge.
+
+**Tech Stack:** TypeScript, Vitest, existing executor types from `@frontagent/shared` and `packages/core/src/types.ts`.
+
+---
+
+### Task 1: Lock Progress Enforcement Behavior
+
+**Files:**
+- Create: `packages/core/src/executor/progress-enforcement.test.ts`
+
+- [ ] **Step 1: Add focused helper tests**
+
+Create tests for dependency-ready ordering, status/result updates, callback ordering, rollback skip behavior, and missing dependency errors.
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run: `pnpm --dir packages/core exec vitest run src/executor/progress-enforcement.test.ts`
+
+Expected: FAIL because `packages/core/src/executor/progress-enforcement.ts` does not exist yet.
+
+### Task 2: Extract Progress Enforcement Helper
+
+**Files:**
+- Create: `packages/core/src/executor/progress-enforcement.ts`
+- Modify: `packages/core/src/executor/executor.ts`
+
+- [ ] **Step 1: Create the helper**
+
+Create `packages/core/src/executor/progress-enforcement.ts` with `executeStepsWithProgressEnforcement`. The helper owns the native sequential progress loop: `pendingSteps`, dependency readiness, `running`/`completed`/`failed` transitions, result assignment, callback invocation, completed-step tracking, and rollback-driven pending step skips.
+
+- [ ] **Step 2: Delegate from Executor**
+
+In `packages/core/src/executor/executor.ts`, import the helper and replace the body of `executeSteps` with a delegation that passes `this.executeStep`.
+
+- [ ] **Step 3: Run focused tests**
+
+Run: `pnpm --dir packages/core exec vitest run src/executor/progress-enforcement.test.ts src/executor/executor.test.ts`
+
+Expected: PASS.
+
+### Task 3: Final Verification And PR Prep
+
+**Files:**
+- Verify: `packages/core/src/executor/executor.ts`
+- Verify: `packages/core/src/executor/progress-enforcement.ts`
+- Verify: `packages/core/src/executor/progress-enforcement.test.ts`
+- Verify: `docs/superpowers/plans/2026-06-08-executor-progress-enforcement.md`
+
+- [ ] **Step 1: Run executor-focused tests**
+
+Run: `pnpm --dir packages/core exec vitest run src/executor/progress-enforcement.test.ts src/executor/executor.test.ts src/executor/phase-runner.test.ts src/executor/step-feedback-runner.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run precommit gate**
+
+Run: `pnpm quality:precommit`
+
+Expected: PASS.
+
+- [ ] **Step 4: Inspect GitNexus final diff**
+
+Run: `npx gitnexus detect-changes --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-executor-progress-enforcement --scope all`
+
+Expected: changed symbols are limited to executor progress helper, `Executor.executeSteps`, focused executor tests, and the plan document.

--- a/packages/core/src/executor/executor.ts
+++ b/packages/core/src/executor/executor.ts
@@ -17,6 +17,7 @@ import {
 import type { ExecutorOutput } from '../types.js';
 import { buildOrderedPhaseGroups, detectLanguage } from './phase-ordering.js';
 import { PhaseRunner } from './phase-runner.js';
+import { executeStepsWithProgressEnforcement } from './progress-enforcement.js';
 import { executeStepsWithErrorFeedbackViaLangGraph } from './step-feedback-runner.js';
 import type {
   ExecutorCollectedContext,
@@ -765,43 +766,12 @@ export class Executor {
     },
     onStepComplete?: (step: ExecutionStep, output: ExecutorOutput) => void,
   ): Promise<ExecutorOutput[]> {
-    const results: ExecutorOutput[] = [];
-    const completedSteps = new Set<string>();
-
-    const pendingSteps = [...steps];
-
-    while (pendingSteps.length > 0) {
-      const executableIndex = pendingSteps.findIndex((step) =>
-        step.dependencies.every((dep) => completedSteps.has(dep)),
-      );
-
-      if (executableIndex === -1) {
-        throw new Error('Circular dependency detected or missing dependency');
-      }
-
-      const step = pendingSteps.splice(executableIndex, 1)[0];
-      step.status = 'running';
-
-      const output = await this.executeStep(step, context);
-      step.result = output.stepResult;
-      step.status = output.stepResult.success ? 'completed' : 'failed';
-
-      results.push(output);
-      completedSteps.add(step.stepId);
-
-      if (onStepComplete) {
-        onStepComplete(step, output);
-      }
-
-      if (!output.stepResult.success && output.needsRollback) {
-        for (const pending of pendingSteps) {
-          pending.status = 'skipped';
-        }
-        break;
-      }
-    }
-
-    return results;
+    return executeStepsWithProgressEnforcement(
+      steps,
+      context,
+      { executeStep: (step, executionContext) => this.executeStep(step, executionContext) },
+      onStepComplete,
+    );
   }
 
   private shouldUseLangGraphEngine(): boolean {

--- a/packages/core/src/executor/progress-enforcement.test.ts
+++ b/packages/core/src/executor/progress-enforcement.test.ts
@@ -1,0 +1,100 @@
+import type { ExecutionStep } from '@frontagent/shared';
+import { describe, expect, it, vi } from 'vitest';
+import type { ExecutorOutput } from '../types.js';
+import { executeStepsWithProgressEnforcement } from './progress-enforcement.js';
+
+function makeStep(overrides: Partial<ExecutionStep> = {}): ExecutionStep {
+  return {
+    stepId: 'step-1',
+    description: 'Test step',
+    action: 'read_file',
+    tool: 'read_file',
+    params: {},
+    dependencies: [],
+    validation: [],
+    status: 'pending',
+    phase: 'build',
+    ...overrides,
+  };
+}
+
+function makeOutput(overrides: Partial<ExecutorOutput> = {}): ExecutorOutput {
+  return {
+    stepResult: {
+      success: true,
+      output: {},
+      duration: 1,
+    },
+    validation: { pass: true, results: [] },
+    needsRollback: false,
+    ...overrides,
+  };
+}
+
+describe('executeStepsWithProgressEnforcement', () => {
+  it('executes dependency-ready steps and reports completion in execution order', async () => {
+    const first = makeStep({ stepId: 's1' });
+    const second = makeStep({ stepId: 's2', dependencies: ['s1'] });
+    const executeStep = vi.fn().mockResolvedValue(makeOutput());
+    const onStepComplete = vi.fn();
+
+    const results = await executeStepsWithProgressEnforcement(
+      [second, first],
+      {
+        task: { id: 't1', type: 'create', description: 'test' },
+        collectedContext: { files: new Map() },
+      },
+      { executeStep },
+      onStepComplete,
+    );
+
+    expect(results).toHaveLength(2);
+    expect(executeStep.mock.calls.map(([step]) => step.stepId)).toEqual(['s1', 's2']);
+    expect(first.status).toBe('completed');
+    expect(second.status).toBe('completed');
+    expect(onStepComplete.mock.calls.map(([step]) => step.stepId)).toEqual(['s1', 's2']);
+  });
+
+  it('marks remaining pending steps as skipped when rollback is needed', async () => {
+    const failed = makeStep({ stepId: 's1' });
+    const pending = makeStep({ stepId: 's2', dependencies: ['s1'] });
+    const failingOutput = makeOutput({
+      stepResult: {
+        success: false,
+        error: 'failed',
+        duration: 1,
+      },
+      validation: { pass: false, results: [], blockedBy: ['failed'] },
+      needsRollback: true,
+    });
+    const executeStep = vi.fn().mockResolvedValue(failingOutput);
+
+    const results = await executeStepsWithProgressEnforcement(
+      [failed, pending],
+      {
+        task: { id: 't1', type: 'create', description: 'test' },
+        collectedContext: { files: new Map() },
+      },
+      { executeStep },
+    );
+
+    expect(results).toEqual([failingOutput]);
+    expect(failed.status).toBe('failed');
+    expect(pending.status).toBe('skipped');
+  });
+
+  it('throws when no pending step has satisfied dependencies', async () => {
+    const step = makeStep({ stepId: 's1', dependencies: ['missing'] });
+
+    await expect(
+      executeStepsWithProgressEnforcement(
+        [step],
+        {
+          task: { id: 't1', type: 'create', description: 'test' },
+          collectedContext: { files: new Map() },
+        },
+        { executeStep: vi.fn() },
+      ),
+    ).rejects.toThrow('Circular dependency detected or missing dependency');
+  });
+});

--- a/packages/core/src/executor/progress-enforcement.ts
+++ b/packages/core/src/executor/progress-enforcement.ts
@@ -1,0 +1,51 @@
+import type { AgentTask, ExecutionStep } from '@frontagent/shared';
+import type { ExecutorOutput } from '../types.js';
+import type { ExecutorCollectedContext } from './types.js';
+
+export interface ExecuteStepsWithProgressDeps {
+  executeStep(
+    step: ExecutionStep,
+    context: { task: AgentTask; collectedContext: ExecutorCollectedContext },
+  ): Promise<ExecutorOutput>;
+}
+
+export async function executeStepsWithProgressEnforcement(
+  steps: ExecutionStep[],
+  context: { task: AgentTask; collectedContext: ExecutorCollectedContext },
+  deps: ExecuteStepsWithProgressDeps,
+  onStepComplete?: (step: ExecutionStep, output: ExecutorOutput) => void,
+): Promise<ExecutorOutput[]> {
+  const results: ExecutorOutput[] = [];
+  const completedSteps = new Set<string>();
+  const pendingSteps = [...steps];
+
+  while (pendingSteps.length > 0) {
+    const executableIndex = pendingSteps.findIndex((step) =>
+      step.dependencies.every((dep) => completedSteps.has(dep)),
+    );
+
+    if (executableIndex === -1) {
+      throw new Error('Circular dependency detected or missing dependency');
+    }
+
+    const step = pendingSteps.splice(executableIndex, 1)[0];
+    step.status = 'running';
+
+    const output = await deps.executeStep(step, context);
+    step.result = output.stepResult;
+    step.status = output.stepResult.success ? 'completed' : 'failed';
+
+    results.push(output);
+    completedSteps.add(step.stepId);
+    onStepComplete?.(step, output);
+
+    if (!output.stepResult.success && output.needsRollback) {
+      for (const pending of pendingSteps) {
+        pending.status = 'skipped';
+      }
+      break;
+    }
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Linked Issue Or Context

Closes #201

## Summary

- Extracted native `Executor.executeSteps` progress enforcement into `packages/core/src/executor/progress-enforcement.ts`.
- Kept the public `Executor` API and execution behavior unchanged by delegating from `Executor.executeSteps`.
- Added focused tests for dependency-ready ordering, completion callbacks, rollback-driven skips, and missing dependency errors.
- Added the required implementation plan under `docs/superpowers/plans/`.

## Impact Scope

- `packages/core/src/executor/executor.ts`
- `packages/core/src/executor/progress-enforcement.ts`
- `packages/core/src/executor/progress-enforcement.test.ts`
- `docs/superpowers/plans/2026-06-08-executor-progress-enforcement.md`

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: Executor native step progress enforcement only; no Agent, Planner, ContextManager, MemoryStore, MCP boundary, public command, or security policy changes.
- GitNexus impact: `impact executeSteps --file packages/core/src/executor/executor.ts --kind Method --direction upstream --depth 3 --include-tests` reported LOW risk with one direct caller (`packages/core/src/executor/executor.test.ts`) and 0 affected processes/modules. After indexing the new helper, `detect_changes` (`detect-changes --scope compare --base-ref origin/develop`) reported 5 files, 11 symbols, 0 affected processes, LOW risk. `impact executeStepsWithProgressEnforcement --file packages/core/src/executor/progress-enforcement.ts --kind Function --direction upstream --depth 3 --include-tests` reported LOW risk with direct caller limited to `progress-enforcement.test.ts` and 0 affected processes/modules. Query for executor progress/dependency flows surfaced executor/phase-runner related flows; this change keeps `executeStepsWithErrorFeedback` and `PhaseRunner` untouched.
- Verification: `pnpm agent:bootstrap`, `pnpm quality:predev`, focused executor tests, `pnpm typecheck`, `pnpm quality:precommit`, and `pnpm quality:local` passed. Lint emits an existing warning in `packages/core/src/llm/llm-service.test.ts:160` unrelated to this change.

## Verification

- `pnpm --dir packages/core exec vitest run src/executor/progress-enforcement.test.ts src/executor/executor.test.ts src/executor/phase-runner.test.ts src/executor/step-feedback-runner.test.ts`
- `pnpm typecheck`
- `pnpm quality:precommit`
- `pnpm quality:local`
- `npx gitnexus detect_changes (`detect-changes`) --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-executor-progress-enforcement --scope compare --base-ref origin/develop`

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

