### PR TITLE
refactor(core): extract ContextManager facts merge helpers

### DIFF
--- a/docs/superpowers/plans/2026-06-08-contextmanager-facts-merge-helpers.md
+++ b/docs/superpowers/plans/2026-06-08-contextmanager-facts-merge-helpers.md
@@ -1,0 +1,39 @@
+# ContextManager Facts Merge Helpers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `ContextManager` facts update merge and snapshot replacement clone mechanics into a focused helper module without changing public APIs or serialized shapes.
+
+**Architecture:** `ContextManager` remains the public task-scoped facade. A new context-local helper module owns `ProjectFacts` snapshot export, snapshot materialization, and `ProjectFactsUpdate` mutation logic using the existing `ProjectFacts`, `ProjectFactsSnapshot`, and `ProjectFactsUpdate` types.
+
+**Tech Stack:** TypeScript, Vitest, pnpm workspace, GitNexus.
+
+---
+
+## Impact And Risk
+
+- GitNexus impact before edits:
+  - `ContextManager` class: CRITICAL, 23 impacted symbols, 12 direct, 5 affected Agent processes (`planOnly`, `execute`, `enqueueFactsUpdate`, `executeSteps`, `constructor`).
+  - `exportFactsSnapshot`: LOW, 0 impacted symbols.
+  - `mergeFactsUpdate`: LOW, 2 impacted symbols; direct caller `FrontAgent.flushFactsUpdates`; affected process `enqueueFactsUpdate`.
+  - `replaceFactsFromSnapshot`: LOW, 0 impacted symbols.
+  - private set/mapping helpers: LOW; direct users include existing ContextManager facts methods.
+- Risk handling: keep `ContextManager` public methods and external types unchanged; only delegate existing logic to helper functions.
+
+## Files
+
+- Create: `packages/core/src/context/facts-merge-helpers.ts`
+- Modify: `packages/core/src/context/context-manager.ts`
+- Modify: `packages/core/src/context/context-manager.test.ts`
+
+## Tasks
+
+- [x] Add focused tests that assert exported snapshots and replaced facts are independent deep clones for module arrays, directory contents, and errors.
+- [x] Add focused tests that assert merged `ProjectFactsUpdate` clones mutable arrays/errors from the update payload and reports unchanged updates without revision bumps.
+- [x] Run focused context tests to confirm any new regression-focused assertions fail before helper extraction if they expose currently under-specified behavior.
+- [x] Implement `exportProjectFactsSnapshot`, `projectFactsFromSnapshot`, and `mergeProjectFactsUpdate` in `facts-merge-helpers.ts`.
+- [x] Replace low-level facts merge/snapshot logic in `ContextManager` with helper delegation while preserving unknown-task behavior.
+- [x] Run focused tests: `pnpm --filter @frontagent/core test -- src/context/context-manager.test.ts src/context/fact-serializer.test.ts`.
+- [x] Run typecheck: `pnpm --filter @frontagent/core typecheck`.
+- [x] Run `pnpm quality:precommit` because `packages/core/src/context/` is an agent-core critical skeleton path.
+- [x] Run `npx gitnexus detect_changes --scope staged` and include the output summary in the PR body.

--- a/packages/core/src/context/context-manager.test.ts
+++ b/packages/core/src/context/context-manager.test.ts
@@ -1,7 +1,12 @@
 import type { AgentTask, ExecutionPlan, ExecutionStep, SDDConfig } from '@frontagent/shared';
 import { describe, expect, it } from 'vitest';
-import type { Message } from '../types.js';
+import type { Message, ModuleInfo, ProjectFactsUpdate } from '../types.js';
 import { ContextManager, createContextManager } from './context-manager.js';
