### PR TITLE
Refactor executor step trace orchestration

### DIFF
--- a/docs/superpowers/plans/2026-06-08-executor-executestep-orchestration.md
+++ b/docs/superpowers/plans/2026-06-08-executor-executestep-orchestration.md
@@ -1,0 +1,87 @@
+# Executor executeStep Orchestration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Decompose one focused trace lifecycle boundary out of `Executor.executeStep` while preserving executor behavior and public APIs.
+
+**Architecture:** Extract trace stage timing and final trace emission into an internal `StepTraceRecorder` helper under `packages/core/src/executor/`. Keep `executeStep` responsible for validation, tool preparation, tool invocation, output shaping, rollback decisions, and LangGraph/native execution wiring.
+
+**Tech Stack:** TypeScript, Vitest, GitNexus, pnpm workspace scripts.
+
+---
+
+## GitNexus Blast Radius
+
+- Target: `Method:packages/core/src/executor/executor.ts:Executor.executeStep#2`
+- Risk level: LOW
+- Direct dependents: indexed `executeStep` self-flow, `packages/core/src/executor/executor.test.ts`, `packages/core/src/security.test.ts`
+- Affected process groups: `ExecuteStep -> Builtin`, `ExecuteStep -> EmitSecurityDecision`, `ExecuteStep -> DebugLog`, `ExecuteStep -> NowMs`, `ExecuteStep -> IsSuccessfulToolResult`, `ExecuteStep -> IsTraceEnabled`, `ExecuteStep -> ValidateStepParams`
+- Decision: proceed with a trace-only helper extraction; do not touch security approval, action skill semantics, rollback, LangGraph execution, or public executor APIs.
+
+### Task 1: Pin Trace Helper Behavior
+
+**Files:**
+- Modify: `packages/core/src/executor/trace.test.ts`
+- Create: `packages/core/src/executor/step-trace-recorder.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests that import `createStepTraceRecorder` from `./step-trace-recorder.js`, verify a skipped output emits the same trace payload shape, and verify `withStage` records failed stage errors.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pnpm --filter @frontagent/core test -- src/executor/trace.test.ts`
+Expected: FAIL because `step-trace-recorder.js` does not exist.
+
+- [ ] **Step 3: Implement helper**
+
+Create `packages/core/src/executor/step-trace-recorder.ts` with `finish`, `withStage`, `addSubStage`, and `markCatchIfEmpty` methods. Keep timing injected through `nowMs` so `Executor` preserves its current monotonic timing behavior.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `pnpm --filter @frontagent/core test -- src/executor/trace.test.ts`
+Expected: PASS.
+
+### Task 2: Wire Executor To Helper
+
+**Files:**
+- Modify: `packages/core/src/executor/executor.ts`
+- Test: `packages/core/src/executor/executor.test.ts`
+- Test: `packages/core/src/executor/trace.test.ts`
+
+- [ ] **Step 1: Replace inline trace lifecycle**
+
+In `executeStep`, replace local `traceEnabled`, `traceStartedAt`, `traceStages`, `subStages`, `finish`, and `withStage` closures with `const trace = createStepTraceRecorder(...)`.
+
+- [ ] **Step 2: Preserve call sites**
+
+Use `trace.withStage(...)`, `trace.addSubStage(...)`, `trace.markCatchIfEmpty(...)`, and `trace.finish(...)` at the existing orchestration points. Do not move validation, tool call, post-validation, rollback, or security logic.
+
+- [ ] **Step 3: Run focused verification**
+
+Run: `pnpm --filter @frontagent/core test -- src/executor/executor.test.ts src/executor/trace.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `pnpm --filter @frontagent/core typecheck`
+Expected: PASS.
+
+### Task 3: Final Gates And PR
+
+**Files:**
+- Modify: `.github` only if PR tooling requires body template discovery; otherwise no source changes.
+
+- [ ] **Step 1: Run broader gate**
+
+Run: `pnpm quality:precommit`
+Expected: PASS.
+
+- [ ] **Step 2: Inspect final impact**
+
+Run: `npx gitnexus detect_changes --repo "/Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-executor-executestep-orchestration"`
+Expected: changed symbols limited to executor trace helper, `Executor.executeStep`, tests, and this plan.
+
+- [ ] **Step 3: Open PR**
+
+Create a PR to `develop` with `Closes #222` and a GitNexus Impact Summary containing `Risk level`, `Critical skeleton changes`, `GitNexus impact`, and `Verification`.

