### PR TITLE
Extract VS Code webview body renderer

### DIFF
--- a/apps/vscode/src/webview-html.test.ts
+++ b/apps/vscode/src/webview-html.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   getWebviewHtml,
   nonce,
+  renderWebviewBodySection,
   renderWebviewScriptSection,
   renderWebviewStyleSection,
 } from './webview-html.js';
@@ -46,5 +47,12 @@ describe('VS Code webview HTML nonce handling', () => {
 
     expect(scriptNonce).toBeDefined();
     expect(scriptSection).toBe(renderWebviewScriptSection(scriptNonce ?? ''));
+  });
+
+  it('renders the body markup through a focused renderer', () => {
+    const html = getWebviewHtml({ cspSource: 'vscode-webview://frontagent.test' } as never);
+    const bodySection = html.match(/<body>\n([\s\S]*?)\n\n {2}<script nonce="/)?.[1];
+
+    expect(bodySection).toBe(renderWebviewBodySection());
   });
 });

--- a/apps/vscode/src/webview-html.ts
+++ b/apps/vscode/src/webview-html.ts
@@ -727,25 +727,8 @@ export function renderWebviewScriptSection(scriptNonce: string): string {
   </script>`;
 }
 
-export function getWebviewHtml(webview: vscode.Webview): string {
-  const scriptNonce = nonce();
-  const styleNonce = nonce();
-  const csp = [
-    `default-src 'none'`,
-    `style-src ${webview.cspSource} 'nonce-${styleNonce}'`,
-    `script-src 'nonce-${scriptNonce}'`,
-  ].join('; ');
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="${csp}">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-${renderWebviewStyleSection(styleNonce)}
-</head>
-<body>
-  <div class="shell">
+export function renderWebviewBodySection(): string {
+  return `  <div class="shell">
     <header class="top">
       <div class="bar">
         <div class="identity">
@@ -834,7 +817,28 @@ ${renderWebviewStyleSection(styleNonce)}
         </div>
       </details>
     </form>
-  </div>
+  </div>`;
+}
+
+export function getWebviewHtml(webview: vscode.Webview): string {
+  const scriptNonce = nonce();
+  const styleNonce = nonce();
+  const csp = [
+    `default-src 'none'`,
+    `style-src ${webview.cspSource} 'nonce-${styleNonce}'`,
+    `script-src 'nonce-${scriptNonce}'`,
+  ].join('; ');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="${csp}">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+${renderWebviewStyleSection(styleNonce)}
+</head>
+<body>
+${renderWebviewBodySection()}
 
 ${renderWebviewScriptSection(scriptNonce)}
 </body>

--- a/docs/superpowers/plans/2026-06-08-vscode-webview-body-renderer.md
+++ b/docs/superpowers/plans/2026-06-08-vscode-webview-body-renderer.md
@@ -1,0 +1,133 @@
+# VS Code Webview Body Renderer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve Issue #223 by extracting the VS Code webview body markup from `getWebviewHtml` without changing generated HTML, CSP nonce behavior, message protocol, state behavior, IDs, classes, or UI copy.
+
+**Architecture:** Keep `getWebviewHtml(webview)` as the public document renderer that owns nonce generation, CSP construction, `<head>`, style section insertion, script section insertion, and final document assembly. Add `renderWebviewBodySection()` beside the existing style and script renderers; the new helper returns only the existing `.shell` body markup so future body changes can be reviewed independently.
+
+**Tech Stack:** TypeScript, VS Code webview HTML, Vitest, GitNexus CLI.
+
+---
+
+### Task 1: Add the Body Renderer Contract Test
+
+**Files:**
+- Modify: `apps/vscode/src/webview-html.test.ts`
+- Read: `apps/vscode/src/webview-html.ts`
+
+**GitNexus impact before code edits:** `npx gitnexus impact getWebviewHtml --direction upstream --file apps/vscode/src/webview-html.ts --kind Function --include-tests --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-vscode-webview-body-renderer` reported LOW risk, 1 direct dependent (`apps/vscode/src/webview-html.test.ts`), and 0 affected processes/modules. `context getWebviewHtml` showed outgoing calls to `nonce`, `renderWebviewStyleSection`, and `renderWebviewScriptSection`, with runtime flow participation in `ResolveWebviewView -> Nonce`, `ResolveWebviewView -> RenderWebviewStyleSection`, and `ResolveWebviewView -> RenderWebviewScriptSection`. `query "VS Code webview body render sections"` surfaced the same `ResolveWebviewView -> RenderWebviewScriptSection` flow and `getWebviewHtml`.
+
+- [ ] **Step 1: Write the failing import and test**
+
+Change the import to include `renderWebviewBodySection`:
+
+```ts
+import {
+  getWebviewHtml,
+  nonce,
+  renderWebviewBodySection,
+  renderWebviewScriptSection,
+  renderWebviewStyleSection,
+} from './webview-html.js';
+```
+
+Add this test in the existing `describe` block:
+
+```ts
+it('renders the body markup through a focused renderer', () => {
+  const html = getWebviewHtml({ cspSource: 'vscode-webview://frontagent.test' } as never);
+  const bodySection = html.match(/<body>\n([\s\S]*?)\n\n {2}<script nonce="/)?.[1];
+
+  expect(bodySection).toBe(renderWebviewBodySection());
+});
+```
+
+- [ ] **Step 2: Run focused test and verify RED**
+
+Run:
+
+```bash
+pnpm --filter frontagent test -- src/webview-html.test.ts
+```
+
+Expected: FAIL because `renderWebviewBodySection` is not exported yet.
+
+### Task 2: Extract the Body Markup Renderer
+
+**Files:**
+- Modify: `apps/vscode/src/webview-html.ts`
+- Test: `apps/vscode/src/webview-html.test.ts`
+
+- [ ] **Step 1: Add the renderer**
+
+Move the exact current body markup from inside `<body>` into a new exported function after `renderWebviewScriptSection` and before `getWebviewHtml`:
+
+```ts
+export function renderWebviewBodySection(): string {
+  return `  <div class="shell">
+    <header class="top">
+      ...
+  </div>`;
+}
+```
+
+The helper must preserve every existing ID, class, label, placeholder, text node, and indentation in the moved markup.
+
+- [ ] **Step 2: Replace the inline body markup**
+
+In `getWebviewHtml`, replace only the original body markup between `<body>` and `${renderWebviewScriptSection(scriptNonce)}` with:
+
+```ts
+${renderWebviewBodySection()}
+```
+
+- [ ] **Step 3: Run focused test and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter frontagent test -- src/webview-html.test.ts
+```
+
+Expected: PASS with nonce, style, script, and body renderer tests passing.
+
+### Task 3: Verify and Prepare PR
+
+**Files:**
+- Read: final diff only
+
+- [ ] **Step 1: Run scoped and broader validation**
+
+Run:
+
+```bash
+pnpm --filter frontagent test -- src/webview-html.test.ts
+pnpm --filter frontagent typecheck
+pnpm quality:precommit
+```
+
+Expected: commands pass. If `.gitnexus/*` index drift appears after quality gates, do not stage it unless the task explicitly asks for GitNexus seed updates.
+
+- [ ] **Step 2: Run GitNexus detect changes**
+
+Run:
+
+```bash
+npx gitnexus detect_changes --scope all --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-vscode-webview-body-renderer
+```
+
+Expected: changed symbols are limited to `getWebviewHtml`, new `renderWebviewBodySection`, focused webview HTML test coverage, and this plan document.
+
+- [ ] **Step 3: Open PR**
+
+Push branch `improve/vscode-webview-body-renderer` and open a PR to `develop` with `Closes #223` and a GitNexus Impact Summary:
+
+```md
+## GitNexus Impact Summary
+
+- Risk level: MEDIUM
+- Critical skeleton changes: none; touched VS Code webview HTML helper extraction and focused test/plan only.
+- GitNexus impact: `getWebviewHtml` upstream impact was LOW with 1 direct dependent (`apps/vscode/src/webview-html.test.ts`), 0 affected processes/modules; context/query found the existing `ResolveWebviewView` webview render flow. `detect_changes` reported MEDIUM risk with changed symbol `getWebviewHtml` and affected flows `ResolveWebviewView -> Nonce`, `ResolveWebviewView -> RenderWebviewStyleSection`, and `ResolveWebviewView -> RenderWebviewScriptSection`.
+- Verification: include focused test, typecheck, quality gate, and `detect_changes` results.
+```


### PR DESCRIPTION
## Linked Issue Or Context

Closes #223

## Summary

- Extracted the VS Code webview body markup into `renderWebviewBodySection()`.
- Kept `getWebviewHtml()` responsible for nonce generation, CSP construction, style/body/script assembly, and final document structure.
- Added focused webview HTML coverage for the body renderer and recorded the implementation plan.

## Impact Scope

Scoped to `apps/vscode/src/webview-html.ts`, `apps/vscode/src/webview-html.test.ts`, and `docs/superpowers/plans/2026-06-08-vscode-webview-body-renderer.md`. No CSP, nonce generation, message protocol, state behavior, IDs/classes, UI copy, or script wiring changed.

## GitNexus Impact Summary

- Risk level: MEDIUM
- Critical skeleton changes: none; VS Code webview HTML helper extraction plus focused test/plan only.
- GitNexus impact: pre-edit `getWebviewHtml` upstream impact was LOW with 1 direct dependent (`apps/vscode/src/webview-html.test.ts`) and 0 affected processes/modules. `context getWebviewHtml` found outgoing calls to `nonce`, `renderWebviewStyleSection`, and `renderWebviewScriptSection`; `query` surfaced the existing `ResolveWebviewView` webview render flow. Final `detect_changes` reported 3 files, changed symbol `getWebviewHtml`, MEDIUM risk, and affected flows `ResolveWebviewView -> Nonce`, `ResolveWebviewView -> RenderWebviewStyleSection`, and `ResolveWebviewView -> RenderWebviewScriptSection`.
- Verification: `pnpm agent:bootstrap`; `pnpm quality:predev`; RED `pnpm --filter frontagent test -- src/webview-html.test.ts` failed on missing `renderWebviewBodySection`; GREEN `pnpm --filter frontagent test -- src/webview-html.test.ts` passed 5 tests; `pnpm --filter @frontagent/runtime-node... build`; `pnpm --filter frontagent typecheck`; `pnpm quality:precommit`; pre-push `pnpm quality:local` passed.

## Verification

- `pnpm --filter frontagent test -- src/webview-html.test.ts`
- `pnpm --filter frontagent typecheck`
- `pnpm quality:precommit`
- `pnpm quality:local` via pre-push hook
- `npx gitnexus detect_changes --scope staged --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-vscode-webview-body-renderer`

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.