### PR TITLE
Extract runtime MCP task invocation setup

### DIFF
--- a/docs/superpowers/plans/2026-06-08-runtime-mcp-tool-handler-helpers.md
+++ b/docs/superpowers/plans/2026-06-08-runtime-mcp-tool-handler-helpers.md
@@ -1,0 +1,39 @@
+# Runtime MCP Tool Handler Helpers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract shared runtime MCP run/plan tool invocation setup without changing public MCP tools, payloads, or error behavior.
+
+**Architecture:** Keep the public `createFrontAgentMcpServer` dispatch table in `packages/runtime-node/src/mcp-server.ts`, but move the duplicated run/plan setup into a private helper in the same module. Reuse existing `toRuntimeInput`, `toRunOptions`, `collectSecurityDecisions`, and response shaping so tool schemas and output fields remain stable.
+
+**Tech Stack:** TypeScript, MCP SDK request handlers, Vitest contract tests, GitNexus impact checks.
+
+---
+
+### Task 1: Lock Existing MCP Run/Plan Behavior
+
+**Files:**
+- Modify: `packages/runtime-node/src/mcp-server.test.ts`
+
+- [x] Add focused tests for `frontagent_run_task` and `frontagent_plan_task` that assert the existing payload fields, `isError` behavior, run log path propagation, and security decision collection.
+- [x] Run `pnpm --filter @frontagent/runtime-node test -- mcp-server.test.ts` and confirm the tests pass before refactoring, proving the expected behavior is already covered.
+
+### Task 2: Extract Shared Run/Plan Invocation Setup
+
+**Files:**
+- Modify: `packages/runtime-node/src/mcp-server.ts`
+
+- [x] Add a private helper that creates `events`, `securityDecisions`, `runLogPathRef`, normalized runtime input, sampling/direct backend, and `RunFrontAgentTaskOptions`.
+- [x] Replace the duplicated setup in `frontagent_run_task` and `frontagent_plan_task` with the helper.
+- [x] Preserve the two tool-specific result payloads exactly: run returns `executedStepsSummary`; plan returns `plan`; both keep `success`, `taskId`, `error`, `duration`, `runLogPath`, `securityDecisions`, and `isError = !result.success`.
+
+### Task 3: Verify And Prepare PR
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-06-08-runtime-mcp-tool-handler-helpers.md`
+
+- [x] Run `pnpm --filter @frontagent/runtime-node test`.
+- [x] Run `pnpm --filter @frontagent/runtime-node typecheck`.
+- [x] Run `pnpm quality:precommit`; if it fails due unrelated pre-existing authority/GitNexus document drift, record that explicitly and verify target commands still pass.
+- [x] Run `npx gitnexus detect-changes --scope compare --base-ref origin/develop` and include the result in the PR impact summary.
+- [ ] Open a PR to `develop` with `Closes #211`, GitNexus impact summary, verification evidence, and unchanged public MCP API note.

--- a/packages/runtime-node/src/mcp-server.test.ts
+++ b/packages/runtime-node/src/mcp-server.test.ts
@@ -32,6 +32,10 @@ vi.mock('./run.js', () => ({
   planFrontAgentTask,
 }));
 
