### PR TITLE
Extract VS Code webview script renderer

### DIFF
--- a/apps/vscode/src/webview-html.test.ts
+++ b/apps/vscode/src/webview-html.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { getWebviewHtml, nonce, renderWebviewStyleSection } from './webview-html.js';
+import {
+  getWebviewHtml,
+  nonce,
+  renderWebviewScriptSection,
+  renderWebviewStyleSection,
+} from './webview-html.js';
 
 describe('VS Code webview HTML nonce handling', () => {
   it('generates base64url nonces from cryptographic bytes', () => {
@@ -32,5 +37,14 @@ describe('VS Code webview HTML nonce handling', () => {
 
     expect(styleNonce).toBeDefined();
     expect(styleSection).toBe(renderWebviewStyleSection(styleNonce ?? ''));
+  });
+
+  it('renders the script bootstrapping section through a focused renderer', () => {
+    const html = getWebviewHtml({ cspSource: 'vscode-webview://frontagent.test' } as never);
+    const scriptNonce = html.match(/<script nonce="([^"]+)"/)?.[1];
+    const scriptSection = html.match(/ {2}<script nonce="[^"]+">[\s\S]*? {2}<\/script>/)?.[0];
+
+    expect(scriptNonce).toBeDefined();
+    expect(scriptSection).toBe(renderWebviewScriptSection(scriptNonce ?? ''));
   });
 });

--- a/apps/vscode/src/webview-html.ts
+++ b/apps/vscode/src/webview-html.ts
@@ -492,116 +492,8 @@ export function renderWebviewStyleSection(styleNonce: string): string {
   </style>`;
 }
 
-export function getWebviewHtml(webview: vscode.Webview): string {
-  const scriptNonce = nonce();
-  const styleNonce = nonce();
-  const csp = [
-    `default-src 'none'`,
-    `style-src ${webview.cspSource} 'nonce-${styleNonce}'`,
-    `script-src 'nonce-${scriptNonce}'`,
-  ].join('; ');
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="${csp}">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-${renderWebviewStyleSection(styleNonce)}
-</head>
-<body>
-  <div class="shell">
-    <header class="top">
-      <div class="bar">
-        <div class="identity">
-          <div class="title">FrontAgent</div>
-          <div id="configText" class="subtitle">Checking configuration...</div>
-        </div>
-        <div class="header-actions">
-          <div id="status" class="status">Idle</div>
-          <button id="toggleConfig" class="ghost" type="button">Configure</button>
-        </div>
-      </div>
-      <div id="configBanner" class="config-banner">
-        <div class="config-copy">
-          <span id="configPrimary" class="config-primary">Model setup</span>
-          <span id="configSecondary" class="config-secondary">Configure provider, model, base URL, and key when needed.</span>
-        </div>
-        <button id="openCommandConfig" class="secondary" type="button">Command</button>
-      </div>
-      <form id="configForm" class="config-form">
-        <label>Provider
-          <select id="configProvider">
-            <option value="">Select provider</option>
-            <option value="openai">OpenAI-compatible</option>
-            <option value="anthropic">Anthropic</option>
-          </select>
-        </label>
-        <label>Model
-          <input id="configModel" placeholder="zai-org/GLM-4.6">
-        </label>
-        <label>Base URL
-          <input id="configBaseUrl" placeholder="https://api.siliconflow.cn/v1">
-        </label>
-        <label>API Key
-          <input id="configApiKey" type="password" placeholder="Stored in SecretStorage">
-        </label>
-        <div class="config-actions">
-          <button id="saveConfig" type="submit">Save</button>
-          <button id="closeConfig" class="secondary" type="button">Close</button>
-        </div>
-      </form>
-    </header>
-
-    <main id="messages" class="messages"></main>
-
-    <form id="composer" class="composer">
-      <div class="composer-card">
-        <textarea id="prompt" placeholder="Ask FrontAgent to explain, edit, or debug this workspace..."></textarea>
-        <div id="contextFiles" class="context-row"></div>
-        <div id="selectionPreview" class="selection hidden"></div>
-        <label class="url-field">
-          <span>Browser</span>
-          <input id="browserUrl" placeholder="http://localhost:5173">
-        </label>
-        <div class="composer-toolbar">
-          <div class="mode-control">
-            <span class="toolbar-label">Mode</span>
-            <select id="modeSelect" class="mode-select">
-              <option value="query">Ask</option>
-              <option value="modify">Agent Edit</option>
-              <option value="debug">Debug</option>
-            </select>
-            <span id="modeDescription" class="mode-description">Explain and answer</span>
-          </div>
-          <div class="composer-actions">
-            <button id="stopButton" class="ghost icon" type="button" title="Stop">Stop</button>
-            <button id="sendButton" class="icon" type="submit" title="Send">Send</button>
-          </div>
-        </div>
-      </div>
-      <details id="detailsPanel">
-        <summary>Run details</summary>
-        <div class="details-grid">
-          <div class="activity">
-            <div id="activityLabel">等待开始</div>
-            <div id="operation" class="muted"></div>
-          </div>
-          <button id="logButton" class="secondary" type="button">Open log</button>
-          <div>
-            <div class="muted">Plan <span id="phaseCount"></span></div>
-            <div id="phases" class="muted">No plan yet.</div>
-          </div>
-          <div>
-            <div class="muted">Knowledge <span id="ragMeta"></span></div>
-            <div id="rag" class="muted">No matches yet.</div>
-          </div>
-        </div>
-      </details>
-    </form>
-  </div>
-
-  <script nonce="${scriptNonce}">
+export function renderWebviewScriptSection(scriptNonce: string): string {
+  return `  <script nonce="${scriptNonce}">
     const vscode = acquireVsCodeApi();
     let state = null;
     let activeMode = 'query';
@@ -832,7 +724,119 @@ ${renderWebviewStyleSection(styleNonce)}
     });
 
     vscode.postMessage({ type: 'ready' });