+import {
+  exportProjectFactsSnapshot,
+  mergeProjectFactsUpdate,
+  projectFactsFromSnapshot,
+} from './facts-merge-helpers.js';
 
 function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
   return {
@@ -565,6 +570,104 @@ describe('ContextManager', () => {
         changes: {},
       });
       expect(result.applied).toBe(false);
+    });
+  });
+
+  describe('facts merge helpers', () => {
+    it('clones mutable snapshot values when exporting and restoring facts', () => {
+      const manager = new ContextManager();
+      const facts = manager.createContext(makeTask({ id: 't1' })).facts;
+      const moduleInfo: ModuleInfo = {
+        path: 'src/app.ts',
+        type: 'component',
+        exports: ['App'],
+        imports: ['react'],
+      };
+
+      facts.revision = 7;
+      facts.filesystem.existingFiles.add('src/app.ts');
+      facts.filesystem.directoryContents.set('src', ['src/app.ts']);
+      facts.moduleDependencyGraph.modules.set(moduleInfo.path, moduleInfo);
+      facts.moduleDependencyGraph.dependencies.set(moduleInfo.path, ['react']);
+      facts.errors.push({ stepId: 's1', type: 'test', message: 'original', timestamp: 1 });
+
+      const snapshot = exportProjectFactsSnapshot(facts);
+
+      moduleInfo.exports.push('mutated-after-export');
+      facts.filesystem.directoryContents.get('src')!.push('src/mutated.ts');
+      facts.moduleDependencyGraph.dependencies.get(moduleInfo.path)!.push('mutated-dep');
+      facts.errors[0].message = 'mutated-after-export';
+
+      expect(snapshot.moduleDependencyGraph.modules[moduleInfo.path].exports).toEqual(['App']);
+      expect(snapshot.filesystem.directoryContents.src).toEqual(['src/app.ts']);
+      expect(snapshot.moduleDependencyGraph.dependencies[moduleInfo.path]).toEqual(['react']);
+      expect(snapshot.errors[0].message).toBe('original');
+
+      const restored = projectFactsFromSnapshot(snapshot);
+      snapshot.moduleDependencyGraph.modules[moduleInfo.path].imports.push('mutated-after-restore');
+      snapshot.filesystem.directoryContents.src.push('src/after-restore.ts');
+      snapshot.errors[0].message = 'mutated-after-restore';
+
+      expect(restored.moduleDependencyGraph.modules.get(moduleInfo.path)!.imports).toEqual([
+        'react',
+      ]);
+      expect(restored.filesystem.directoryContents.get('src')).toEqual(['src/app.ts']);
+      expect(restored.errors[0].message).toBe('original');
+    });
+
+    it('merges facts updates with cloned mutable payload values', () => {
+      const manager = new ContextManager();
+      const facts = manager.createContext(makeTask({ id: 't1' })).facts;
+      const moduleInfo: ModuleInfo = {
+        path: 'src/app.ts',
+        type: 'component',
+        exports: ['App'],
+        imports: ['react'],
+      };
+      const update: ProjectFactsUpdate = {
+        baseRevision: 0,
+        source: 'sub-agent',
+        timestamp: 1,
+        changes: {
+          setDirectoryContents: [{ path: 'src', entries: ['src/app.ts'] }],
+          upsertModules: [moduleInfo],
+          setDependencies: [{ path: moduleInfo.path, dependencies: ['react'] }],
+          addErrors: [{ stepId: 's1', type: 'test', message: 'original', timestamp: 1 }],
+        },
+      };
+
+      const result = mergeProjectFactsUpdate(facts, update);
+
+      moduleInfo.exports.push('mutated-after-merge');
+      update.changes.setDirectoryContents![0].entries.push('src/mutated.ts');
+      update.changes.setDependencies![0].dependencies.push('mutated-dep');
+      update.changes.addErrors![0].message = 'mutated-after-merge';
+
+      expect(result.applied).toBe(true);
+      expect(result.previousRevision).toBe(0);
+      expect(result.nextRevision).toBe(1);
+      expect(facts.moduleDependencyGraph.modules.get(moduleInfo.path)!.exports).toEqual(['App']);
+      expect(facts.filesystem.directoryContents.get('src')).toEqual(['src/app.ts']);
+      expect(facts.moduleDependencyGraph.dependencies.get(moduleInfo.path)).toEqual(['react']);
+      expect(facts.errors[0].message).toBe('original');
+    });
+
+    it('reports empty facts updates without bumping revision', () => {
+      const manager = new ContextManager();
+      const facts = manager.createContext(makeTask({ id: 't1' })).facts;
+
+      const result = mergeProjectFactsUpdate(facts, {
+        baseRevision: 0,
+        source: 'sub-agent',
+        timestamp: 1,
+        changes: {},
+      });
+
+      expect(result.applied).toBe(false);
+      expect(result.staleBaseRevision).toBe(false);
+      expect(result.previousRevision).toBe(0);
+      expect(result.nextRevision).toBe(0);
+      expect(facts.revision).toBe(0);
     });
   });
 