+vi.mock('./sampling-llm.js', () => ({
+  SamplingLLMBackend: vi.fn(function SamplingLLMBackend() {}),
+}));
+
 const { createFrontAgentMcpServer } = await import('./mcp-server.js');
 
 function getRequestHandler(
@@ -54,6 +58,10 @@ function getRequestHandler(
 function parseTextResult(result: unknown): Record<string, unknown> {
   const text = (result as { content: Array<{ type: string; text: string }> }).content[0]?.text;
   return JSON.parse(text) as Record<string, unknown>;
+}
+
+function textResultIsError(result: unknown): boolean | undefined {
+  return (result as { isError?: boolean }).isError;
 }
 
 type ListedTool = {
@@ -168,6 +176,16 @@ function expectSharedTaskSchema(tool: ListedTool): void {
   });
 }
 
+const securityDecision = {
+  decision: 'deny',
+  riskLevel: 'high',
+  reasonCode: 'blocked_command',
+  message: 'Command blocked',
+  toolName: 'run_command',
+  argsSummary: 'rm -rf dist',
+  provenance: [{ source: 'builtin', ruleId: 'dangerous-command' }],
+};
+
 describe('createFrontAgentMcpServer contract', () => {
   beforeEach(() => {
     listSkills.mockClear();
@@ -257,5 +275,122 @@ describe('createFrontAgentMcpServer contract', () => {
     expect(listSkills).toHaveBeenCalledTimes(1);
     expect(runFrontAgentTask).not.toHaveBeenCalled();
     expect(planFrontAgentTask).not.toHaveBeenCalled();
+  });
+
+  it('dispatches frontagent_run_task with stable payload and error flag', async () => {
+    runFrontAgentTask.mockImplementationOnce(async (options) => {
+      options.onRunLogPath('/workspace/project/.frontagent/runs/run-1.json');
+      options.onEvent({ type: 'security_decision', decision: securityDecision });
+      return {
+        success: false,
+        taskId: 'task-1',
+        output: 'partial output',
+        error: 'run failed',
+        duration: 42,
+        validations: [],
+        executedSteps: [
+          {
+            stepId: 'step-1',
+            phase: 'Build',
+            action: 'run',
+            tool: 'run_command',
+            status: 'failed',
+            description: 'Run build',
+            result: { success: false, error: 'command denied' },
+          },
+        ],
+      };
+    });
+    const server = createFrontAgentMcpServer({ projectRoot: '/workspace/project' });
+    const handler = getRequestHandler(server, CallToolRequestSchema.shape.method.value);
+
+    const result = await handler({
+      method: 'tools/call',
+      params: {
+        name: 'frontagent_run_task',
+        arguments: {
+          task: 'Build project',
+          type: 'test',
+          securityMode: 'strict',
+        },
+      },
+    });
+    const payload = parseTextResult(result);
+
+    expect(payload).toEqual({
+      success: false,
+      taskId: 'task-1',
+      output: 'partial output',
+      error: 'run failed',
+      duration: 42,
+      runLogPath: '/workspace/project/.frontagent/runs/run-1.json',
+      executedStepsSummary: [
+        {
+          stepId: 'step-1',
+          phase: 'Build',
+          action: 'run',
+          tool: 'run_command',
+          status: 'failed',
+          description: 'Run build',
+          error: 'command denied',
+        },
+      ],
+      securityDecisions: [securityDecision],
+    });
+    expect(textResultIsError(result)).toBe(true);
+    expect(runFrontAgentTask).toHaveBeenCalledTimes(1);
+    expect(planFrontAgentTask).not.toHaveBeenCalled();
+  });
+
+  it('dispatches frontagent_plan_task with stable payload and success flag', async () => {
+    planFrontAgentTask.mockImplementationOnce(async (options) => {
+      options.onRunLogPath('/workspace/project/.frontagent/runs/plan-1.json');
+      options.onEvent({ type: 'security_decision', decision: securityDecision });
+      return {
+        success: true,
+        taskId: 'plan-1',
+        plan: {
+          taskId: 'plan-1',
+          phases: [],
+          steps: [],
+          estimatedDuration: 0,
+          risks: [],
+        },
+        duration: 7,
+      };
+    });
+    const server = createFrontAgentMcpServer({ projectRoot: '/workspace/project' });
+    const handler = getRequestHandler(server, CallToolRequestSchema.shape.method.value);
+
+    const result = await handler({
+      method: 'tools/call',
+      params: {
+        name: 'frontagent_plan_task',
+        arguments: {
+          task: 'Plan project',
+          type: 'query',
+          disableRag: true,
+        },
+      },
+    });
+    const payload = parseTextResult(result);
+
+    expect(payload).toEqual({
+      success: true,
+      taskId: 'plan-1',
+      plan: {
+        taskId: 'plan-1',
+        phases: [],
+        steps: [],
+        estimatedDuration: 0,
+        risks: [],
+      },
+      duration: 7,
+      runLogPath: '/workspace/project/.frontagent/runs/plan-1.json',
+      securityDecisions: [securityDecision],
+    });
+    expect(textResultIsError(result)).toBe(false);
+    expect(planFrontAgentTask).toHaveBeenCalledTimes(1);
+    expect(runFrontAgentTask).not.toHaveBeenCalled();
   });
 });

--- a/packages/runtime-node/src/mcp-server.ts
+++ b/packages/runtime-node/src/mcp-server.ts
@@ -309,6 +309,36 @@ function toRunOptions(input: {
   };
 }
 
+function createTaskInvocationContext(input: {
+  args: Record<string, unknown>;
+  defaults: FrontAgentMcpServerOptions;
+  projectRoot: string;
+  server: Server;
+}): {
+  runLogPathRef: { value: string | null };
+  runOptions: RunFrontAgentTaskOptions;
+  securityDecisions: SecurityDecision[];
+} {
+  const events: AgentEvent[] = [];
+  const securityDecisions: SecurityDecision[] = [];
+  const runLogPathRef = { value: null as string | null };
+  const runtimeInput = toRuntimeInput(input.args, input.defaults);
+  const llmBackend = createAutoBackend(input.server, runtimeInput, input.projectRoot);
+
+  return {
+    runLogPathRef,
+    runOptions: toRunOptions({
+      args: input.args,
+      defaults: input.defaults,
+      projectRoot: input.projectRoot,
+      llmBackend,
+      runLogPathRef,
+      onEvent: collectSecurityDecisions(events, securityDecisions),
+    }),
+    securityDecisions,
+  };
+}
+
 const sharedTaskProperties = {
   task: { type: 'string', description: 'Natural-language FrontAgent task.' },
   type: {
@@ -527,21 +557,13 @@ export function createFrontAgentMcpServer(options: FrontAgentMcpServerOptions = 
         }
 
         case 'frontagent_run_task': {
-          const events: AgentEvent[] = [];
-          const securityDecisions: SecurityDecision[] = [];
-          const runLogPathRef = { value: null as string | null };
-          const runtimeInput = toRuntimeInput(args, options);
-          const llmBackend = createAutoBackend(server, runtimeInput, projectRoot);
-          const result = await runFrontAgentTask(
-            toRunOptions({
-              args,
-              defaults: options,
-              projectRoot,
-              llmBackend,
-              runLogPathRef,
-              onEvent: collectSecurityDecisions(events, securityDecisions),
-            }),
-          );
+          const invocation = createTaskInvocationContext({
+            args,
+            defaults: options,
+            projectRoot,
+            server,
+          });
+          const result = await runFrontAgentTask(invocation.runOptions);
           return textResult(
             {
               success: result.success,
@@ -549,30 +571,22 @@ export function createFrontAgentMcpServer(options: FrontAgentMcpServerOptions = 
               output: result.output,
               error: result.error,
               duration: result.duration,
-              runLogPath: runLogPathRef.value,
+              runLogPath: invocation.runLogPathRef.value,
               executedStepsSummary: summarizeExecutedSteps(result),
-              securityDecisions,
+              securityDecisions: invocation.securityDecisions,
             },
             !result.success,
           );
         }
 
         case 'frontagent_plan_task': {
-          const events: AgentEvent[] = [];
-          const securityDecisions: SecurityDecision[] = [];
-          const runLogPathRef = { value: null as string | null };
-          const runtimeInput = toRuntimeInput(args, options);
-          const llmBackend = createAutoBackend(server, runtimeInput, projectRoot);
-          const result = await planFrontAgentTask(
-            toRunOptions({
-              args,
-              defaults: options,
-              projectRoot,
-              llmBackend,
-              runLogPathRef,
-              onEvent: collectSecurityDecisions(events, securityDecisions),
-            }),
-          );
+          const invocation = createTaskInvocationContext({
+            args,
+            defaults: options,
+            projectRoot,
+            server,
+          });
+          const result = await planFrontAgentTask(invocation.runOptions);
           return textResult(
             {
               success: result.success,
@@ -580,8 +594,8 @@ export function createFrontAgentMcpServer(options: FrontAgentMcpServerOptions = 
               plan: result.plan,
               error: result.error,
               duration: result.duration,
-              runLogPath: runLogPathRef.value,
-              securityDecisions,
+              runLogPath: invocation.runLogPathRef.value,
+              securityDecisions: invocation.securityDecisions,
             },
             !result.success,
           );


### PR DESCRIPTION
## Linked Issue Or Context

Closes #211.

## Summary

- Extracted shared `frontagent_run_task` / `frontagent_plan_task` invocation setup into a private `createTaskInvocationContext` helper in `packages/runtime-node/src/mcp-server.ts`.
- Added focused runtime-node MCP contract coverage for run and plan payload shape, run-log path propagation, security decisions, and `isError` behavior.
- Added the required short implementation plan under `docs/superpowers/plans/2026-06-08-runtime-mcp-tool-handler-helpers.md`.

## Impact Scope

- Runtime MCP server internals only.
- Public MCP tool names, schemas, payload fields, and unknown-tool/error wrapping behavior are intended to remain unchanged.
- Touched critical skeleton category: `mcp-boundary` via `packages/runtime-node/src/mcp-server.ts` and matching runtime-node tests.

## GitNexus Impact Summary

- Risk level: HIGH
- Critical skeleton changes: `mcp-boundary` changes in `packages/runtime-node/src/mcp-server.ts`, covered by `packages/runtime-node/src/mcp-server.test.ts`.
- GitNexus impact: pre-edit `impact createFrontAgentMcpServer --direction upstream --file packages/runtime-node/src/mcp-server.ts --kind Function --include-tests` reported LOW risk with 1 direct caller, `startFrontAgentMcpServer`, and 1 affected module/process group. `context createFrontAgentMcpServer` showed outgoing calls to existing runtime helpers plus `runFrontAgentTask` and `planFrontAgentTask`. `query "runtime MCP call_tool frontagent_run_task frontagent_plan_task"` did not identify additional runtime MCP-specific execution-flow risks. Final `detect_changes --scope staged` reported 3 files, 2 changed symbols (`sharedTaskProperties`, `createFrontAgentMcpServer`), 9 affected `StartFrontAgentMcpServer` flows, and HIGH risk.
- Contract Guard keywords: `detect_changes`, `query`, `context`, and `impact` are intentionally present for the critical skeleton PR contract.
- Verification: `pnpm --filter @frontagent/runtime-node test`, `pnpm --filter @frontagent/runtime-node typecheck`, `pnpm quality:precommit`, and push-hook `pnpm quality:local` all completed successfully.

## Verification

- `pnpm --filter @frontagent/runtime-node test` -> 4 test files passed, 42 tests passed.
- `pnpm --filter @frontagent/runtime-node typecheck` -> `tsc --noEmit` passed.
- `pnpm quality:precommit` -> lint, turbo typecheck, turbo test, workflow tests passed.
- `git push` pre-push hook ran `pnpm quality:local` -> GitNexus contract passed, quality:ci passed, build/package passed.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.
