### PR TITLE
Refactor FrontAgent facts update flushing

### DIFF
--- a/docs/superpowers/plans/2026-06-08-frontagent-facts-update-flush.md
+++ b/docs/superpowers/plans/2026-06-08-frontagent-facts-update-flush.md
@@ -1,0 +1,51 @@
+# FrontAgent Facts Update Flush Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract facts update flushing from `FrontAgent` into a focused helper while preserving public API, task execution, memory persistence, and callback ordering.
+
+**Architecture:** Keep `FrontAgent` as the orchestrator and move the pending facts update queue plus reentrant flush guard into `packages/core/src/agent/facts-update-flush.ts`. The helper receives `ContextManager` and debug logging dependencies and exposes `enqueue()` plus `reset()` so `planOnly()` and `execute()` lifecycle cleanup remains explicit.
+
+**Tech Stack:** TypeScript, Vitest, GitNexus, pnpm workspace scripts.
+
+---
+
+## GitNexus Impact
+
+- `npx gitnexus impact FrontAgent --repo <worktree> --direction upstream --depth 3 --include-tests`: LOW; direct upstream symbols are `createAgent`, `packages/core/src/agent/index.ts`, and `packages/core/src/agent/agent.test.ts`; no affected execution flows.
+- `npx gitnexus impact flushFactsUpdates --repo <worktree> --direction upstream --depth 3 --include-tests`: LOW; direct caller is `enqueueFactsUpdate`; affected flows are `EnqueueFactsUpdate -> AddToSet`, `EnqueueFactsUpdate -> RemoveFromSet`, and `EnqueueFactsUpdate -> DebugLog`.
+- `npx gitnexus impact mergeFactsUpdate --repo <worktree> --direction upstream --depth 3 --include-tests`: LOW; direct callers are `flushFactsUpdates` and `context-manager.test.ts`; same facts update flows are affected.
+- `constructor`, `phaseCheckDeps`, `planOnly`, and `execute` disambiguated with `--file packages/core/src/agent/agent.ts --kind Method`: LOW; no upstream dependents reported.
+
+## Tasks
+
+### Task 1: Add focused facts flush tests
+
+**Files:**
+- Create: `packages/core/src/agent/facts-update-flush.test.ts`
+
+- [ ] Add a test that enqueues multiple updates and verifies they are merged in order with the existing debug log message.
+- [ ] Add a test that injects a nested enqueue during `mergeFactsUpdate` and verifies the helper drains the queued update after the active flush, preserving the current reentrant state-machine behavior.
+- [ ] Run `pnpm --filter @frontagent/core test -- packages/core/src/agent/facts-update-flush.test.ts` and confirm it fails because the helper module does not exist yet.
+
+### Task 2: Extract helper and wire FrontAgent
+
+**Files:**
+- Create: `packages/core/src/agent/facts-update-flush.ts`
+- Modify: `packages/core/src/agent/agent.ts`
+
+- [ ] Implement `FactsUpdateFlusher` with private `pendingFactsUpdates`, private `flushInProgress`, `enqueue(taskId, update)`, and `reset()`.
+- [ ] Preserve the existing flush loop semantics: return immediately during an active flush, clear the in-progress flag in `finally`, and restart flushing when queued updates were added during the active pass.
+- [ ] Replace `FrontAgent` facts queue fields and private flush methods with a `FactsUpdateFlusher` instance.
+- [ ] Keep `phaseCheckDeps.enqueueFactsUpdate` as the callback boundary and call `factsUpdateFlusher.reset()` in the same lifecycle positions where queue state was previously cleared.
+
+### Task 3: Verify scope
+
+**Files:**
+- Modify only files listed above plus this plan.
+
+- [ ] Run the focused facts flush test.
+- [ ] Run `pnpm --filter @frontagent/core test`.
+- [ ] Run `pnpm --filter @frontagent/core typecheck`.
+- [ ] Run `npx gitnexus detect_changes --repo <worktree>` and record affected symbols and risk.
+- [ ] Run `pnpm quality:precommit` because this touches the agent-core critical skeleton.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -41,6 +41,7 @@ import { buildFinalOutput } from './answer-generation.js';
 import { gatherRequestedContext } from './context-gathering.js';
 import { detectDevServerPort } from './dev-server-detection.js';
 import { createExecutionCallbacks } from './execution-callbacks.js';
+import { FactsUpdateFlusher } from './facts-update-flush.js';
 import { persistMemory, preloadMemory } from './memory-lifecycle.js';
 import { retrieveRagContext } from './rag-retrieval.js';
 