--- a/packages/core/src/context/context-manager.ts
+++ b/packages/core/src/context/context-manager.ts
@@ -3,7 +3,6 @@ import type {
   AgentContext,
   FilesenseNavigationIntent,
   Message,
-  ModuleInfo,
   ProjectFacts,
   ProjectFactsMergeResult,
   ProjectFactsSnapshot,
@@ -12,12 +11,14 @@ import type {
 } from '../types.js';
 import { serializeProjectFactsForLLM } from './fact-serializer.js';
 import {
-  cloneStringArray,
+  exportProjectFactsSnapshot,
+  mergeProjectFactsUpdate,
+  projectFactsFromSnapshot,
+} from './facts-merge-helpers.js';
+import {
   formatFilesenseNavigationContext,
-  mapToRecord,
   normalizeFilesenseNavigation,
   parentDirectoriesForPath,
-  recordToClonedStringArrayMap,
 } from './helpers.js';
 import { updateModuleDependencyGraphFromToolResult } from './module-dependency-graph.js';
 
@@ -710,44 +711,7 @@ export class ContextManager {
     const context = this.contexts.get(taskId);
     if (!context) return undefined;
 
-    const { facts } = context;
-
-    const modulesRecord: Record<string, ModuleInfo> = {};
-    for (const [path, moduleInfo] of facts.moduleDependencyGraph.modules.entries()) {
-      modulesRecord[path] = {
-        ...moduleInfo,
-        exports: cloneStringArray(moduleInfo.exports),
-        imports: cloneStringArray(moduleInfo.imports),
-      };
-    }
-
-    return {
-      revision: facts.revision,
-      filesystem: {
-        existingFiles: Array.from(facts.filesystem.existingFiles),
-        existingDirectories: Array.from(facts.filesystem.existingDirectories),
-        nonExistentPaths: Array.from(facts.filesystem.nonExistentPaths),
-        directoryContents: mapToRecord(facts.filesystem.directoryContents, cloneStringArray),
-      },
-      dependencies: {
-        installedPackages: Array.from(facts.dependencies.installedPackages),
-        missingPackages: Array.from(facts.dependencies.missingPackages),
-      },
-      project: {
-        devServerRunning: facts.project.devServerRunning,
-        runningPort: facts.project.runningPort,
-        buildStatus: facts.project.buildStatus,
-      },
-      moduleDependencyGraph: {
-        modules: modulesRecord,
-        dependencies: mapToRecord(facts.moduleDependencyGraph.dependencies, cloneStringArray),
-        reverseDependencies: mapToRecord(
-          facts.moduleDependencyGraph.reverseDependencies,
-          cloneStringArray,
-        ),
-      },
-      errors: facts.errors.map((error) => ({ ...error })),
-    };
+    return exportProjectFactsSnapshot(context.facts);
   }
 
   /**
@@ -765,120 +729,7 @@ export class ContextManager {
       };
     }
 
-    const { facts } = context;
-    const previousRevision = facts.revision;
-    const staleBaseRevision = update.baseRevision !== previousRevision;
-    let changed = false;
-    const { changes } = update;
-
-    for (const path of changes.addExistingFiles ?? []) {
-      changed = this.addToSet(facts.filesystem.existingFiles, path) || changed;
-      changed = this.removeFromSet(facts.filesystem.nonExistentPaths, path) || changed;
-    }
-
-    for (const path of changes.addExistingDirectories ?? []) {
-      changed = this.addToSet(facts.filesystem.existingDirectories, path) || changed;
-      changed = this.removeFromSet(facts.filesystem.nonExistentPaths, path) || changed;
-    }
-
-    for (const path of changes.addNonExistentPaths ?? []) {
-      changed = this.addToSet(facts.filesystem.nonExistentPaths, path) || changed;
-      changed = this.removeFromSet(facts.filesystem.existingFiles, path) || changed;
-    }
-
-    for (const path of changes.removeNonExistentPaths ?? []) {
-      changed = this.removeFromSet(facts.filesystem.nonExistentPaths, path) || changed;
-    }
-
-    for (const entry of changes.setDirectoryContents ?? []) {
-      changed =
-        this.setStringArrayMap(
-          facts.filesystem.directoryContents,
-          entry.path,
-          cloneStringArray(entry.entries),
-        ) || changed;
-    }
-
-    for (const pkg of changes.addInstalledPackages ?? []) {
-      changed = this.addToSet(facts.dependencies.installedPackages, pkg) || changed;
-      changed = this.removeFromSet(facts.dependencies.missingPackages, pkg) || changed;
-    }
-
-    for (const pkg of changes.addMissingPackages ?? []) {
-      changed = this.addToSet(facts.dependencies.missingPackages, pkg) || changed;
-    }
-
-    for (const pkg of changes.removeMissingPackages ?? []) {
-      changed = this.removeFromSet(facts.dependencies.missingPackages, pkg) || changed;
-    }
-
-    if (changes.project) {
-      const nextProject = changes.project;
-      if (
-        nextProject.devServerRunning !== undefined &&
-        facts.project.devServerRunning !== nextProject.devServerRunning
-      ) {
-        facts.project.devServerRunning = nextProject.devServerRunning;
-        changed = true;
-      }
-      if (
-        nextProject.runningPort !== undefined &&
-        facts.project.runningPort !== nextProject.runningPort
-      ) {
-        facts.project.runningPort = nextProject.runningPort;
-        changed = true;
-      }
-      if (
-        nextProject.buildStatus !== undefined &&
-        facts.project.buildStatus !== nextProject.buildStatus
-      ) {
-        facts.project.buildStatus = nextProject.buildStatus;
-        changed = true;
-      }
-    }
-
-    for (const moduleInfo of changes.upsertModules ?? []) {
-      const normalized: ModuleInfo = {
-        ...moduleInfo,
-        exports: cloneStringArray(moduleInfo.exports),
-        imports: cloneStringArray(moduleInfo.imports),
-      };
-      facts.moduleDependencyGraph.modules.set(moduleInfo.path, normalized);
-      changed = true;
-    }
-
-    for (const depEntry of changes.setDependencies ?? []) {
-      facts.moduleDependencyGraph.dependencies.set(
-        depEntry.path,
-        cloneStringArray(depEntry.dependencies),
-      );
-      changed = true;
-    }
-
-    for (const reverseDepEntry of changes.setReverseDependencies ?? []) {
-      facts.moduleDependencyGraph.reverseDependencies.set(
-        reverseDepEntry.path,
-        cloneStringArray(reverseDepEntry.reverseDependencies),
-      );
-      changed = true;
-    }
-
-    for (const error of changes.addErrors ?? []) {
-      facts.errors.push({ ...error });
-      changed = true;
-    }
-
-    if (changed) {
-      this.bumpFactsRevision(facts);
-    }
-
-    return {
-      applied: changed,
-      staleBaseRevision,
-      previousRevision,
-      nextRevision: facts.revision,
-      source: update.source,
-    };
+    return mergeProjectFactsUpdate(context.facts, update);
   }
 
   /**
@@ -888,41 +739,7 @@ export class ContextManager {
     const context = this.contexts.get(taskId);
     if (!context) return;
 
-    const modulesMap = new Map<string, ModuleInfo>();
-    for (const [path, moduleInfo] of Object.entries(snapshot.moduleDependencyGraph.modules)) {
-      modulesMap.set(path, {
-        ...moduleInfo,
-        exports: cloneStringArray(moduleInfo.exports),
-        imports: cloneStringArray(moduleInfo.imports),
-      });
-    }
-
-    context.facts = {
-      revision: snapshot.revision,
-      filesystem: {
-        existingFiles: new Set(snapshot.filesystem.existingFiles),
-        existingDirectories: new Set(snapshot.filesystem.existingDirectories),
-        nonExistentPaths: new Set(snapshot.filesystem.nonExistentPaths),
-        directoryContents: recordToClonedStringArrayMap(snapshot.filesystem.directoryContents),
-      },
-      dependencies: {
-        installedPackages: new Set(snapshot.dependencies.installedPackages),
-        missingPackages: new Set(snapshot.dependencies.missingPackages),
-      },
-      project: {
-        devServerRunning: snapshot.project.devServerRunning,
-        runningPort: snapshot.project.runningPort,
-        buildStatus: snapshot.project.buildStatus ?? 'unknown',
-      },
-      moduleDependencyGraph: {
-        modules: modulesMap,
-        dependencies: recordToClonedStringArrayMap(snapshot.moduleDependencyGraph.dependencies),
-        reverseDependencies: recordToClonedStringArrayMap(
-          snapshot.moduleDependencyGraph.reverseDependencies,
-        ),
-      },
-      errors: snapshot.errors.map((error) => ({ ...error })),
-    };
+    context.facts = projectFactsFromSnapshot(snapshot);
   }
 
   /**

--- a/packages/core/src/context/facts-merge-helpers.ts
+++ b/packages/core/src/context/facts-merge-helpers.ts
@@ -1,0 +1,222 @@
+import type {
+  ModuleInfo,
+  ProjectFacts,
+  ProjectFactsMergeResult,
+  ProjectFactsSnapshot,
+  ProjectFactsUpdate,
+} from '../types.js';
+import { cloneStringArray, mapToRecord, recordToClonedStringArrayMap } from './helpers.js';
+
+function addToSet(set: Set<string>, value: string): boolean {
+  const before = set.size;
+  set.add(value);
+  return set.size !== before;
+}
+
+function removeFromSet(set: Set<string>, value: string): boolean {
+  return set.delete(value);
+}
+
+function setStringArrayMap(map: Map<string, string[]>, key: string, value: string[]): boolean {
+  const previous = map.get(key);
+  if (
+    previous &&
+    previous.length === value.length &&
+    previous.every((item, idx) => item === value[idx])
+  ) {
+    return false;
+  }
+  map.set(key, value);
+  return true;
+}
+
+function cloneModuleInfo(moduleInfo: ModuleInfo): ModuleInfo {
+  return {
+    ...moduleInfo,
+    exports: cloneStringArray(moduleInfo.exports),
+    imports: cloneStringArray(moduleInfo.imports),
+  };
+}
+
+export function exportProjectFactsSnapshot(facts: ProjectFacts): ProjectFactsSnapshot {
+  const modulesRecord: Record<string, ModuleInfo> = {};
+  for (const [path, moduleInfo] of facts.moduleDependencyGraph.modules.entries()) {
+    modulesRecord[path] = cloneModuleInfo(moduleInfo);
+  }
+
+  return {
+    revision: facts.revision,
+    filesystem: {
+      existingFiles: Array.from(facts.filesystem.existingFiles),
+      existingDirectories: Array.from(facts.filesystem.existingDirectories),
+      nonExistentPaths: Array.from(facts.filesystem.nonExistentPaths),
+      directoryContents: mapToRecord(facts.filesystem.directoryContents, cloneStringArray),
+    },
+    dependencies: {
+      installedPackages: Array.from(facts.dependencies.installedPackages),
+      missingPackages: Array.from(facts.dependencies.missingPackages),
+    },
+    project: {
+      devServerRunning: facts.project.devServerRunning,
+      runningPort: facts.project.runningPort,
+      buildStatus: facts.project.buildStatus,
+    },
+    moduleDependencyGraph: {
+      modules: modulesRecord,
+      dependencies: mapToRecord(facts.moduleDependencyGraph.dependencies, cloneStringArray),
+      reverseDependencies: mapToRecord(
+        facts.moduleDependencyGraph.reverseDependencies,
+        cloneStringArray,
+      ),
+    },
+    errors: facts.errors.map((error) => ({ ...error })),
+  };
+}
+
+export function projectFactsFromSnapshot(snapshot: ProjectFactsSnapshot): ProjectFacts {
+  const modulesMap = new Map<string, ModuleInfo>();
+  for (const [path, moduleInfo] of Object.entries(snapshot.moduleDependencyGraph.modules)) {
+    modulesMap.set(path, cloneModuleInfo(moduleInfo));
+  }
+
+  return {
+    revision: snapshot.revision,
+    filesystem: {
+      existingFiles: new Set(snapshot.filesystem.existingFiles),
+      existingDirectories: new Set(snapshot.filesystem.existingDirectories),
+      nonExistentPaths: new Set(snapshot.filesystem.nonExistentPaths),
+      directoryContents: recordToClonedStringArrayMap(snapshot.filesystem.directoryContents),
+    },
+    dependencies: {
+      installedPackages: new Set(snapshot.dependencies.installedPackages),
+      missingPackages: new Set(snapshot.dependencies.missingPackages),
+    },
+    project: {
+      devServerRunning: snapshot.project.devServerRunning,
+      runningPort: snapshot.project.runningPort,
+      buildStatus: snapshot.project.buildStatus ?? 'unknown',
+    },
+    moduleDependencyGraph: {
+      modules: modulesMap,
+      dependencies: recordToClonedStringArrayMap(snapshot.moduleDependencyGraph.dependencies),
+      reverseDependencies: recordToClonedStringArrayMap(
+        snapshot.moduleDependencyGraph.reverseDependencies,
+      ),
+    },
+    errors: snapshot.errors.map((error) => ({ ...error })),
+  };
+}
+
+export function mergeProjectFactsUpdate(
+  facts: ProjectFacts,
+  update: ProjectFactsUpdate,
+): ProjectFactsMergeResult {
+  const previousRevision = facts.revision;
+  const staleBaseRevision = update.baseRevision !== previousRevision;
+  let changed = false;
+  const { changes } = update;
+
+  for (const path of changes.addExistingFiles ?? []) {
+    changed = addToSet(facts.filesystem.existingFiles, path) || changed;
+    changed = removeFromSet(facts.filesystem.nonExistentPaths, path) || changed;
+  }
+
+  for (const path of changes.addExistingDirectories ?? []) {
+    changed = addToSet(facts.filesystem.existingDirectories, path) || changed;
+    changed = removeFromSet(facts.filesystem.nonExistentPaths, path) || changed;
+  }
+
+  for (const path of changes.addNonExistentPaths ?? []) {
+    changed = addToSet(facts.filesystem.nonExistentPaths, path) || changed;
+    changed = removeFromSet(facts.filesystem.existingFiles, path) || changed;
+  }
+
+  for (const path of changes.removeNonExistentPaths ?? []) {
+    changed = removeFromSet(facts.filesystem.nonExistentPaths, path) || changed;
+  }
+
+  for (const entry of changes.setDirectoryContents ?? []) {
+    changed =
+      setStringArrayMap(
+        facts.filesystem.directoryContents,
+        entry.path,
+        cloneStringArray(entry.entries),
+      ) || changed;
+  }
+
+  for (const pkg of changes.addInstalledPackages ?? []) {
+    changed = addToSet(facts.dependencies.installedPackages, pkg) || changed;
+    changed = removeFromSet(facts.dependencies.missingPackages, pkg) || changed;
+  }
+
+  for (const pkg of changes.addMissingPackages ?? []) {
+    changed = addToSet(facts.dependencies.missingPackages, pkg) || changed;
+  }
+
+  for (const pkg of changes.removeMissingPackages ?? []) {
+    changed = removeFromSet(facts.dependencies.missingPackages, pkg) || changed;
+  }
+
+  if (changes.project) {
+    const nextProject = changes.project;
+    if (
+      nextProject.devServerRunning !== undefined &&
+      facts.project.devServerRunning !== nextProject.devServerRunning
+    ) {
+      facts.project.devServerRunning = nextProject.devServerRunning;
+      changed = true;
+    }
+    if (
+      nextProject.runningPort !== undefined &&
+      facts.project.runningPort !== nextProject.runningPort
+    ) {
+      facts.project.runningPort = nextProject.runningPort;
+      changed = true;
+    }
+    if (
+      nextProject.buildStatus !== undefined &&
+      facts.project.buildStatus !== nextProject.buildStatus
+    ) {
+      facts.project.buildStatus = nextProject.buildStatus;
+      changed = true;
+    }
+  }
+
+  for (const moduleInfo of changes.upsertModules ?? []) {
+    facts.moduleDependencyGraph.modules.set(moduleInfo.path, cloneModuleInfo(moduleInfo));
+    changed = true;
+  }
+
+  for (const depEntry of changes.setDependencies ?? []) {
+    facts.moduleDependencyGraph.dependencies.set(
+      depEntry.path,
+      cloneStringArray(depEntry.dependencies),
+    );
+    changed = true;
+  }
+
+  for (const reverseDepEntry of changes.setReverseDependencies ?? []) {
+    facts.moduleDependencyGraph.reverseDependencies.set(
+      reverseDepEntry.path,
+      cloneStringArray(reverseDepEntry.reverseDependencies),
+    );
+    changed = true;
+  }
+
+  for (const error of changes.addErrors ?? []) {
+    facts.errors.push({ ...error });
+    changed = true;
+  }
+
+  if (changed) {
+    facts.revision += 1;
+  }
+
+  return {
+    applied: changed,
+    staleBaseRevision,
+    previousRevision,
+    nextRevision: facts.revision,
+    source: update.source,
+  };
+}


### PR DESCRIPTION
## Linked Issue Or Context

Closes #221

## Summary

- Added `facts-merge-helpers.ts` for ProjectFacts snapshot export, snapshot restoration, and ProjectFactsUpdate merge mutation logic.
- Kept `ContextManager` public facts methods unchanged while delegating low-level clone/mutation work to the helper module.
- Added focused clone/merge tests and the required implementation plan.

## Impact Scope

- `packages/core/src/context/context-manager.ts` facts snapshot/merge public methods only.
- `packages/core/src/context/facts-merge-helpers.ts` new internal helper module.
- No changes to `ProjectFactsUpdate`, snapshot shape, public `ContextManager` API, or serialization semantics.

## GitNexus Impact Summary

- Risk level: HIGH
- Critical skeleton changes: agent-core path `packages/core/src/context/`; no public MCP boundary, memory boundary, type-shape, or serialization contract changes.
- GitNexus impact: pre-edit impact found `ContextManager` class CRITICAL with 23 impacted symbols, 12 direct dependents, and 5 affected Agent processes (`planOnly`, `execute`, `enqueueFactsUpdate`, `executeSteps`, `constructor`); `mergeFactsUpdate` was LOW with direct caller `FrontAgent.flushFactsUpdates` and affected process `enqueueFactsUpdate`; `exportFactsSnapshot` and `replaceFactsFromSnapshot` were LOW with 0 impacted symbols. GitNexus query for `ContextManager facts snapshot merge update` surfaced `flushFactsUpdates`, `mergeFactsUpdate`, `summarizeSharedFacts`, and memory snapshot paths. After rebasing onto latest `origin/develop`, `detect_changes --scope compare --base-ref origin/develop` reported 5 files, 15 symbols, 0 affected processes, risk level low, including `ContextManager`, `exportFactsSnapshot`, `mergeFactsUpdate`, `replaceFactsFromSnapshot`, and the new helper functions.
- Verification: `pnpm agent:bootstrap` passed; `pnpm quality:predev` passed; `pnpm --filter @frontagent/core test -- src/context/context-manager.test.ts src/context/fact-serializer.test.ts` passed with 57 tests; `pnpm --filter @frontagent/core typecheck` passed after building workspace dependency packages; `pnpm quality:precommit` passed; push hook `pnpm quality:local` passed after the initial push and again after the rebase/force-push, including `quality:ci` and build/package.

## Verification

- `pnpm agent:bootstrap`
- `pnpm quality:predev`
- `pnpm --filter @frontagent/core test -- src/context/context-manager.test.ts src/context/fact-serializer.test.ts`
- `pnpm --filter @frontagent/core typecheck`
- `pnpm quality:precommit`
- push hook: `pnpm quality:local`
- `npx gitnexus detect_changes --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-contextmanager-facts-merge-helpers --scope compare --base-ref origin/develop`

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.