### PR TITLE
Extract filesense query result helper

### DIFF
--- a/docs/superpowers/plans/2026-06-08-filesense-engine-query-helpers.md
+++ b/docs/superpowers/plans/2026-06-08-filesense-engine-query-helpers.md
@@ -27,6 +27,7 @@
 Create `packages/mcp-filesense/src/engine-query.test.ts` with tests that call `buildQueryResult` directly and assert the exact existing root-relative path behavior:
 
 ```ts
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { buildQueryResult } from './engine-query.js';
 import type { IndexFile, NotesFile } from './types.js';
@@ -68,15 +69,15 @@ describe('engine query helpers', () => {
     });
   });
 
-  it('builds nested query results with slash-normalized rootRelativePath', () => {
+  it('builds nested query results with native path.relative semantics', () => {
     const result = buildQueryResult({
       root: '/repo',
-      target: '/repo/src/components',
+      target: '/repo/src\\components',
       index,
       notes: null,
     });
 
-    expect(result.rootRelativePath).toBe('src/components');
+    expect(result.rootRelativePath).toBe(path.relative('/repo', '/repo/src\\components'));
     expect(result.notes).toBeNull();
   });
 });
@@ -106,7 +107,7 @@ export function buildQueryResult({
   index,
   notes,
 }: BuildQueryResultOptions): QueryResult {
-  const relative = path.relative(root, target).replace(/\\/g, '/');
+  const relative = path.relative(root, target);
   return {
     root,
     target,

--- a/docs/superpowers/plans/2026-06-08-filesense-engine-query-helpers.md
+++ b/docs/superpowers/plans/2026-06-08-filesense-engine-query-helpers.md
@@ -1,0 +1,147 @@
+# Filesense Engine Query Helpers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract one remaining `mcp-filesense` query result shaping responsibility from `packages/mcp-filesense/src/engine.ts` without changing public tool output.
+
+**Architecture:** Keep filesystem lookup, config resolution, index reads, and error behavior in `engine.ts`. Add a pure `packages/mcp-filesense/src/engine-query.ts` helper that builds the existing `QueryResult` object from already-loaded root/target/index/notes inputs, making the response shape independently testable.
+
+**Tech Stack:** TypeScript, Vitest, existing `@frontagent/mcp-filesense` package scripts.
+
+---
+
+### Task 1: Query Result Shaping Helper
+
+**Files:**
+- Create: `packages/mcp-filesense/src/engine-query.ts`
+- Create: `packages/mcp-filesense/src/engine-query.test.ts`
+- Modify: `packages/mcp-filesense/src/engine.ts:734-746`
+
+**GitNexus Impact:**
+- `npx gitnexus impact query --direction upstream --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-filesense-engine-query-helpers --file packages/mcp-filesense/src/engine.ts --include-tests`
+- Risk level: LOW
+- Blast radius: one direct test-file dependent, `packages/mcp-filesense/src/engine.test.ts`; no affected execution processes or modules.
+
+- [x] **Step 1: Add the focused failing test**
+
+Create `packages/mcp-filesense/src/engine-query.test.ts` with tests that call `buildQueryResult` directly and assert the exact existing root-relative path behavior:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { buildQueryResult } from './engine-query.js';
+import type { IndexFile, NotesFile } from './types.js';
+
+const index: IndexFile = {
+  schema_version: '1.0',
+  generated_at: '2026-06-08T00:00:00.000Z',
+  root_relative_path: '.',
+  directory: { name: 'workspace', path: '.' },
+  children: [],
+  sync: {
+    child_count: 0,
+    file_count: 0,
+    dir_count: 0,
+    last_full_sync: null,
+    last_incremental_sync: null,
+  },
+};
+
+const notes: NotesFile = {
+  directory_purpose: 'Project root directory containing source code.',
+};
+
+describe('engine query helpers', () => {
+  it('builds root query results with dot rootRelativePath', () => {
+    const result = buildQueryResult({
+      root: '/repo',
+      target: '/repo',
+      index,
+      notes,
+    });
+
+    expect(result).toEqual({
+      root: '/repo',
+      target: '/repo',
+      rootRelativePath: '.',
+      index,
+      notes,
+    });
+  });
+
+  it('builds nested query results with slash-normalized rootRelativePath', () => {
+    const result = buildQueryResult({
+      root: '/repo',
+      target: '/repo/src/components',
+      index,
+      notes: null,
+    });
+
+    expect(result.rootRelativePath).toBe('src/components');
+    expect(result.notes).toBeNull();
+  });
+});
+```
+
+Run: `pnpm --filter @frontagent/mcp-filesense test -- engine-query.test.ts`
+Expected before implementation: FAIL because `./engine-query.js` does not exist.
+
+- [x] **Step 2: Implement the helper**
+
+Create `packages/mcp-filesense/src/engine-query.ts`:
+
+```ts
+import path from 'node:path';
+import type { IndexFile, NotesFile, QueryResult } from './types.js';
+
+export interface BuildQueryResultOptions {
+  root: string;
+  target: string;
+  index: IndexFile;
+  notes: NotesFile | null;
+}
+
+export function buildQueryResult({
+  root,
+  target,
+  index,
+  notes,
+}: BuildQueryResultOptions): QueryResult {
+  const relative = path.relative(root, target).replace(/\\/g, '/');
+  return {
+    root,
+    target,
+    rootRelativePath: relative === '' ? '.' : relative,
+    index,
+    notes,
+  };
+}
+```
+
+- [x] **Step 3: Delegate `engine.query` result shaping**
+
+In `packages/mcp-filesense/src/engine.ts`, import `buildQueryResult` and replace the inline final return with:
+
+```ts
+return buildQueryResult({ root, target, index, notes });
+```
+
+- [x] **Step 4: Verify focused and package gates**
+
+Run:
+
+```bash
+pnpm --filter @frontagent/mcp-filesense test -- engine-query.test.ts engine.test.ts
+pnpm --filter @frontagent/mcp-filesense test
+pnpm --filter @frontagent/mcp-filesense typecheck
+```
+
+- [x] **Step 5: Final scope inspection**
+
+Run:
+
+```bash
+npx gitnexus detect-changes --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-filesense-engine-query-helpers --scope all
+pnpm quality:precommit
+```
+
+Expected: changed symbols are limited to the new query helper/test, the `query` delegation, and this plan.

