### PR TITLE
fix: resolve relative core worktree paths

### DIFF
--- a/scripts/tests/workflow-rules.test.mjs
+++ b/scripts/tests/workflow-rules.test.mjs
@@ -145,6 +145,41 @@ test('Git workspace guard accepts matching toplevel and core.worktree', () => {
   );
 });
 
+test('Git workspace guard accepts matching toplevel when core.worktree is unset', () => {
+  const workspaceRoot = '/tmp/frontagent-workspace';
+
+  assert.doesNotThrow(() =>
+    assertGitWorkspaceRootMatchesCwd({
+      cwd: workspaceRoot,
+      gitText: (args) => {
+        const command = args.join(' ');
+        if (command === 'rev-parse --show-toplevel') return `${workspaceRoot}\n`;
+        if (command === 'config --get core.worktree') {
+          throw Object.assign(new Error('core.worktree unset'), { status: 1 });
+        }
+        throw new Error(`unexpected git command: ${command}`);
+      },
+    }),
+  );
+});
+
+test('Git workspace guard resolves relative core.worktree from git dir', () => {
+  const workspaceRoot = '/tmp/frontagent-workspace';
+
+  assert.doesNotThrow(() =>
+    assertGitWorkspaceRootMatchesCwd({
+      cwd: workspaceRoot,
+      gitText: (args) => {
+        const command = args.join(' ');
+        if (command === 'rev-parse --show-toplevel') return `${workspaceRoot}\n`;
+        if (command === 'rev-parse --git-dir') return `${workspaceRoot}/.git\n`;
+        if (command === 'config --get core.worktree') return '..\n';
+        throw new Error(`unexpected git command: ${command}`);
+      },
+    }),
+  );
+});
+
 test('Git workspace guard rejects mismatched toplevel and core.worktree with repair hint', () => {
   const workspaceRoot = '/tmp/frontagent-worktree';
   const gitRoot = '/tmp/frontagent-main';

--- a/scripts/workflows/contract-check.mjs
+++ b/scripts/workflows/contract-check.mjs
@@ -1,6 +1,6 @@
 import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, realpathSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { isAbsolute, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   CONTRACT_DIFF_FILTER,
@@ -75,7 +75,7 @@ export function assertGitWorkspaceRootMatchesCwd(options = {}) {
   const gitText = options.gitText ?? ((args) => execFileSync('git', args, { encoding: 'utf8' }));
   const gitTopLevel = normalizeWorkspacePath(gitText(['rev-parse', '--show-toplevel']).trim());
   const coreWorktree = readOptionalGitText(gitText, ['config', '--get', 'core.worktree']);
-  const normalizedCoreWorktree = coreWorktree ? normalizeWorkspacePath(coreWorktree) : '';
+  const normalizedCoreWorktree = coreWorktree ? resolveCoreWorktreePath(coreWorktree, gitText) : '';
 
   if (gitTopLevel === cwd && (!normalizedCoreWorktree || normalizedCoreWorktree === cwd)) return;
 
@@ -259,6 +259,13 @@ function fetchBaseRef(baseBranch) {
 function normalizeWorkspacePath(value) {
   const path = resolve(value);
   return existsSync(path) ? realpathSync(path) : path;
+}
+
+function resolveCoreWorktreePath(coreWorktree, gitText) {
+  if (isAbsolute(coreWorktree)) return normalizeWorkspacePath(coreWorktree);
+
+  const gitDir = normalizeWorkspacePath(gitText(['rev-parse', '--git-dir']).trim());
+  return normalizeWorkspacePath(resolve(gitDir, coreWorktree));
 }
 
 function isMainModule() {


### PR DESCRIPTION

## Summary

- Follow-up to #215 for repo-guard feedback.
- Resolve relative `core.worktree` values using `git rev-parse --git-dir`, matching Git semantics instead of resolving from `process.cwd()`.
- Add workflow tests for unset `core.worktree` and relative `core.worktree` values.

Closes #209

## GitNexus Impact Summary

- Risk level: MEDIUM
- Critical skeleton changes: repo-harness workflow script `scripts/workflows/contract-check.mjs` plus matching workflow tests only.
- GitNexus impact: `impact assertGitWorkspaceRootMatchesCwd`, `impact normalizeWorkspacePath`, and `impact readOptionalGitText` were LOW risk. Final `detect_changes --scope compare --base-ref origin/develop` reported 2 changed files, 3 changed symbols, 3 affected RunGitNexusContract execution flows, and MEDIUM risk.
- Verification: `pnpm test:workflows`, `pnpm agent:bootstrap`, `pnpm quality:predev`, `pnpm quality:precommit`, and pre-push `pnpm quality:local` passed locally.

## Verification

- `pnpm test:workflows`
- `pnpm agent:bootstrap`
- `pnpm quality:predev`
- `pnpm quality:precommit`
- `pnpm quality:local` via pre-push hook
- `npx gitnexus detect_changes --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-bootstrap-core-worktree-guard --scope compare --base-ref origin/develop`