@@ -64,14 +65,17 @@ export class FrontAgent {
   private skillContentResolver?: SkillContentResolver;
   private memoryStore: MemoryStore;
   private workflowIntegration?: WorkflowIntegration;
-  private pendingFactsUpdates: ProjectFactsUpdate[] = [];
-  private factsUpdateFlushInProgress = false;
+  private factsUpdateFlusher: FactsUpdateFlusher;
   private lastAnswerGenerationError?: string;
   private lastLlmFailureError?: string;
 
   constructor(config: AgentConfig) {
     this.config = config;
     this.contextManager = new ContextManager();
+    this.factsUpdateFlusher = new FactsUpdateFlusher({
+      contextManager: this.contextManager,
+      debugLog: this.debugLog.bind(this),
+    });
     this.sddParser = new SDDParser();
 
     if (config.sddPath) {
@@ -378,8 +382,7 @@ export class FrontAgent {
     },
   ): Promise<AgentPlanResult> {
     const startTime = Date.now();
-    this.pendingFactsUpdates = [];
-    this.factsUpdateFlushInProgress = false;
+    this.factsUpdateFlusher.reset();
     this.lastAnswerGenerationError = undefined;
     this.lastLlmFailureError = undefined;
 
@@ -561,8 +564,7 @@ export class FrontAgent {
       };
     } finally {
       this.emitStatus('清理计划上下文', '清理计划上下文');
-      this.pendingFactsUpdates = [];
-      this.factsUpdateFlushInProgress = false;
+      this.factsUpdateFlusher.reset();
       this.currentTaskId = undefined;
       this.contextManager.clearContext(task.id);
     }
@@ -578,8 +580,7 @@ export class FrontAgent {
     },
   ): Promise<AgentExecutionResult> {
     const startTime = Date.now();
-    this.pendingFactsUpdates = [];
-    this.factsUpdateFlushInProgress = false;
+    this.factsUpdateFlusher.reset();
     this.lastAnswerGenerationError = undefined;
     this.lastLlmFailureError = undefined;
     const skillResolution = this.skillContentResolver?.resolveForTask(taskDescription);
@@ -827,8 +828,7 @@ export class FrontAgent {
       persistMemory(this.memoryDeps, task.id, task.description);
 
       this.emitStatus('清理运行上下文', '清理运行上下文');
-      this.pendingFactsUpdates = [];
-      this.factsUpdateFlushInProgress = false;
+      this.factsUpdateFlusher.reset();
       this.currentTaskId = undefined;
       this.contextManager.clearContext(task.id);
     }
@@ -904,43 +904,7 @@ export class FrontAgent {
   }
 
   private async enqueueFactsUpdate(taskId: string, update: ProjectFactsUpdate): Promise<void> {
-    this.pendingFactsUpdates.push(update);
-    await this.flushFactsUpdates(taskId);
-  }
-
-  private async flushFactsUpdates(taskId: string): Promise<void> {
-    if (this.factsUpdateFlushInProgress) {
-      return;
-    }
-
-    this.factsUpdateFlushInProgress = true;
-    while (true) {
-      try {
-        while (this.pendingFactsUpdates.length > 0) {
-          const nextUpdate = this.pendingFactsUpdates.shift();
-          if (!nextUpdate) {
-            continue;
-          }
-
-          const mergeResult = this.contextManager.mergeFactsUpdate(taskId, nextUpdate);
-          const staleText = mergeResult.staleBaseRevision
-            ? ' (stale base revision, rebased in main reducer)'
-            : '';
-          this.debugLog(
-            `[Agent] Merged facts update from ${mergeResult.source}: ` +
-              `r${mergeResult.previousRevision} -> r${mergeResult.nextRevision}${staleText}`,
-          );
-        }
-      } finally {
-        this.factsUpdateFlushInProgress = false;
-      }
-
-      if (this.pendingFactsUpdates.length === 0) {
-        break;
-      }
-
-      this.factsUpdateFlushInProgress = true;
-    }
+    await this.factsUpdateFlusher.enqueue(taskId, update);
   }
 
   getSDDConfig(): SDDConfig | undefined {

--- a/packages/core/src/agent/facts-update-flush.test.ts
+++ b/packages/core/src/agent/facts-update-flush.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ContextManager } from '../context.js';
+import type { ProjectFactsMergeResult, ProjectFactsUpdate } from '../types.js';
+import { FactsUpdateFlusher } from './facts-update-flush.js';
+
+function makeTask(id = 'task-1') {
+  return {
+    id,
+    type: 'feature' as const,
+    description: 'Test task',
+    context: { workingDirectory: '/tmp/project' },
+  };
+}
+
+function makeMergeResult(
+  update: ProjectFactsUpdate,
+  previousRevision: number,
+): ProjectFactsMergeResult {
+  return {
+    applied: true,
+    source: update.source,
+    previousRevision,
+    nextRevision: previousRevision + 1,
+    staleBaseRevision: update.baseRevision !== previousRevision,
+  };
+}
+
+describe('FactsUpdateFlusher', () => {
+  it('merges queued facts updates and logs revisions in order', async () => {
+    const contextManager = new ContextManager();
+    contextManager.createContext(makeTask());
+    const debugLog = vi.fn();
+    const flusher = new FactsUpdateFlusher({ contextManager, debugLog });
+
+    await flusher.enqueue('task-1', {
+      baseRevision: 0,
+      source: 'first-review',
+      changes: { addExistingFiles: ['src/first.ts'] },
+    });
+    await flusher.enqueue('task-1', {
+      baseRevision: 1,
+      source: 'second-review',
+      changes: { addExistingFiles: ['src/second.ts'] },
+    });
+
+    const facts = contextManager.getContext('task-1')!.facts;
+    expect(Array.from(facts.filesystem.existingFiles)).toEqual(['src/first.ts', 'src/second.ts']);
+    expect(facts.revision).toBe(2);
+    expect(debugLog).toHaveBeenNthCalledWith(
+      1,
+      '[Agent] Merged facts update from first-review: r0 -> r1',
+    );
+    expect(debugLog).toHaveBeenNthCalledWith(
+      2,
+      '[Agent] Merged facts update from second-review: r1 -> r2',
+    );
+  });
+
+  it('drains facts updates enqueued while a flush is already in progress', async () => {
+    const debugLog = vi.fn();
+    const mergedSources: string[] = [];
+    let revision = 0;
+    let flusher: FactsUpdateFlusher;
+
+    const nestedUpdate: ProjectFactsUpdate = {
+      baseRevision: 1,
+      source: 'nested-review',
+      changes: { addExistingFiles: ['src/nested.ts'] },
+    };
+
+    const contextManager = {
+      mergeFactsUpdate: vi.fn((taskId: string, update: ProjectFactsUpdate) => {
+        expect(taskId).toBe('task-1');
+        const previousRevision = revision;
+        mergedSources.push(update.source);
+        revision += 1;
+
+        if (update.source === 'outer-review') {
+          void flusher.enqueue(taskId, nestedUpdate);
+        }
+
+        return makeMergeResult(update, previousRevision);
+      }),
+    } as unknown as ContextManager;
+
+    flusher = new FactsUpdateFlusher({ contextManager, debugLog });
+
+    await flusher.enqueue('task-1', {
+      baseRevision: 0,
+      source: 'outer-review',
+      changes: { addExistingFiles: ['src/outer.ts'] },
+    });
+
+    expect(mergedSources).toEqual(['outer-review', 'nested-review']);
+    expect(contextManager.mergeFactsUpdate).toHaveBeenCalledTimes(2);
+    expect(debugLog).toHaveBeenNthCalledWith(
+      1,
+      '[Agent] Merged facts update from outer-review: r0 -> r1',
+    );
+    expect(debugLog).toHaveBeenNthCalledWith(
+      2,
+      '[Agent] Merged facts update from nested-review: r1 -> r2',
+    );
+  });
+
+  it('clears pending facts updates when reset is called', async () => {
+    const debugLog = vi.fn();
+    let flusher: FactsUpdateFlusher;
+    const mergedSources: string[] = [];
+
+    const contextManager = {
+      mergeFactsUpdate: vi.fn((taskId: string, update: ProjectFactsUpdate) => {
+        mergedSources.push(update.source);
+        if (update.source === 'blocking-review') {
+          void flusher.enqueue(taskId, {
+            baseRevision: 1,
+            source: 'queued-review',
+            changes: { addExistingFiles: ['src/queued.ts'] },
+          });
+          flusher.reset();
+        }
+        return makeMergeResult(update, mergedSources.length - 1);
+      }),
+    } as unknown as ContextManager;
+
+    flusher = new FactsUpdateFlusher({ contextManager, debugLog });
+
+    await flusher.enqueue('task-1', {
+      baseRevision: 0,
+      source: 'blocking-review',
+      changes: { addExistingFiles: ['src/blocking.ts'] },
+    });
+
+    expect(mergedSources).toEqual(['blocking-review']);
+    expect(contextManager.mergeFactsUpdate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/agent/facts-update-flush.ts
+++ b/packages/core/src/agent/facts-update-flush.ts
@@ -1,0 +1,59 @@
+import type { ContextManager } from '../context.js';
+import type { ProjectFactsUpdate } from '../types.js';
+
+export interface FactsUpdateFlusherDeps {
+  contextManager: ContextManager;
+  debugLog: (...args: unknown[]) => void;
+}
+
+export class FactsUpdateFlusher {
+  private pendingFactsUpdates: ProjectFactsUpdate[] = [];
+  private flushInProgress = false;
+
+  constructor(private readonly deps: FactsUpdateFlusherDeps) {}
+
+  reset(): void {
+    this.pendingFactsUpdates = [];
+    this.flushInProgress = false;
+  }
+
+  async enqueue(taskId: string, update: ProjectFactsUpdate): Promise<void> {
+    this.pendingFactsUpdates.push(update);
+    await this.flush(taskId);
+  }
+
+  private async flush(taskId: string): Promise<void> {
+    if (this.flushInProgress) {
+      return;
+    }
+
+    this.flushInProgress = true;
+    while (true) {
+      try {
+        while (this.pendingFactsUpdates.length > 0) {
+          const nextUpdate = this.pendingFactsUpdates.shift();
+          if (!nextUpdate) {
+            continue;
+          }
+
+          const mergeResult = this.deps.contextManager.mergeFactsUpdate(taskId, nextUpdate);
+          const staleText = mergeResult.staleBaseRevision
+            ? ' (stale base revision, rebased in main reducer)'
+            : '';
+          this.deps.debugLog(
+            `[Agent] Merged facts update from ${mergeResult.source}: ` +
+              `r${mergeResult.previousRevision} -> r${mergeResult.nextRevision}${staleText}`,
+          );
+        }
+      } finally {
+        this.flushInProgress = false;
+      }
+
+      if (this.pendingFactsUpdates.length === 0) {
+        break;
+      }
+
+      this.flushInProgress = true;
+    }
+  }
+}


### PR DESCRIPTION
## Linked Issue Or Context

Closes #220

## Summary

- Extracted the FrontAgent facts update queue and reentrant flush guard into `FactsUpdateFlusher`.
- Kept the existing `phaseCheckDeps.enqueueFactsUpdate` callback boundary while delegating flush behavior to the helper.
- Added focused tests for ordered facts merges, nested enqueue during active flush, and lifecycle reset clearing pending updates.

## Impact Scope

- Agent-core internal refactor only.
- Public `FrontAgent` API, task execution result shape, memory persistence calls, callback ordering, and #216 context gathering behavior are unchanged.

## GitNexus Impact Summary

- Risk level: CRITICAL
- Critical skeleton changes: agent-core files changed: `packages/core/src/agent/agent.ts`, `packages/core/src/agent/facts-update-flush.ts`, and `packages/core/src/agent/facts-update-flush.test.ts`.
- GitNexus impact: `detect_changes --scope staged` reported 4 files, 8 symbols, 19 affected processes, risk CRITICAL; changed flows include `Execute -> StripQuotes`, `PlanOnly -> StripQuotes`, `Execute -> RegisterRoot`, and `PlanOnly -> RegisterRoot`. Pre-edit `impact` results were LOW for `FrontAgent`, `flushFactsUpdates`, `mergeFactsUpdate`, `constructor`, `phaseCheckDeps`, `planOnly`, and `execute`; `flushFactsUpdates` directly affected `enqueueFactsUpdate` and the `EnqueueFactsUpdate -> AddToSet/RemoveFromSet/DebugLog` flows. `context FrontAgent` showed direct upstream imports/callers limited to `createAgent`, `packages/core/src/agent/index.ts`, and `packages/core/src/agent/agent.test.ts`; `query "FrontAgent facts flush context update"` surfaced the FrontAgent/context/memory facts area used for this extraction.
- Verification: `pnpm agent:bootstrap`, `pnpm quality:predev`, `pnpm --filter @frontagent/core test -- src/agent/facts-update-flush.test.ts`, `pnpm --filter @frontagent/core test`, `pnpm --filter @frontagent/core typecheck`, `pnpm quality:precommit`, and `pnpm quality:local` all passed locally.

## Verification

- `pnpm agent:bootstrap`
- `pnpm quality:predev`
- `pnpm --filter @frontagent/core test -- src/agent/facts-update-flush.test.ts`
- `pnpm --filter @frontagent/core test`
- `pnpm --filter @frontagent/core typecheck`
- `pnpm quality:precommit`
- `pnpm quality:local`

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.