--- a/packages/mcp-filesense/src/engine-query.test.ts
+++ b/packages/mcp-filesense/src/engine-query.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { buildQueryResult } from './engine-query.js';
+import type { IndexFile, NotesFile } from './types.js';
+
+const index: IndexFile = {
+  schema_version: '1.0',
+  generated_at: '2026-06-08T00:00:00.000Z',
+  root_relative_path: '.',
+  directory: { name: 'workspace', path: '.' },
+  children: [],
+  sync: {
+    child_count: 0,
+    file_count: 0,
+    dir_count: 0,
+    last_full_sync: null,
+    last_incremental_sync: null,
+  },
+};
+
+const notes: NotesFile = {
+  directory_purpose: 'Project root directory containing source code.',
+};
+
+describe('engine query helpers', () => {
+  it('builds root query results with dot rootRelativePath', () => {
+    const result = buildQueryResult({
+      root: '/repo',
+      target: '/repo',
+      index,
+      notes,
+    });
+
+    expect(result).toEqual({
+      root: '/repo',
+      target: '/repo',
+      rootRelativePath: '.',
+      index,
+      notes,
+    });
+  });
+
+  it('builds nested query results with slash-normalized rootRelativePath', () => {
+    const result = buildQueryResult({
+      root: '/repo',
+      target: '/repo/src/components',
+      index,
+      notes: null,
+    });
+
+    expect(result.rootRelativePath).toBe('src/components');
+    expect(result.notes).toBeNull();
+  });
+});

--- a/packages/mcp-filesense/src/engine-query.test.ts
+++ b/packages/mcp-filesense/src/engine-query.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { buildQueryResult } from './engine-query.js';
 import type { IndexFile, NotesFile } from './types.js';
@@ -39,15 +40,15 @@ describe('engine query helpers', () => {
     });
   });
 
-  it('builds nested query results with slash-normalized rootRelativePath', () => {
+  it('builds nested query results with native path.relative semantics', () => {
     const result = buildQueryResult({
       root: '/repo',
-      target: '/repo/src/components',
+      target: '/repo/src\\components',
       index,
       notes: null,
     });
 
-    expect(result.rootRelativePath).toBe('src/components');
+    expect(result.rootRelativePath).toBe(path.relative('/repo', '/repo/src\\components'));
     expect(result.notes).toBeNull();
   });
 });