--- a/packages/core/src/executor/executor.ts
+++ b/packages/core/src/executor/executor.ts
@@ -19,11 +19,10 @@ import { buildOrderedPhaseGroups, detectLanguage } from './phase-ordering.js';
 import { PhaseRunner } from './phase-runner.js';
 import { executeStepsWithProgressEnforcement } from './progress-enforcement.js';
 import { executeStepsWithErrorFeedbackViaLangGraph } from './step-feedback-runner.js';
+import { createStepTraceRecorder } from './step-trace-recorder.js';
 import type {
   ExecutorCollectedContext,
   ExecutorConfig,
-  ExecutorSubStage,
-  ExecutorTraceStage,
   MCPClient,
   PhaseExecutionGroup,
 } from './types.js';
@@ -85,24 +84,6 @@ export class Executor {
     return Number(process.hrtime.bigint()) / 1_000_000;
   }
 
-  private isTraceEnabled(): boolean {
-    return Boolean(this.config.trace?.enabled || this.config.trace?.onStepTrace);
-  }
-
-  private createTraceStage(
-    name: ExecutorTraceStage['name'],
-    startedAtMs: number,
-    success: boolean,
-    error?: string,
-  ): ExecutorTraceStage {
-    return {
-      name,
-      durationMs: this.nowMs() - startedAtMs,
-      success,
-      error,
-    };
-  }
-
   registerMCPClient(name: string, client: MCPClient): void {
     this.mcpClients.set(name, client);
   }
