### PR TITLE
Extract shared FrontAgent project pre-scan preparation

### DIFF
--- a/docs/superpowers/plans/2026-06-08-frontagent-project-prescan.md
+++ b/docs/superpowers/plans/2026-06-08-frontagent-project-prescan.md
@@ -1,0 +1,79 @@
+# FrontAgent Project Pre-Scan Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the duplicated `planOnly`/`execute` project preparation scan into a shared helper without changing public FrontAgent APIs, result shapes, memory lifecycle, facts flushing, planning retry, or callback ordering.
+
+**Architecture:** Keep `FrontAgent` as the orchestrator and add `packages/core/src/agent/project-prescan-preparation.ts` as a narrow helper for project structure scanning, config pre-read, dev server port detection, and RAG retrieval. `planOnly` and `execute` continue to emit the same status labels in the same order by passing `emitStatus` and RAG event emission through the helper dependencies.
+
+**Tech Stack:** TypeScript, Vitest, existing `Executor.callTool`, `detectDevServerPort`, and `retrieveRagContext`.
+
+---
+
+**GitNexus impact before code edits:**
+- `npx gitnexus impact planOnly --direction upstream --file packages/core/src/agent/agent.ts --kind Method --include-tests --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-frontagent-project-prescan`: LOW; 0 direct callers, 0 affected processes, 0 affected modules.
+- `npx gitnexus impact execute --direction upstream --file packages/core/src/agent/agent.ts --kind Method --include-tests --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-frontagent-project-prescan`: LOW; 0 direct callers, 0 affected processes, 0 affected modules.
+- `npx gitnexus impact detectDevServerPort --direction upstream --file packages/core/src/agent/dev-server-detection.ts --kind Function --include-tests --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-frontagent-project-prescan`: LOW; direct callers are `FrontAgent.planOnly`, `FrontAgent.execute`, and `dev-server-detection.test.ts`; affected process groups include `planOnly` and `execute`.
+- `npx gitnexus context FrontAgent --file packages/core/src/agent/agent.ts --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-frontagent-project-prescan`: `FrontAgent` is imported by `packages/core/src/agent/index.ts` and `packages/core/src/agent/agent.test.ts`, and constructed by `createAgent`.
+- `npx gitnexus query "FrontAgent execute planOnly project prescan RAG context" --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-frontagent-project-prescan`: query surfaced the agent/context/RAG area; this supports treating the change as agent-core risk even though symbol-level impact is LOW.
+
+### Task 1: Shared Pre-Scan Helper
+
+**Files:**
+- Create: `packages/core/src/agent/project-prescan-preparation.ts`
+- Create: `packages/core/src/agent/project-prescan-preparation.test.ts`
+- Modify: `packages/core/src/agent/agent.ts`
+
+- [ ] **Step 1: Write the failing helper test**
+
+Create a Vitest test that imports `prepareProjectPlanningContext`, stubs `executor.callTool`, `detectDevServerPort` through real behavior, and verifies:
+- status order stays `扫描项目结构`, `检测开发服务器端口`, `检索知识库`;
+- `list_directory` excludes `node_modules` and `.git` files from `projectStructure`;
+- package/vite config contents are read and passed into port detection;
+- RAG formatted results and event payload are returned.
+
+Run: `pnpm --filter @frontagent/core test -- src/agent/project-prescan-preparation.test.ts`
+Expected: FAIL because `project-prescan-preparation.ts` does not exist.
+
+- [ ] **Step 2: Implement the helper**
+
+Add `prepareProjectPlanningContext(deps, input)` that:
+- emits the existing status labels and operation strings;
+- calls `list_directory` recursively at `projectRoot`;
+- builds the same `项目文件列表（共 N 个文件）` string;
+- reads `package.json` and `vite.config*` files best-effort;
+- calls `detectDevServerPort`;
+- calls `retrieveRagContext`;
+- returns `{ projectStructure, devServerPort, ragResults, ragEvent }`.
+
+Preserve existing debug warnings by accepting a `preScanFailureLabel` string so `planOnly` keeps `[Agent] Failed to pre-scan project structure for plan-only:` and `execute` keeps `[Agent] Failed to pre-scan project structure:`.
+
+- [ ] **Step 3: Replace duplicated orchestration**
+
+In `FrontAgent.planOnly` and `FrontAgent.execute`, replace the duplicated scan/read/port/RAG block with one `prepareProjectPlanningContext` call. Keep the planner input fields unchanged, and continue to emit `rag_retrieved` only when `config.rag?.enabled !== false`.
+
+- [ ] **Step 4: Verify focused tests**
+
+Run:
+`pnpm --filter @frontagent/core test -- src/agent/project-prescan-preparation.test.ts src/agent/agent.test.ts src/agent/context-gathering.test.ts`
+
+### Task 2: Final Gates and Review
+
+**Files:**
+- Modify: implementation and test files from Task 1
+
+- [ ] **Step 1: Typecheck**
+
+Run: `pnpm --filter @frontagent/core typecheck`
+
+- [ ] **Step 2: Precommit gate**
+
+Run: `pnpm quality:precommit`
+
+- [ ] **Step 3: GitNexus final diff**
+
+Run: `npx gitnexus detect_changes --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-frontagent-project-prescan`
+
+- [ ] **Step 4: PR**
+
+Push `improve/frontagent-project-prescan` and open a PR to `develop`. The PR body must include `Closes #231`, a GitNexus Impact Summary with `detect_changes`, verification commands, and note that this is not a critical skeleton rewrite beyond extracting shared helper logic.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -39,11 +39,10 @@ import type {
 import { WorkflowIntegration } from '../workflow-integration.js';
 import { buildFinalOutput } from './answer-generation.js';
 import { gatherRequestedContext } from './context-gathering.js';
-import { detectDevServerPort } from './dev-server-detection.js';
 import { createExecutionCallbacks } from './execution-callbacks.js';
 import { FactsUpdateFlusher } from './facts-update-flush.js';
 import { persistMemory, preloadMemory } from './memory-lifecycle.js';
-import { retrieveRagContext } from './rag-retrieval.js';
+import { prepareProjectPlanningContext } from './project-prescan-preparation.js';
 
 /**
  * FrontAgent 主类
@@ -430,65 +429,25 @@ export class FrontAgent {
         });
       }
 
-      let projectStructure: string | undefined;
-      const preScannedFiles = new Map<string, string>();
-      try {
-        this.emitStatus('扫描项目结构', 'list_directory 扫描项目结构');
-        const listResult = (await this.executor.callTool('list_directory', {
-          path: this.config.projectRoot,
-          recursive: true,
-        })) as { success: boolean; entries?: Array<{ name: string; type: string; path: string }> };
-
-        if (listResult.success && listResult.entries) {
-          const files = listResult.entries
-            .filter(
-              (e) =>
-                e.type === 'file' && !e.path.includes('node_modules') && !e.path.includes('.git'),
-            )
-            .map((e) => e.path);
-
-          if (files.length > 0) {
-            projectStructure = `项目文件列表（共 ${files.length} 个文件）:\n${files.join('\n')}`;
-          }
-
-          const configFiles = files.filter(
-            (f) => f.endsWith('package.json') || f.includes('vite.config'),
-          );
-          for (const configFile of configFiles) {
-            try {
-              const readResult = (await this.executor.callTool('read_file', {
-                path: configFile,
-              })) as { success: boolean; content?: string };
-              if (readResult.success && readResult.content) {
-                preScannedFiles.set(configFile, readResult.content);
-              }
-            } catch {
-              // Ignore optional pre-scan read failures.
-            }
-          }
-        }
-      } catch (error) {
-        this.debugWarn('[Agent] Failed to pre-scan project structure for plan-only:', error);
-      }
-
-      this.emitStatus('检测开发服务器端口', '检测开发服务器端口');
-      const devServerPort = detectDevServerPort(
-        { debugLog: this.debugLog.bind(this), debugWarn: this.debugWarn.bind(this) },
-        preScannedFiles,
-      );
-
-      this.emitStatus('检索知识库', 'RAG 检索');
-      const ragContext = await retrieveRagContext(this.ragDeps, task.id, task.description);
-      const ragResults = ragContext?.formattedResults;
+      const planningPreparation = await prepareProjectPlanningContext({
+        deps: {
+          executor: this.executor,
+          ragDeps: this.ragDeps,
+          emitStatus: this.emitStatus.bind(this),
+          debugLog: this.debugLog.bind(this),
+          debugWarn: this.debugWarn.bind(this),
+        },
+        taskId: task.id,
+        taskDescription: task.description,
+        projectRoot: this.config.projectRoot,
+        ragEnabled: this.config.rag?.enabled !== false,
+        preScanFailureLabel: '[Agent] Failed to pre-scan project structure for plan-only:',
+      });
 
       if (this.config.rag?.enabled !== false) {
         this.emit({
           type: 'rag_retrieved',
-          searchMode: ragContext?.searchMode,
-          reranked: ragContext?.reranked,
-          warnings: ragContext?.warnings,
-          timing: ragContext?.timing,
-          matches: ragContext?.matches ?? [],
+          ...planningPreparation.ragEvent,
         });
       }
 
@@ -500,9 +459,9 @@ export class FrontAgent {
         {
           files: context.collectedContext.files,
           pageStructure: context.collectedContext.pageStructure,
-          ragResults,
-          projectStructure,
-          devServerPort,
+          ragResults: planningPreparation.ragResults,
+          projectStructure: planningPreparation.projectStructure,
+          devServerPort: planningPreparation.devServerPort,
           skillContext,
           matchedSkillNames,
           memoryContext: context.collectedContext.memoryContext,
@@ -632,66 +591,26 @@ export class FrontAgent {
         });
       }
 
-      let projectStructure: string | undefined;
-      const preScannedFiles = new Map<string, string>();
-      try {
-        this.emitStatus('扫描项目结构', 'list_directory 扫描项目结构');
-        const listResult = (await this.executor.callTool('list_directory', {
-          path: this.config.projectRoot,
-          recursive: true,
-        })) as { success: boolean; entries?: Array<{ name: string; type: string; path: string }> };
-
-        if (listResult.success && listResult.entries) {
-          const files = listResult.entries
-            .filter(
-              (e) =>
-                e.type === 'file' && !e.path.includes('node_modules') && !e.path.includes('.git'),
-            )
-            .map((e) => e.path);
-
-          if (files.length > 0) {
-            projectStructure = `项目文件列表（共 ${files.length} 个文件）:\n${files.join('\n')}`;
-            this.debugLog(`[Agent] 📂 Pre-scanned project structure: ${files.length} files`);
-          }
-
-          const configFiles = files.filter(
-            (f) => f.endsWith('package.json') || f.includes('vite.config'),
-          );
-          for (const configFile of configFiles) {
-            try {
-              const readResult = (await this.executor.callTool('read_file', {
-                path: configFile,
-              })) as { success: boolean; content?: string };
-              if (readResult.success && readResult.content) {
-                preScannedFiles.set(configFile, readResult.content);
-              }
-            } catch (_error) {
-              // Ignore read failures
-            }
-          }
-        }
-      } catch (error) {
-        this.debugWarn('[Agent] Failed to pre-scan project structure:', error);
-      }
-
-      this.emitStatus('检测开发服务器端口', '检测开发服务器端口');
-      const devServerPort = detectDevServerPort(
-        { debugLog: this.debugLog.bind(this), debugWarn: this.debugWarn.bind(this) },
-        preScannedFiles,
-      );
-
-      this.emitStatus('检索知识库', 'RAG 检索');
-      const ragContext = await retrieveRagContext(this.ragDeps, task.id, task.description);
-      const ragResults = ragContext?.formattedResults;
+      const planningPreparation = await prepareProjectPlanningContext({
+        deps: {
+          executor: this.executor,
+          ragDeps: this.ragDeps,
+          emitStatus: this.emitStatus.bind(this),
+          debugLog: this.debugLog.bind(this),
+          debugWarn: this.debugWarn.bind(this),
+        },
+        taskId: task.id,
+        taskDescription: task.description,
+        projectRoot: this.config.projectRoot,
+        ragEnabled: this.config.rag?.enabled !== false,
+        preScanFailureLabel: '[Agent] Failed to pre-scan project structure:',
+        logProjectStructure: true,
+      });
 
       if (this.config.rag?.enabled !== false) {
         this.emit({
           type: 'rag_retrieved',
-          searchMode: ragContext?.searchMode,
-          reranked: ragContext?.reranked,
-          warnings: ragContext?.warnings,
-          timing: ragContext?.timing,
-          matches: ragContext?.matches ?? [],
+          ...planningPreparation.ragEvent,
         });
       }
 
@@ -703,9 +622,9 @@ export class FrontAgent {
         {
           files: context.collectedContext.files,
           pageStructure: context.collectedContext.pageStructure,
-          ragResults,
-          projectStructure,
-          devServerPort,
+          ragResults: planningPreparation.ragResults,
+          projectStructure: planningPreparation.projectStructure,
+          devServerPort: planningPreparation.devServerPort,
           skillContext,
           matchedSkillNames,
           memoryContext: context.collectedContext.memoryContext,

--- a/packages/core/src/agent/project-prescan-preparation.test.ts
+++ b/packages/core/src/agent/project-prescan-preparation.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { prepareProjectPlanningContext } from './project-prescan-preparation.js';
+import { retrieveRagContext } from './rag-retrieval.js';
+
+vi.mock('./rag-retrieval.js', () => ({
+  retrieveRagContext: vi.fn(),
+}));
+
+describe('prepareProjectPlanningContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('prepares project structure, config contents, dev server port, and RAG context', async () => {
+    vi.mocked(retrieveRagContext).mockResolvedValue({
+      formattedResults: ['[doc] Prescan source=https://example.test\nUse shared context.'],
+      matches: [
+        {
+          type: 'doc',
+          title: 'Prescan',
+          sourceUrl: 'https://example.test',
+          snippet: 'Use shared context.',
+        },
+      ],
+      searchMode: 'hybrid',
+      reranked: true,
+      warnings: ['cache warmup'],
+      timing: { totalMs: 12 },
+    });
+
+    const toolCalls: Array<{ name: string; params: Record<string, unknown> }> = [];
+    const executor = {
+      callTool: vi.fn(async (name: string, params: Record<string, unknown>) => {
+        toolCalls.push({ name, params });
+
+        if (name === 'list_directory') {
+          return {
+            success: true,
+            entries: [
+              { name: 'App.tsx', type: 'file', path: 'src/App.tsx' },
+              { name: 'package.json', type: 'file', path: 'package.json' },
+              { name: 'vite.config.ts', type: 'file', path: 'vite.config.ts' },
+              { name: 'ignored.js', type: 'file', path: 'node_modules/pkg/ignored.js' },
+              { name: 'config', type: 'file', path: '.git/config' },
+              { name: 'src', type: 'directory', path: 'src' },
+            ],
+          };
+        }
+
+        if (name === 'read_file' && params.path === 'package.json') {
+          return {
+            success: true,
+            content: JSON.stringify({ scripts: { dev: 'vite --port 3001' } }),
+          };
+        }
+
+        if (name === 'read_file' && params.path === 'vite.config.ts') {
+          return { success: true, content: 'export default { server: { port: 4321 } }' };
+        }
+
+        throw new Error(`Unexpected tool call: ${name}`);
+      }),
+    };
+    const statuses: Array<{ label: string; operation?: string }> = [];
+    const warnings: unknown[][] = [];
+
+    const result = await prepareProjectPlanningContext({
+      deps: {
+        executor,
+        ragDeps: {
+          config: { projectRoot: '/repo', llm: { provider: 'openai', model: 'gpt-4' } },
+          executor: executor as never,
+          llmService: {} as never,
+          contextManager: {} as never,
+          debugLog: () => {},
+          debugWarn: () => {},
+        },
+        emitStatus: (label, operation) => statuses.push({ label, operation }),
+        debugLog: () => {},
+        debugWarn: (...args) => warnings.push(args),
+      },
+      taskId: 'task-1',
+      taskDescription: 'Build a shared project prescan helper',
+      projectRoot: '/repo',
+      ragEnabled: true,
+      preScanFailureLabel: '[Agent] Failed to pre-scan project structure:',
+      logProjectStructure: true,
+    });
+
+    expect(statuses.map((status) => status.label)).toEqual([
+      '扫描项目结构',
+      '检测开发服务器端口',
+      '检索知识库',
+    ]);
+    expect(statuses.map((status) => status.operation)).toEqual([
+      'list_directory 扫描项目结构',
+      '检测开发服务器端口',
+      'RAG 检索',
+    ]);
+
+    expect(toolCalls).toEqual([
+      { name: 'list_directory', params: { path: '/repo', recursive: true } },
+      { name: 'read_file', params: { path: 'package.json' } },
+      { name: 'read_file', params: { path: 'vite.config.ts' } },
+    ]);
+
+    expect(result.projectStructure).toContain('项目文件列表（共 3 个文件）');
+    expect(result.projectStructure).toContain('src/App.tsx');
+    expect(result.projectStructure).toContain('package.json');
+    expect(result.projectStructure).toContain('vite.config.ts');
+    expect(result.projectStructure).not.toContain('node_modules');
+    expect(result.projectStructure).not.toContain('.git/config');
+    expect(result.devServerPort).toBe(4321);
+    expect(result.ragResults).toEqual([
+      '[doc] Prescan source=https://example.test\nUse shared context.',
+    ]);
+    expect(result.ragEvent).toEqual({
+      searchMode: 'hybrid',
+      reranked: true,
+      warnings: ['cache warmup'],
+      timing: { totalMs: 12 },
+      matches: [
+        {
+          type: 'doc',
+          title: 'Prescan',
+          sourceUrl: 'https://example.test',
+          snippet: 'Use shared context.',
+        },
+      ],
+    });
+    expect(retrieveRagContext).toHaveBeenCalledWith(
+      expect.any(Object),
+      'task-1',
+      'Build a shared project prescan helper',
+    );
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/core/src/agent/project-prescan-preparation.ts
+++ b/packages/core/src/agent/project-prescan-preparation.ts
@@ -1,0 +1,145 @@
+import type { Executor } from '../executor.js';
+import type { RagQueryTiming } from '../types.js';
+import { detectDevServerPort } from './dev-server-detection.js';
+import { type RagRetrievalDeps, retrieveRagContext } from './rag-retrieval.js';
+
+interface ProjectPrescanPreparationDeps {
+  executor: Pick<Executor, 'callTool'>;
+  ragDeps: RagRetrievalDeps;
+  emitStatus: (label: string, operation?: string, detail?: string) => void;
+  debugLog: (...args: unknown[]) => void;
+  debugWarn: (...args: unknown[]) => void;
+}
+
+interface ProjectPrescanPreparationInput {
+  deps: ProjectPrescanPreparationDeps;
+  taskId: string;
+  taskDescription: string;
+  projectRoot: string;
+  ragEnabled: boolean;
+  preScanFailureLabel: string;
+  logProjectStructure?: boolean;
+}
+
+interface ProjectPrescanRagEvent {
+  searchMode?: 'hybrid' | 'keyword_only' | 'openviking' | 'composite';
+  reranked?: boolean;
+  warnings?: string[];
+  timing?: RagQueryTiming;
+  matches: Array<{
+    type: string;
+    title: string;
+    sourceUrl: string;
+    snippet: string;
+    path?: string;
+    score?: number;
+    rerankScore?: number;
+  }>;
+}
+
+export interface ProjectPlanningPreparation {
+  projectStructure?: string;
+  devServerPort: number;
+  ragResults?: string[];
+  ragEvent: ProjectPrescanRagEvent;
+}
+
+export async function prepareProjectPlanningContext({
+  deps,
+  taskId,
+  taskDescription,
+  projectRoot,
+  ragEnabled,
+  preScanFailureLabel,
+  logProjectStructure,
+}: ProjectPrescanPreparationInput): Promise<ProjectPlanningPreparation> {
+  const { projectStructure, preScannedFiles } = await preScanProject({
+    deps,
+    projectRoot,
+    preScanFailureLabel,
+    logProjectStructure,
+  });
+
+  deps.emitStatus('检测开发服务器端口', '检测开发服务器端口');
+  const devServerPort = detectDevServerPort(
+    { debugLog: deps.debugLog, debugWarn: deps.debugWarn },
+    preScannedFiles,
+  );
+
+  deps.emitStatus('检索知识库', 'RAG 检索');
+  const ragContext = await retrieveRagContext(deps.ragDeps, taskId, taskDescription);
+
+  return {
+    projectStructure,
+    devServerPort,
+    ragResults: ragContext?.formattedResults,
+    ragEvent: {
+      searchMode: ragContext?.searchMode,
+      reranked: ragContext?.reranked,
+      warnings: ragContext?.warnings,
+      timing: ragContext?.timing,
+      matches: ragEnabled ? (ragContext?.matches ?? []) : [],
+    },
+  };
+}
+
+async function preScanProject({
+  deps,
+  projectRoot,
+  preScanFailureLabel,
+  logProjectStructure,
+}: {
+  deps: ProjectPrescanPreparationDeps;
+  projectRoot: string;
+  preScanFailureLabel: string;
+  logProjectStructure?: boolean;
+}): Promise<{ projectStructure?: string; preScannedFiles: Map<string, string> }> {
+  let projectStructure: string | undefined;
+  const preScannedFiles = new Map<string, string>();
+
+  try {
+    deps.emitStatus('扫描项目结构', 'list_directory 扫描项目结构');
+    const listResult = (await deps.executor.callTool('list_directory', {
+      path: projectRoot,
+      recursive: true,
+    })) as { success: boolean; entries?: Array<{ name: string; type: string; path: string }> };
+
+    if (listResult.success && listResult.entries) {
+      const files = listResult.entries
+        .filter(
+          (entry) =>
+            entry.type === 'file' &&
+            !entry.path.includes('node_modules') &&
+            !entry.path.includes('.git'),
+        )
+        .map((entry) => entry.path);
+
+      if (files.length > 0) {
+        projectStructure = `项目文件列表（共 ${files.length} 个文件）:\n${files.join('\n')}`;
+        if (logProjectStructure) {
+          deps.debugLog(`[Agent] 📂 Pre-scanned project structure: ${files.length} files`);
+        }
+      }
+
+      const configFiles = files.filter(
+        (filePath) => filePath.endsWith('package.json') || filePath.includes('vite.config'),
+      );
+      for (const configFile of configFiles) {
+        try {
+          const readResult = (await deps.executor.callTool('read_file', {
+            path: configFile,
+          })) as { success: boolean; content?: string };
+          if (readResult.success && readResult.content) {
+            preScannedFiles.set(configFile, readResult.content);
+          }
+        } catch {
+          // Ignore optional pre-scan read failures.
+        }
+      }
+    }
+  } catch (error) {
+    deps.debugWarn(preScanFailureLabel, error);
+  }
+
+  return { projectStructure, preScannedFiles };
+}


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #231

## Summary

- Added a focused `prepareProjectPlanningContext` helper for shared project pre-scan preparation.
- Replaced duplicated `planOnly` and `execute` scan/config/dev-server/RAG preparation blocks with the helper.
- Added focused tests for project structure filtering, config pre-read, dev server port detection, RAG result shaping, and status ordering.

## Impact Scope

- Internal `@frontagent/core` agent orchestration only.
- Public FrontAgent APIs and result shapes are unchanged.
- Memory preload/persistence, facts flushing, planning retry behavior, and execution callback ordering are left in place.

## GitNexus Impact Summary

- Risk level: HIGH
- Critical skeleton changes: Yes. Critical agent-core files changed: `packages/core/src/agent/agent.ts`, `packages/core/src/agent/project-prescan-preparation.ts`, and `packages/core/src/agent/project-prescan-preparation.test.ts`.
- GitNexus impact: Before edits, `impact planOnly` and `impact execute` were LOW with 0 direct callers/processes; `impact detectDevServerPort` was LOW with direct callers `FrontAgent.planOnly`, `FrontAgent.execute`, and `dev-server-detection.test.ts`. Final `npx gitnexus detect_changes --scope compare --base-ref origin/develop --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-frontagent-project-prescan` reported 5 files, 15 symbols, 14 affected execution flows, risk HIGH. Affected flows are the existing `Execute -> RegisterRoot/NormalizeTriggers/ExtractReferencedFiles/NormalizeText/EscapeRegExp` and `PlanOnly -> RegisterRoot/NormalizeTriggers/ExtractReferencedFiles/NormalizeText/EscapeRegExp` groups.
- Verification: `pnpm agent:bootstrap`; `pnpm quality:predev`; red/green `pnpm --filter @frontagent/core test -- src/agent/project-prescan-preparation.test.ts`; `pnpm --filter @frontagent/core test -- src/agent/agent.test.ts src/agent/context-gathering.test.ts`; `pnpm --filter @frontagent/core typecheck`; `pnpm quality:precommit`; pre-push `pnpm quality:local`.

## Verification

- `pnpm agent:bootstrap`
- `pnpm quality:predev`
- `pnpm --filter @frontagent/core test -- src/agent/project-prescan-preparation.test.ts`
- `pnpm --filter @frontagent/core test -- src/agent/agent.test.ts src/agent/context-gathering.test.ts`
- `pnpm --filter @frontagent/core typecheck`
- `pnpm quality:precommit`
- `git push` pre-push hook ran `pnpm quality:local`

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.