### PR TITLE
fix: guard bootstrap against mismatched worktree

### DIFF
--- a/docs/superpowers/plans/2026-06-08-bootstrap-core-worktree-guard.md
+++ b/docs/superpowers/plans/2026-06-08-bootstrap-core-worktree-guard.md
@@ -1,0 +1,40 @@
+# Bootstrap Core Worktree Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fail agent bootstrap and local contract checks when Git resolves the repository root to a different workspace than the current one.
+
+**Architecture:** Add a small guard in `scripts/workflows/contract-check.mjs` before bootstrap hook installation and before GitNexus local/CI contract analysis. The guard compares the current workspace root with `git rev-parse --show-toplevel` and optional `git config --get core.worktree`, then throws a clear repair-oriented error on mismatch.
+
+**Tech Stack:** Node.js ESM, `node:child_process`, `node:test`, Git CLI.
+
+---
+
+### Task 1: Add Workflow Coverage
+
+**Files:**
+- Modify: `scripts/tests/workflow-rules.test.mjs`
+
+- [x] Add a normal-case test for matching workspace root, Git toplevel, and `core.worktree`.
+- [x] Add a mismatch test that verifies the failure includes the current workspace path, Git-resolved path, `core.worktree`, and a repair hint.
+- [x] Run `pnpm test:workflows` and confirm the new tests fail before implementation.
+
+### Task 2: Add Bootstrap/Contract Guard
+
+**Files:**
+- Modify: `scripts/workflows/contract-check.mjs`
+
+- [x] Export a testable workspace-root guard with injectable Git output.
+- [x] Call it at the start of `runBootstrap()`.
+- [x] Call it at the start of `runGitNexusContract()`.
+- [x] Keep the change scoped to the workflow script and tests.
+
+### Task 3: Verify and Prepare PR
+
+**Files:**
+- Modify: `scripts/tests/workflow-rules.test.mjs`
+- Modify: `scripts/workflows/contract-check.mjs`
+
+- [x] Run `pnpm test:workflows`, `pnpm agent:bootstrap`, `pnpm quality:predev`, and `pnpm quality:precommit`.
+- [x] Run `npx gitnexus detect_changes --repo <current-worktree> --scope compare --base-ref develop`.
+- [ ] Open a PR to `develop` with `Closes #209` and a GitNexus impact summary.

--- a/scripts/tests/workflow-rules.test.mjs
+++ b/scripts/tests/workflow-rules.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { readFileSync, statSync } from 'node:fs';
 import test from 'node:test';