--- a/packages/mcp-filesense/src/engine-query.ts
+++ b/packages/mcp-filesense/src/engine-query.ts
@@ -14,7 +14,7 @@ export function buildQueryResult({
   index,
   notes,
 }: BuildQueryResultOptions): QueryResult {
-  const relative = path.relative(root, target).replace(/\\/g, '/');
+  const relative = path.relative(root, target);
   return {
     root,
     target,

--- a/packages/mcp-filesense/src/engine-query.ts
+++ b/packages/mcp-filesense/src/engine-query.ts
@@ -1,0 +1,25 @@
+import path from 'node:path';
+import type { IndexFile, NotesFile, QueryResult } from './types.js';
+
+export interface BuildQueryResultOptions {
+  root: string;
+  target: string;
+  index: IndexFile;
+  notes: NotesFile | null;
+}
+
+export function buildQueryResult({
+  root,
+  target,
+  index,
+  notes,
+}: BuildQueryResultOptions): QueryResult {
+  const relative = path.relative(root, target).replace(/\\/g, '/');
+  return {
+    root,
+    target,
+    rootRelativePath: relative === '' ? '.' : relative,
+    index,
+    notes,
+  };
+}

--- a/packages/mcp-filesense/src/engine.ts
+++ b/packages/mcp-filesense/src/engine.ts
@@ -8,6 +8,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { inferDirectoryPurpose, inferImportance, scoreCandidate } from './engine-helpers.js';
 import { type ComparableIndex, persistDirectoryIndex } from './engine-indexing.js';
+import { buildQueryResult } from './engine-query.js';
 import type {
   CheckSummary,
   ChildEntry,
@@ -734,7 +735,6 @@ export async function check(targetPath: string): Promise<CheckSummary> {
 export async function query(targetPath: string): Promise<QueryResult> {
   const target = path.resolve(targetPath);
   const { root, config } = await resolveRootAndConfig(target);
-  const relative = path.relative(root, target);
   const indexPath = path.join(target, config.indexFile);
   if (!(await exists(indexPath)))
     throw new Error(`No ${config.indexFile} found in ${target}. Run sync first.`);
@@ -743,7 +743,7 @@ export async function query(targetPath: string): Promise<QueryResult> {
   const notesPath = path.join(target, config.notesFile);
   const notes = (await exists(notesPath)) ? ((await readJson(notesPath)) as NotesFile) : null;
 
-  return { root, target, rootRelativePath: relative === '' ? '.' : relative, index, notes };
+  return buildQueryResult({ root, target, index, notes });
 }
 
 function detectPackageManager(indexes: IndexFile[]): string | undefined {


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #224

## Summary

- Added `engine-query.ts` with a pure `buildQueryResult` helper for existing `QueryResult` shaping.
- Delegated `engine.query` final response construction to the helper while keeping filesystem reads, errors, MCP schemas, persisted index format, scoring, and native `path.relative` behavior unchanged.
- Added focused helper tests and the required implementation plan.

## Impact Scope

- Files changed: `packages/mcp-filesense/src/engine.ts`, `packages/mcp-filesense/src/engine-query.ts`, `packages/mcp-filesense/src/engine-query.test.ts`, `docs/superpowers/plans/2026-06-08-filesense-engine-query-helpers.md`.
- Public response shape remains `{ root, target, rootRelativePath, index, notes }`.
- Repo Guard feedback adopted: removed slash normalization and added regression coverage for native `path.relative` semantics.

## GitNexus Impact Summary

- Risk level: MEDIUM
- Critical skeleton changes: No MCP tool schemas, response fields, persisted index format, or scoring behavior changed. This touches the mcp-filesense boundary but only extracts query result shaping.
- GitNexus impact: Pre-edit `npx gitnexus impact query --direction upstream --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-filesense-engine-query-helpers --file packages/mcp-filesense/src/engine.ts --include-tests` returned LOW, one direct dependent (`packages/mcp-filesense/src/engine.test.ts`), no affected processes/modules. Final local `npx gitnexus detect_changes --scope compare --base-ref origin/develop` returned MEDIUM; after the repo-guard fix it mapped 4 changed files / 1 symbol with affected flows `Check → Exists` and `Check → ReadJson`. Earlier compare output after CI indexing mapped 5 files / 7 symbols including `buildQueryResult`, `query`, and `HandleFilesenseTool → BuildQueryResult`.
- Verification: `pnpm agent:bootstrap`, `pnpm quality:predev`, focused red/green helper tests, package tests/typecheck, `pnpm quality:precommit`, and push-time `pnpm quality:local` passed.

## Verification

- `pnpm --filter @frontagent/mcp-filesense test -- engine-query.test.ts engine.test.ts`
- `pnpm --filter @frontagent/mcp-filesense test`
- `pnpm --filter @frontagent/mcp-filesense typecheck`
- `pnpm quality:precommit`
- Push hook: `pnpm quality:local`

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.