-  </script>
+  </script>`;
+}
+
+export function getWebviewHtml(webview: vscode.Webview): string {
+  const scriptNonce = nonce();
+  const styleNonce = nonce();
+  const csp = [
+    `default-src 'none'`,
+    `style-src ${webview.cspSource} 'nonce-${styleNonce}'`,
+    `script-src 'nonce-${scriptNonce}'`,
+  ].join('; ');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="${csp}">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+${renderWebviewStyleSection(styleNonce)}
+</head>
+<body>
+  <div class="shell">
+    <header class="top">
+      <div class="bar">
+        <div class="identity">
+          <div class="title">FrontAgent</div>
+          <div id="configText" class="subtitle">Checking configuration...</div>
+        </div>
+        <div class="header-actions">
+          <div id="status" class="status">Idle</div>
+          <button id="toggleConfig" class="ghost" type="button">Configure</button>
+        </div>
+      </div>
+      <div id="configBanner" class="config-banner">
+        <div class="config-copy">
+          <span id="configPrimary" class="config-primary">Model setup</span>
+          <span id="configSecondary" class="config-secondary">Configure provider, model, base URL, and key when needed.</span>
+        </div>
+        <button id="openCommandConfig" class="secondary" type="button">Command</button>
+      </div>
+      <form id="configForm" class="config-form">
+        <label>Provider
+          <select id="configProvider">
+            <option value="">Select provider</option>
+            <option value="openai">OpenAI-compatible</option>
+            <option value="anthropic">Anthropic</option>
+          </select>
+        </label>
+        <label>Model
+          <input id="configModel" placeholder="zai-org/GLM-4.6">
+        </label>
+        <label>Base URL
+          <input id="configBaseUrl" placeholder="https://api.siliconflow.cn/v1">
+        </label>
+        <label>API Key
+          <input id="configApiKey" type="password" placeholder="Stored in SecretStorage">
+        </label>
+        <div class="config-actions">
+          <button id="saveConfig" type="submit">Save</button>
+          <button id="closeConfig" class="secondary" type="button">Close</button>
+        </div>
+      </form>
+    </header>
+
+    <main id="messages" class="messages"></main>
+
+    <form id="composer" class="composer">
+      <div class="composer-card">
+        <textarea id="prompt" placeholder="Ask FrontAgent to explain, edit, or debug this workspace..."></textarea>
+        <div id="contextFiles" class="context-row"></div>
+        <div id="selectionPreview" class="selection hidden"></div>
+        <label class="url-field">
+          <span>Browser</span>
+          <input id="browserUrl" placeholder="http://localhost:5173">
+        </label>
+        <div class="composer-toolbar">
+          <div class="mode-control">
+            <span class="toolbar-label">Mode</span>
+            <select id="modeSelect" class="mode-select">
+              <option value="query">Ask</option>
+              <option value="modify">Agent Edit</option>
+              <option value="debug">Debug</option>
+            </select>
+            <span id="modeDescription" class="mode-description">Explain and answer</span>
+          </div>
+          <div class="composer-actions">
+            <button id="stopButton" class="ghost icon" type="button" title="Stop">Stop</button>
+            <button id="sendButton" class="icon" type="submit" title="Send">Send</button>
+          </div>
+        </div>
+      </div>
+      <details id="detailsPanel">
+        <summary>Run details</summary>
+        <div class="details-grid">
+          <div class="activity">
+            <div id="activityLabel">等待开始</div>
+            <div id="operation" class="muted"></div>
+          </div>
+          <button id="logButton" class="secondary" type="button">Open log</button>
+          <div>
+            <div class="muted">Plan <span id="phaseCount"></span></div>
+            <div id="phases" class="muted">No plan yet.</div>
+          </div>
+          <div>
+            <div class="muted">Knowledge <span id="ragMeta"></span></div>
+            <div id="rag" class="muted">No matches yet.</div>
+          </div>
+        </div>
+      </details>
+    </form>
+  </div>
+
+${renderWebviewScriptSection(scriptNonce)}
 </body>
 </html>`;
 }