@@ -127,69 +108,22 @@ export class Executor {
     },
   ): Promise<ExecutorOutput> {
     const startTime = Date.now();
-    const traceEnabled = this.isTraceEnabled();
-    const traceStartedAt = traceEnabled ? this.nowMs() : 0;
-    const traceStages: ExecutorTraceStage[] = [];
-    const subStages: ExecutorSubStage[] = [];
-
-    const finish = (output: ExecutorOutput): ExecutorOutput => {
-      if (traceEnabled) {
-        const stepResult = output.stepResult;
-        const toolResult = stepResult.output as Record<string, unknown> | undefined;
-        this.config.trace?.onStepTrace?.({
-          taskId: context.task.id,
-          stepId: step.stepId,
-          action: step.action,
-          tool: step.tool,
-          totalMs: this.nowMs() - traceStartedAt,
-          success: stepResult.success,
-          skipped:
-            typeof stepResult.output === 'object' &&
-            stepResult.output !== null &&
-            Boolean((stepResult.output as { skipped?: boolean }).skipped),
-          error: stepResult.error,
-          stages: traceStages,
-          toolDurationMs: toolResult?.__toolDurationMs as number | undefined,
-          subStages: subStages.length > 0 ? subStages : undefined,
-        });
-      }
-      return output;
-    };
-
-    const withStage = async <T>(
-      name: ExecutorTraceStage['name'],
-      fn: () => Promise<T> | T,
-    ): Promise<T> => {
-      if (!traceEnabled) {
-        return fn();
-      }
-      const stageStartedAt = this.nowMs();
-      try {
-        const result = await fn();
-        traceStages.push(this.createTraceStage(name, stageStartedAt, true));
-        return result;
-      } catch (error) {
-        traceStages.push(
-          this.createTraceStage(
-            name,
-            stageStartedAt,
-            false,
-            error instanceof Error ? error.message : String(error),
-          ),
-        );
-        throw error;
-      }
-    };
+    const trace = createStepTraceRecorder({
+      trace: this.config.trace,
+      taskId: context.task.id,
+      step,
+      nowMs: () => this.nowMs(),
+    });
 
     try {
-      const paramValidation = await withStage('validate_params', () =>
+      const paramValidation = await trace.withStage('validate_params', () =>
         this.validateStepParams(step),
       );
       if (!paramValidation.valid) {
         if (this.config.debug) {
           console.log(`[Executor] Skipping step due to invalid params: ${paramValidation.reason}`);
         }
-        return finish({
+        return trace.finish({
           stepResult: {
             success: true,
             output: { skipped: true, reason: paramValidation.reason },
@@ -200,7 +134,7 @@ export class Executor {
         });
       }
 
-      const preValidation = await withStage('validate_before', () =>
+      const preValidation = await trace.withStage('validate_before', () =>
         this.validateBeforeExecution(step, context),
       );
       if (!preValidation.pass) {
@@ -213,7 +147,7 @@ export class Executor {
           if (this.config.debug) {
             console.log(`[Executor] Skipping step due to validation: ${errorMsg}`);
           }
-          return finish({
+          return trace.finish({
             stepResult: {
               success: true,
               output: { skipped: true, reason: errorMsg, exists: false },
@@ -224,7 +158,7 @@ export class Executor {
           });
         }
 
-        return finish({
+        return trace.finish({
           stepResult: {
             success: false,
             error: `Pre-execution validation failed: ${errorMsg}`,
@@ -245,18 +179,20 @@ export class Executor {
         console.log('[Executor] Step params:', toolParams);
       }
 
-      toolParams = await withStage('prepare_tool_params', () =>
+      toolParams = await trace.withStage('prepare_tool_params', () =>
         this.actionSkills.prepareToolParams({
           step,
           params: toolParams,
           context,
           onSubStageTiming: (name, durationMs) => {
-            subStages.push({ name, durationMs, success: true });
+            trace.addSubStage(name, durationMs);
           },
         }),
       );
 
-      const toolResult = await withStage('call_tool', () => this.callTool(step.tool, toolParams));
+      const toolResult = await trace.withStage('call_tool', () =>
+        this.callTool(step.tool, toolParams),
+      );
 
       if (typeof toolResult === 'object' && toolResult !== null) {
         const resultObj = toolResult as { success?: boolean; error?: string };
@@ -266,7 +202,7 @@ export class Executor {
             if (this.config.debug) {
               console.log(`[Executor] Skipping step due to tool error: ${resultObj.error}`);
             }
-            return finish({
+            return trace.finish({
               stepResult: {
                 success: true,
                 output: { skipped: true, reason: resultObj.error },
@@ -279,7 +215,7 @@ export class Executor {
         }
       }
 
-      const postValidation = await withStage('validate_after', () =>
+      const postValidation = await trace.withStage('validate_after', () =>
         this.validateAfterExecution(step, toolResult, toolParams),
       );
 
@@ -291,23 +227,14 @@ export class Executor {
         snapshotId: (toolResult as { snapshotId?: string })?.snapshotId,
       };
 
-      return finish({
+      return trace.finish({
         stepResult,
         validation: postValidation,
         needsRollback: !postValidation.pass && step.validation.some((v) => v.required),
       });
     } catch (error) {
-      if (traceEnabled && traceStages.length === 0) {
-        traceStages.push(
-          this.createTraceStage(
-            'catch',
-            traceStartedAt,
-            false,
-            error instanceof Error ? error.message : String(error),
-          ),
-        );
-      }
-      return finish({
+      trace.markCatchIfEmpty(error);
+      return trace.finish({
         stepResult: {
           success: false,
           error: error instanceof Error ? error.message : String(error),

--- a/packages/core/src/executor/step-trace-recorder.ts
+++ b/packages/core/src/executor/step-trace-recorder.ts
@@ -1,0 +1,114 @@
+import type { ExecutionStep } from '@frontagent/shared';
+import type { ExecutorOutput } from '../types.js';
+import type {
+  ExecutorStepTrace,
+  ExecutorSubStage,
+  ExecutorTraceConfig,
+  ExecutorTraceStage,
+} from './types.js';
+
+export interface StepTraceRecorderOptions {
+  trace?: ExecutorTraceConfig;
+  taskId: string;
+  step: ExecutionStep;
+  nowMs(): number;
+}
+
+export interface StepTraceRecorder {
+  addSubStage(name: string, durationMs: number, success?: boolean, error?: string): void;
+  finish(output: ExecutorOutput): ExecutorOutput;
+  markCatchIfEmpty(error: unknown): void;
+  withStage<T>(name: ExecutorTraceStage['name'], fn: () => Promise<T> | T): Promise<T>;
+}
+
+function isTraceEnabled(trace?: ExecutorTraceConfig): boolean {
+  return Boolean(trace?.enabled || trace?.onStepTrace);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function createTraceStage(
+  name: ExecutorTraceStage['name'],
+  nowMs: () => number,
+  startedAtMs: number,
+  success: boolean,
+  error?: string,
+): ExecutorTraceStage {
+  return {
+    name,
+    durationMs: nowMs() - startedAtMs,
+    success,
+    error,
+  };
+}
+
+function isSkippedOutput(output: unknown): boolean {
+  return (
+    typeof output === 'object' &&
+    output !== null &&
+    Boolean((output as { skipped?: boolean }).skipped)
+  );
+}
+
+export function createStepTraceRecorder({
+  trace,
+  taskId,
+  step,
+  nowMs,
+}: StepTraceRecorderOptions): StepTraceRecorder {
+  const enabled = isTraceEnabled(trace);
+  const traceStartedAt = enabled ? nowMs() : 0;
+  const stages: ExecutorTraceStage[] = [];
+  const subStages: ExecutorSubStage[] = [];
+
+  return {
+    addSubStage(name, durationMs, success = true, error) {
+      subStages.push({ name, durationMs, success, error });
+    },
+
+    finish(output) {
+      if (enabled) {
+        const stepResult = output.stepResult;
+        const toolResult = stepResult.output as Record<string, unknown> | undefined;
+        const stepTrace: ExecutorStepTrace = {
+          taskId,
+          stepId: step.stepId,
+          action: step.action,
+          tool: step.tool,
+          totalMs: nowMs() - traceStartedAt,
+          success: stepResult.success,
+          skipped: isSkippedOutput(stepResult.output),
+          error: stepResult.error,
+          stages,
+          toolDurationMs: toolResult?.__toolDurationMs as number | undefined,
+          subStages: subStages.length > 0 ? subStages : undefined,
+        };
+        trace?.onStepTrace?.(stepTrace);
+      }
+      return output;
+    },
+
+    markCatchIfEmpty(error) {
+      if (enabled && stages.length === 0) {
+        stages.push(createTraceStage('catch', nowMs, traceStartedAt, false, errorMessage(error)));
+      }
+    },
+
+    async withStage(name, fn) {
+      if (!enabled) {
+        return fn();
+      }
+      const stageStartedAt = nowMs();
+      try {
+        const result = await fn();
+        stages.push(createTraceStage(name, nowMs, stageStartedAt, true));
+        return result;
+      } catch (error) {
+        stages.push(createTraceStage(name, nowMs, stageStartedAt, false, errorMessage(error)));
+        throw error;
+      }
+    },
+  };
+}

--- a/packages/core/src/executor/trace.test.ts
+++ b/packages/core/src/executor/trace.test.ts
@@ -1,4 +1,7 @@
+import type { ExecutionStep } from '@frontagent/shared';
 import { describe, expect, it } from 'vitest';
+import type { ExecutorOutput } from '../types.js';
+import { createStepTraceRecorder } from './step-trace-recorder.js';
 import { createTraceCollector } from './trace.js';
 import type { ExecutorStepTrace } from './types.js';
 
@@ -11,6 +14,34 @@ function makeTrace(overrides: Partial<ExecutorStepTrace> = {}): ExecutorStepTrac
     success: true,
     stages: [{ name: 'call_tool', durationMs: 80, success: true }],
     toolDurationMs: 80,
+    ...overrides,
+  };
+}
+
+function makeStep(overrides: Partial<ExecutionStep> = {}): ExecutionStep {
+  return {
+    stepId: 'step-1',
+    description: 'Read a file',
+    action: 'read_file',
+    tool: 'read_file',
+    params: { path: 'src/a.ts' },
+    dependencies: [],
+    validation: [],
+    status: 'pending',
+    phase: 'build',
+    ...overrides,
+  };
+}
+
+function makeOutput(overrides: Partial<ExecutorOutput> = {}): ExecutorOutput {
+  return {
+    stepResult: {
+      success: true,
+      output: { success: true },
+      duration: 10,
+    },
+    validation: { pass: true, results: [] },
+    needsRollback: false,
     ...overrides,
   };
 }
@@ -119,5 +150,92 @@ describe('createTraceCollector', () => {
 
     const summary = collector.summary();
     expect(summary.write_file.toolDurationMs).toEqual({ avg: 0, min: 0, median: 0, max: 0 });
+  });
+});
+
+describe('createStepTraceRecorder', () => {
+  it('emits the executeStep trace payload when finishing skipped output', () => {
+    const traces: ExecutorStepTrace[] = [];
+    let now = 100;
+    const output = makeOutput({
+      stepResult: {
+        success: true,
+        output: { skipped: true, reason: 'missing path', __toolDurationMs: 12 },
+        duration: 20,
+      },
+    });
+    const recorder = createStepTraceRecorder({
+      trace: {
+        enabled: true,
+        onStepTrace: (trace) => traces.push(trace),
+      },
+      taskId: 'task-1',
+      step: makeStep(),
+      nowMs: () => now,
+    });
+
+    now = 117;
+    recorder.addSubStage('hallucination_check', 7);
+    now = 140;
+    const returned = recorder.finish(output);
+
+    expect(returned).toBe(output);
+    expect(traces).toEqual([
+      expect.objectContaining({
+        taskId: 'task-1',
+        stepId: 'step-1',
+        action: 'read_file',
+        tool: 'read_file',
+        totalMs: 40,
+        success: true,
+        skipped: true,
+        toolDurationMs: 12,
+        stages: [],
+        subStages: [{ name: 'hallucination_check', durationMs: 7, success: true }],
+      }),
+    ]);
+  });
+
+  it('records failed stage timing and error before finish emits the trace', async () => {
+    const traces: ExecutorStepTrace[] = [];
+    let now = 0;
+    const recorder = createStepTraceRecorder({
+      trace: {
+        enabled: true,
+        onStepTrace: (trace) => traces.push(trace),
+      },
+      taskId: 'task-1',
+      step: makeStep(),
+      nowMs: () => now,
+    });
+
+    await expect(
+      recorder.withStage('call_tool', async () => {
+        now = 5;
+        throw new Error('tool exploded');
+      }),
+    ).rejects.toThrow('tool exploded');
+
+    now = 9;
+    recorder.finish(
+      makeOutput({
+        stepResult: {
+          success: false,
+          error: 'tool exploded',
+          duration: 9,
+        },
+        validation: { pass: false, results: [], blockedBy: ['tool exploded'] },
+        needsRollback: true,
+      }),
+    );
+
+    expect(traces[0]).toEqual(
+      expect.objectContaining({
+        totalMs: 9,
+        success: false,
+        error: 'tool exploded',
+        stages: [{ name: 'call_tool', durationMs: 5, success: false, error: 'tool exploded' }],
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Linked Issue Or Context

Closes #222

## Summary

- Extracted `executeStep` trace lifecycle handling into an internal `createStepTraceRecorder` helper.
- Kept validation, tool parameter preparation, tool invocation, security approval, rollback decisions, LangGraph execution, and public executor APIs unchanged.
- Added focused trace helper tests and a short implementation plan under `docs/superpowers/plans/`.

## Impact Scope

- `packages/core/src/executor/executor.ts`: `executeStep` now delegates trace stage recording and final trace emission.
- `packages/core/src/executor/step-trace-recorder.ts`: new internal helper for trace lifecycle state.
- `packages/core/src/executor/trace.test.ts`: focused coverage for skipped trace output and failed stage timing.

## GitNexus Impact Summary

- Risk level: MEDIUM
- Critical skeleton changes: Executor orchestration internals only; trace lifecycle was extracted from `Executor.executeStep` without changing `ExecutorOutput` shape, security approval behavior, action skill semantics, rollback behavior, LangGraph execution, or public APIs.
- GitNexus impact: Before editing, `impact` on `Executor.executeStep` reported LOW risk with 3 direct dependents (`executor.test.ts`, `security.test.ts`, and the indexed executeStep self-flow) and 1 affected Executor process group. After refreshing the index, staged `detect_changes` reported 4 files, 30 symbols, MEDIUM risk, and 5 affected flows: `ExecuteStep -> WithStage`, `ExecuteStep -> ValidateStepParams`, `ExecuteStep -> Finish`, `WithStage -> NowMs`, and `MarkCatchIfEmpty -> NowMs`.
- Verification: `pnpm agent:bootstrap` passed; `pnpm quality:predev` passed; `pnpm --filter @frontagent/core test -- src/executor/trace.test.ts` failed first for missing `step-trace-recorder.js` then passed after implementation; `pnpm --filter @frontagent/core test -- src/executor/executor.test.ts src/executor/trace.test.ts` passed; `pnpm --filter @frontagent/core typecheck` passed; `pnpm quality:precommit` passed; push hook `pnpm quality:local` passed.

## Verification

- [x] `pnpm agent:bootstrap`
- [x] `pnpm quality:predev`
- [x] `pnpm --filter @frontagent/core test -- src/executor/executor.test.ts src/executor/trace.test.ts`
- [x] `pnpm --filter @frontagent/core typecheck`
- [x] `pnpm quality:precommit`
- [x] `pnpm quality:local` via pre-push hook

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.