-import { getChangedFiles } from '../workflows/contract-check.mjs';
+import { assertGitWorkspaceRootMatchesCwd, getChangedFiles } from '../workflows/contract-check.mjs';
 import {
   classifyContractPaths,
   evaluateGitNexusContract,
@@ -127,6 +127,50 @@ test('GitNexus analyze streams output to avoid spawn buffer limits', () => {
   assert.doesNotMatch(analyzeFunction, /encoding: 'utf8'/u);
   assert.match(contractCheck, /'--wal-checkpoint-threshold'/u);
   assert.match(contractCheck, /GITNEXUS_WAL_CHECKPOINT_THRESHOLD = '67108864'/u);
+});
+
+test('Git workspace guard accepts matching toplevel and core.worktree', () => {
+  const workspaceRoot = '/tmp/frontagent-workspace';
+
+  assert.doesNotThrow(() =>
+    assertGitWorkspaceRootMatchesCwd({
+      cwd: workspaceRoot,
+      gitText: (args) => {
+        const command = args.join(' ');
+        if (command === 'rev-parse --show-toplevel') return `${workspaceRoot}\n`;
+        if (command === 'config --get core.worktree') return `${workspaceRoot}\n`;
+        throw new Error(`unexpected git command: ${command}`);
+      },
+    }),
+  );
+});
+
+test('Git workspace guard rejects mismatched toplevel and core.worktree with repair hint', () => {
+  const workspaceRoot = '/tmp/frontagent-worktree';
+  const gitRoot = '/tmp/frontagent-main';
+
+  assert.throws(
+    () =>
+      assertGitWorkspaceRootMatchesCwd({
+        cwd: workspaceRoot,
+        gitText: (args) => {
+          const command = args.join(' ');
+          if (command === 'rev-parse --show-toplevel') return `${gitRoot}\n`;
+          if (command === 'config --get core.worktree') return `${gitRoot}\n`;
+          throw new Error(`unexpected git command: ${command}`);
+        },
+      }),
+    (err) => {
+      assert.match(err.message, /Git workspace root mismatch/u);
+      assert.match(err.message, new RegExp(workspaceRoot, 'u'));
+      assert.match(err.message, new RegExp(gitRoot, 'u'));
+      assert.match(err.message, /git rev-parse --show-toplevel/u);
+      assert.match(err.message, /git config --get core\.worktree/u);
+      assert.match(err.message, /git config --worktree core\.worktree/u);
+      assert.match(err.message, /pnpm agent:bootstrap/u);
+      return true;
+    },
+  );
 });
 
 test('non-critical changes keep GitNexus advisory', () => {

--- a/scripts/workflows/contract-check.mjs
+++ b/scripts/workflows/contract-check.mjs
@@ -1,5 +1,6 @@
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   CONTRACT_DIFF_FILTER,
@@ -35,6 +36,7 @@ if (isMainModule()) {
 }
 
 function runBootstrap() {
+  assertGitWorkspaceRootMatchesCwd();
   execFileSync('node', ['scripts/workflows/install-hooks.mjs'], { stdio: 'inherit' });
   console.log('Agent bootstrap complete.');
   console.log(
@@ -53,6 +55,7 @@ function runBootstrap() {
 }
 
 function runGitNexusContract({ mode }) {
+  assertGitWorkspaceRootMatchesCwd();
   runGitNexusAnalyze(mode);
 
   const changedFiles = getChangedFiles(mode);
@@ -65,6 +68,29 @@ function runGitNexusContract({ mode }) {
 
   printContractResult('GitNexus contract', result);
   if (!result.ok) process.exitCode = 1;
+}
+
+export function assertGitWorkspaceRootMatchesCwd(options = {}) {
+  const cwd = normalizeWorkspacePath(options.cwd ?? process.cwd());
+  const gitText = options.gitText ?? ((args) => execFileSync('git', args, { encoding: 'utf8' }));
+  const gitTopLevel = normalizeWorkspacePath(gitText(['rev-parse', '--show-toplevel']).trim());
+  const coreWorktree = readOptionalGitText(gitText, ['config', '--get', 'core.worktree']);
+  const normalizedCoreWorktree = coreWorktree ? normalizeWorkspacePath(coreWorktree) : '';
+
+  if (gitTopLevel === cwd && (!normalizedCoreWorktree || normalizedCoreWorktree === cwd)) return;
+
+  throw new Error(
+    [
+      'Git workspace root mismatch detected before running the FrontAgent agent workflow.',
+      `- Current workspace root: ${cwd}`,
+      `- git rev-parse --show-toplevel: ${gitTopLevel}`,
+      `- git config --get core.worktree: ${normalizedCoreWorktree || '<unset>'}`,
+      'Git is resolving a different workspace than the directory running this workflow, which can make bootstrap or GitNexus analyze inspect the wrong files.',
+      `Fix linked worktrees with: git config --worktree core.worktree "${cwd}"`,
+      'For a normal checkout with a stale value, run: git config --unset core.worktree',
+      'Then rerun pnpm agent:bootstrap.',
+    ].join('\n'),
+  );
 }
 
 export function getChangedFiles(mode, options = {}) {
@@ -125,6 +151,15 @@ export function getChangedFiles(mode, options = {}) {
     git.lines(['diff', '--name-only', `--diff-filter=${CONTRACT_DIFF_FILTER}`, 'HEAD']),
     git.lines(['ls-files', '--others', '--exclude-standard']),
   );
+}
+
+function readOptionalGitText(gitText, args) {
+  try {
+    return gitText(args).trim();
+  } catch (err) {
+    if (typeof err?.status === 'number' && err.status !== 0) return '';
+    throw err;
+  }
 }
 
 function getImpactSummary() {
@@ -219,6 +254,11 @@ function fetchBaseRef(baseBranch) {
   execFileSync('git', ['fetch', '--no-tags', '--depth=1', 'origin', baseBranch], {
     stdio: 'inherit',
   });
+}
+
+function normalizeWorkspacePath(value) {
+  const path = resolve(value);
+  return existsSync(path) ? realpathSync(path) : path;
 }
 
 function isMainModule() {


### PR DESCRIPTION

## Summary

- Add an agent bootstrap/local contract guard that fails when Git resolves a different workspace root than the current directory.
- Include the current workspace path, `git rev-parse --show-toplevel`, `git config --get core.worktree`, and repair commands in the failure message.
- Add workflow tests for matching and mismatched workspace roots.

Closes #209

## GitNexus Impact Summary

- Risk level: HIGH
- Critical skeleton changes: repo-harness workflow script `scripts/workflows/contract-check.mjs` plus matching workflow tests only.
- GitNexus impact: `impact runBootstrap` and `impact runGitNexusContract` were LOW risk with 1 direct file caller each and `scripts/tests/workflow-rules.test.mjs` as the depth-2 importer. `detect_changes --scope compare --base-ref develop` reported 2 changed files, 9 changed symbols, 9 affected RunGitNexusContract execution flows, and HIGH risk because this touches the repo-harness contract workflow.
- Verification: `pnpm test:workflows`, `pnpm agent:bootstrap`, `pnpm quality:predev`, and `pnpm quality:precommit` passed locally; commit hook reran `pnpm quality:precommit` successfully.

## Verification

- `pnpm test:workflows`
- `pnpm agent:bootstrap`
- `pnpm quality:predev`
- `pnpm quality:precommit`
- `npx gitnexus detect_changes --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-bootstrap-core-worktree-guard --scope compare --base-ref develop`