--- a/docs/superpowers/plans/2026-06-08-vscode-webview-script-renderer.md
+++ b/docs/superpowers/plans/2026-06-08-vscode-webview-script-renderer.md
@@ -1,0 +1,137 @@
+# VS Code Webview Script Renderer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve Issue #213 by extracting the VS Code webview script bootstrapping section from `getWebviewHtml` without changing generated HTML or CSP nonce behavior.
+
+**Architecture:** Keep `getWebviewHtml(webview)` as the public renderer that owns CSP construction and top-level document assembly. Add `renderWebviewScriptSection(scriptNonce)` beside the existing style renderer so the `<script>` nonce remains passed explicitly and all bootstrapping JavaScript stays in one cohesive renderer.
+
+**Tech Stack:** TypeScript, VS Code webview HTML, Vitest, GitNexus CLI.
+
+---
+
+### Task 1: Add the Script Renderer Contract Test
+
+**Files:**
+- Modify: `apps/vscode/src/webview-html.test.ts`
+- Read: `apps/vscode/src/webview-html.ts`
+
+**GitNexus impact before code edits:** `npx gitnexus impact getWebviewHtml --direction upstream --file apps/vscode/src/webview-html.ts --kind Function --include-tests --repo FrontAgent-issue213` reported LOW risk, 1 direct dependent (`apps/vscode/src/webview-html.test.ts`), and 0 affected processes/modules in impact output. `context getWebviewHtml` shows runtime flow participation in `ResolveWebviewView -> Nonce` and `ResolveWebviewView -> RenderWebviewStyleSection`.
+
+- [ ] **Step 1: Write the failing import and test**
+
+Change the import to include `renderWebviewScriptSection`:
+
+```ts
+import {
+  getWebviewHtml,
+  nonce,
+  renderWebviewScriptSection,
+  renderWebviewStyleSection,
+} from './webview-html.js';
+```
+
+Add this test in the existing `describe` block:
+
+```ts
+it('renders the script bootstrapping section through a focused renderer', () => {
+  const html = getWebviewHtml({ cspSource: 'vscode-webview://frontagent.test' } as never);
+  const scriptNonce = html.match(/<script nonce="([^"]+)"/)?.[1];
+  const scriptSection = html.match(/ {2}<script nonce="[^"]+">[\s\S]*? {2}<\/script>/)?.[0];
+
+  expect(scriptNonce).toBeDefined();
+  expect(scriptSection).toBe(renderWebviewScriptSection(scriptNonce ?? ''));
+});
+```
+
+- [ ] **Step 2: Run focused test and verify RED**
+
+Run:
+
+```bash
+pnpm --dir apps/vscode test src/webview-html.test.ts
+```
+
+Expected: FAIL because `renderWebviewScriptSection` is not exported yet.
+
+### Task 2: Extract the Script Bootstrapping Renderer
+
+**Files:**
+- Modify: `apps/vscode/src/webview-html.ts`
+- Test: `apps/vscode/src/webview-html.test.ts`
+
+- [ ] **Step 1: Add the renderer**
+
+Move the exact current inline script block out of `getWebviewHtml` into a new exported function after `renderWebviewStyleSection` and before `getWebviewHtml`. The moved block starts with this line:
+
+```ts
+export function renderWebviewScriptSection(scriptNonce: string): string {
+  return `  <script nonce="${scriptNonce}">
+    const vscode = acquireVsCodeApi();
+```
+
+The moved block ends with these lines:
+
+```ts
+    vscode.postMessage({ type: 'ready' });
+  </script>`;
+}
+```
+
+- [ ] **Step 2: Replace the inline script section**
+
+In `getWebviewHtml`, replace only the original `<script nonce="${scriptNonce}">...</script>` section with:
+
+```ts
+${renderWebviewScriptSection(scriptNonce)}
+```
+
+- [ ] **Step 3: Run focused test and verify GREEN**
+
+Run:
+
+```bash
+pnpm --dir apps/vscode test src/webview-html.test.ts
+```
+
+Expected: PASS with the new script renderer test and existing nonce/style tests passing.
+
+### Task 3: Verify and Prepare PR
+
+**Files:**
+- Read: final diff only
+
+- [ ] **Step 1: Run scoped and broader validation**
+
+Run:
+
+```bash
+pnpm --dir apps/vscode test src/webview-html.test.ts
+pnpm --dir apps/vscode test
+pnpm typecheck
+pnpm quality:precommit
+```
+
+Expected: tests and typecheck pass. If `quality:precommit` fails because unrelated dirty authority/GitNexus files are present, do not stage those files; report the exact failure and keep the PR diff scoped.
+
+- [ ] **Step 2: Run GitNexus detect changes**
+
+Run:
+
+```bash
+npx gitnexus detect-changes --repo FrontAgent-issue213 --scope all
+```
+
+Expected: changed symbols are limited to `getWebviewHtml`, `renderWebviewScriptSection`, test coverage, and this plan document.
+
+- [ ] **Step 3: Open PR**
+
+Push branch `improve/vscode-webview-body-script-renderer` and open a PR to `develop` with:
+
+```md
+Closes #213
+
+GitNexus impact summary:
+- `getWebviewHtml` upstream impact: LOW; 1 direct dependent (`apps/vscode/src/webview-html.test.ts`); 0 affected processes/modules in impact output.
+- `detect_changes`: include the final changed symbol/process summary from the command output.
+```


### PR DESCRIPTION
## Summary
- Extracted the VS Code webview script bootstrapping block into `renderWebviewScriptSection(scriptNonce)`.
- Kept `getWebviewHtml` responsible for CSP and top-level HTML assembly while preserving script nonce wiring.
- Added a focused webview HTML test asserting generated HTML uses the script renderer output.

Closes #213

## GitNexus Impact Summary
- Pre-edit `getWebviewHtml` upstream impact: LOW; 1 direct dependent (`apps/vscode/src/webview-html.test.ts`); 0 affected processes/modules in impact output.
- New `renderWebviewScriptSection` upstream impact after indexing: LOW; 1 direct dependent (`apps/vscode/src/webview-html.test.ts`); 0 affected processes/modules in impact output.
- `detect-changes --scope staged`: 3 files, 6 symbols, 3 affected webview resolve flows; risk level medium.
- Affected flows: `ResolveWebviewView -> Nonce`, `ResolveWebviewView -> RenderWebviewStyleSection`, `ResolveWebviewView -> RenderWebviewScriptSection`.

## Test Plan
- [x] `pnpm --dir apps/vscode test src/webview-html.test.ts`
- [x] `pnpm --dir apps/vscode test`
- [x] `pnpm typecheck`
- [x] `pnpm quality:precommit`
