### PR TITLE
Extract mcp-filesense notes helpers

### DIFF
--- a/docs/superpowers/plans/2026-06-08-filesense-notes-generation-helpers.md
+++ b/docs/superpowers/plans/2026-06-08-filesense-notes-generation-helpers.md
@@ -1,0 +1,30 @@
+# Filesense Notes Generation Helpers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract mcp-filesense notes generation heuristics and result building from `engine.ts` without changing public APIs or persisted output.
+
+**Architecture:** Add a focused `engine-notes.ts` module for notes inference and `FILES.notes.json` construction. Keep `summarize`, tool schemas, query result shaping, indexing, scoring, and persisted formats unchanged.
+
+**Tech Stack:** TypeScript, Vitest, pnpm workspace filters, GitNexus CLI.
+
+---
+
+## GitNexus Impact
+
+- `buildNotesFile`: LOW risk; direct caller `summarize`; affected flows include `summarize` and `handleFilesenseTool`.
+- `summarize`: LOW risk; direct callers include `engine.test.ts`, `syncAndSummarize`, and `handleFilesenseTool`.
+- `inferAgentHints`: HIGH risk; flows include `buildNotesFile`, `summarize`, and `handleFilesenseTool`.
+- `inferConventions`: HIGH risk; direct callers include `buildNotesFile` and `navigate`; flows include `summarize`, `navigate`, and `handleFilesenseTool`.
+- `inferKeyEntrypoints`: HIGH risk; flows include `buildNotesFile`, `summarize`, and `handleFilesenseTool`.
+- Maintainer authorization allows continuing despite HIGH impact. Mitigation: pure relocation, direct helper tests, package test, package typecheck, and final `detect_changes`.
+
+## Tasks
+
+- [ ] Add focused tests for notes helper behavior: inferred notes shape, previous-field preservation, and force overwrite.
+- [ ] Create `packages/mcp-filesense/src/engine-notes.ts` with `buildNotesFile`, `inferAgentHints`, `inferConventions`, and `inferKeyEntrypoints`.
+- [ ] Update `packages/mcp-filesense/src/engine.ts` imports and remove the extracted helper bodies; keep `summarize` behavior and response shape unchanged.
+- [ ] Run `pnpm --filter @frontagent/mcp-filesense test`.
+- [ ] Run `pnpm --filter @frontagent/mcp-filesense typecheck`.
+- [ ] Run `pnpm quality:precommit` because this touches the mcp-boundary critical skeleton category.
+- [ ] Run `npx gitnexus detect_changes --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-filesense-notes-generation-helpers` and summarize the result in the PR.

--- a/packages/mcp-filesense/src/engine-notes.test.ts
+++ b/packages/mcp-filesense/src/engine-notes.test.ts
@@ -1,19 +1,7 @@
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { buildNotesFile, inferConventions, inferKeyEntrypoints } from './engine-notes.js';
-import type { FilesenseConfig, IndexFile, NotesFile } from './types.js';
-
-const config: FilesenseConfig = {
-  schemaVersion: '1.0',
-  root: '.',
-  recursive: true,
-  indexFile: 'FILES.json',
-  notesFile: 'FILES.notes.json',
-  ignoreFile: '.filesignore',
-  schemaDir: 'schemas',
-  exclude: ['.git', 'node_modules'],
-  hashAlgorithm: 'sha1',
-};
+import type { IndexFile, NotesFile } from './types.js';
 
 function createIndex(children: IndexFile['children']): IndexFile {
   return {
@@ -39,6 +27,7 @@ describe('engine notes helpers', () => {
   it('builds the same notes shape used by summarize', () => {
     const root = path.join('/workspace', 'project');
     const dirPath = path.join(root, 'components');
+    const notesSchemaPath = path.join(root, 'schemas', 'FILES.notes.schema.json');
     const index = createIndex([
       {
         name: 'Button.tsx',
@@ -66,7 +55,7 @@ describe('engine notes helpers', () => {
       },
     ]);
 
-    const notes = buildNotesFile(root, dirPath, config, index, null, false);
+    const notes = buildNotesFile(dirPath, notesSchemaPath, index, null, false);
 
     expect(notes).toEqual({
       $schema: '../schemas/FILES.notes.schema.json',
@@ -83,6 +72,7 @@ describe('engine notes helpers', () => {
   it('preserves populated previous fields unless forced', () => {
     const root = path.join('/workspace', 'project');
     const dirPath = path.join(root, 'components');
+    const notesSchemaPath = path.join(root, 'schemas', 'FILES.notes.schema.json');
     const index = createIndex([]);
     const previous: NotesFile = {
       $schema: 'old-schema',
@@ -92,7 +82,7 @@ describe('engine notes helpers', () => {
       key_entrypoints: ['Human.ts'],
     };
 
-    expect(buildNotesFile(root, dirPath, config, index, previous, false)).toEqual({
+    expect(buildNotesFile(dirPath, notesSchemaPath, index, previous, false)).toEqual({
       $schema: '../schemas/FILES.notes.schema.json',
       directory_purpose: 'Human-authored purpose.',
       agent_hints: ['Human hint.'],
@@ -100,7 +90,7 @@ describe('engine notes helpers', () => {
       key_entrypoints: ['Human.ts'],
     });
 
-    expect(buildNotesFile(root, dirPath, config, index, previous, true)).toEqual({
+    expect(buildNotesFile(dirPath, notesSchemaPath, index, previous, true)).toEqual({
       $schema: '../schemas/FILES.notes.schema.json',
       directory_purpose: 'Reusable component directory.',
       agent_hints: [
@@ -109,6 +99,17 @@ describe('engine notes helpers', () => {
       conventions: ['Preserve the local naming and file-placement patterns already present here.'],
       key_entrypoints: [],
     });
+  });
+
+  it('uses the canonical notes schema path supplied by the engine boundary', () => {
+    const root = path.join('/workspace', 'project');
+    const dirPath = path.join(root, 'components');
+    const index = createIndex([]);
+    const notesSchemaPath = path.join(root, 'custom-schemas', 'FILES.notes.schema.json');
+
+    const notes = buildNotesFile(dirPath, notesSchemaPath, index, null, false);
+
+    expect(notes.$schema).toBe('../custom-schemas/FILES.notes.schema.json');
   });
 
   it('exposes convention and entrypoint inference for navigate reuse', () => {

--- a/packages/mcp-filesense/src/engine-notes.test.ts
+++ b/packages/mcp-filesense/src/engine-notes.test.ts
@@ -1,0 +1,150 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { buildNotesFile, inferConventions, inferKeyEntrypoints } from './engine-notes.js';
+import type { FilesenseConfig, IndexFile, NotesFile } from './types.js';
+
+const config: FilesenseConfig = {
+  schemaVersion: '1.0',
+  root: '.',
+  recursive: true,
+  indexFile: 'FILES.json',
+  notesFile: 'FILES.notes.json',
+  ignoreFile: '.filesignore',
+  schemaDir: 'schemas',
+  exclude: ['.git', 'node_modules'],
+  hashAlgorithm: 'sha1',
+};
+
+function createIndex(children: IndexFile['children']): IndexFile {
+  return {
+    schema_version: '1.0',
+    generated_at: '2026-06-08T00:00:00.000Z',
+    root_relative_path: 'components',
+    directory: {
+      name: 'components',
+      path: 'components',
+    },
+    children,
+    sync: {
+      child_count: children.length,
+      file_count: children.filter((child) => child.type === 'file').length,
+      dir_count: children.filter((child) => child.type === 'dir').length,
+      last_full_sync: null,
+      last_incremental_sync: null,
+    },
+  };
+}
+
+describe('engine notes helpers', () => {
+  it('builds the same notes shape used by summarize', () => {
+    const root = path.join('/workspace', 'project');
+    const dirPath = path.join(root, 'components');
+    const index = createIndex([
+      {
+        name: 'Button.tsx',
+        type: 'file',
+        path: 'components/Button.tsx',
+        ext: '.tsx',
+        size: 42,
+        mtimeMs: 1,
+        hash: 'sha1:button',
+        summary: 'TypeScript source file',
+        importance: 'normal',
+        status: 'active',
+      },
+      {
+        name: 'index.ts',
+        type: 'file',
+        path: 'components/index.ts',
+        ext: '.ts',
+        size: 12,
+        mtimeMs: 1,
+        hash: 'sha1:index',
+        summary: 'TypeScript source file',
+        importance: 'high',
+        status: 'active',
+      },
+    ]);
+
+    const notes = buildNotesFile(root, dirPath, config, index, null, false);
+
+    expect(notes).toEqual({
+      $schema: '../schemas/FILES.notes.schema.json',
+      directory_purpose: 'Reusable component directory.',
+      agent_hints: ['Read index.ts first for local entrypoints and conventions.'],
+      conventions: [
+        'Prefer TypeScript for new source files in this directory.',
+        'Component-like files use PascalCase filenames.',
+      ],
+      key_entrypoints: ['index.ts'],
+    });
+  });
+
+  it('preserves populated previous fields unless forced', () => {
+    const root = path.join('/workspace', 'project');
+    const dirPath = path.join(root, 'components');
+    const index = createIndex([]);
+    const previous: NotesFile = {
+      $schema: 'old-schema',
+      directory_purpose: 'Human-authored purpose.',
+      agent_hints: ['Human hint.'],
+      conventions: ['Human convention.'],
+      key_entrypoints: ['Human.ts'],
+    };
+
+    expect(buildNotesFile(root, dirPath, config, index, previous, false)).toEqual({
+      $schema: '../schemas/FILES.notes.schema.json',
+      directory_purpose: 'Human-authored purpose.',
+      agent_hints: ['Human hint.'],
+      conventions: ['Human convention.'],
+      key_entrypoints: ['Human.ts'],
+    });
+
+    expect(buildNotesFile(root, dirPath, config, index, previous, true)).toEqual({
+      $schema: '../schemas/FILES.notes.schema.json',
+      directory_purpose: 'Reusable component directory.',
+      agent_hints: [
+        'Start from high-importance files before editing lower-level implementation details.',
+      ],
+      conventions: ['Preserve the local naming and file-placement patterns already present here.'],
+      key_entrypoints: [],
+    });
+  });
+
+  it('exposes convention and entrypoint inference for navigate reuse', () => {
+    const index = createIndex([
+      {
+        name: 'README.md',
+        type: 'file',
+        path: 'components/README.md',
+        ext: '.md',
+        size: 12,
+        mtimeMs: 1,
+        hash: 'sha1:readme',
+        summary: 'Markdown document',
+        importance: 'high',
+        status: 'active',
+      },
+      {
+        name: 'Button.test.tsx',
+        type: 'file',
+        path: 'components/Button.test.tsx',
+        ext: '.tsx',
+        size: 12,
+        mtimeMs: 1,
+        hash: 'sha1:test',
+        summary: 'TypeScript source file',
+        importance: 'normal',
+        status: 'active',
+      },
+    ]);
+
+    expect(inferKeyEntrypoints(index)).toEqual(['README.md']);
+    expect(inferConventions(index)).toEqual([
+      'Prefer TypeScript for new source files in this directory.',
+      'Component-like files use PascalCase filenames.',
+      'Keep tests close to the implementation they validate.',
+      'Update README.md when directory-level usage or setup changes.',
+    ]);
+  });
+});

--- a/packages/mcp-filesense/src/engine-notes.ts
+++ b/packages/mcp-filesense/src/engine-notes.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { inferDirectoryPurpose } from './engine-helpers.js';
-import type { FilesenseConfig, IndexFile, NotesFile } from './types.js';
+import type { IndexFile, NotesFile } from './types.js';
 
 function relativeSchemaRef(dirPath: string, schemaPath: string): string {
   return path.relative(dirPath, schemaPath).replace(/\\/g, '/');
@@ -70,14 +70,12 @@ export function inferKeyEntrypoints(index: IndexFile): string[] {
 }
 
 export function buildNotesFile(
-  root: string,
   dirPath: string,
-  config: FilesenseConfig,
+  notesSchemaPath: string,
   index: IndexFile,
   previous: NotesFile | null,
   force: boolean,
 ): NotesFile {
-  const notesSchemaPath = path.join(root, config.schemaDir, 'FILES.notes.schema.json');
   const inferred: NotesFile = {
     $schema: relativeSchemaRef(dirPath, notesSchemaPath),
     directory_purpose: inferDirectoryPurpose(index),

--- a/packages/mcp-filesense/src/engine-notes.ts
+++ b/packages/mcp-filesense/src/engine-notes.ts
@@ -1,0 +1,98 @@
+import path from 'node:path';
+import { inferDirectoryPurpose } from './engine-helpers.js';
+import type { FilesenseConfig, IndexFile, NotesFile } from './types.js';
+
+function relativeSchemaRef(dirPath: string, schemaPath: string): string {
+  return path.relative(dirPath, schemaPath).replace(/\\/g, '/');
+}
+
+export function inferAgentHints(index: IndexFile): string[] {
+  const hints: string[] = [];
+  const names = new Set(index.children.map((c) => c.name));
+  const entrypoints = inferKeyEntrypoints(index);
+  if (entrypoints.length > 0)
+    hints.push(
+      `Read ${entrypoints.slice(0, 3).join(', ')} first for local entrypoints and conventions.`,
+    );
+  if (names.has('package.json'))
+    hints.push('Inspect package.json before changing scripts, package metadata, or dependencies.');
+  if (names.has('tsconfig.json'))
+    hints.push('Respect tsconfig.json compiler settings when adding or moving TypeScript files.');
+  if (
+    index.children.some((c) => c.type === 'dir') &&
+    index.children.filter((c) => c.type === 'file').length <= 2
+  ) {
+    hints.push(
+      'Descend into child directories before making edits here; this level is mostly structural.',
+    );
+  }
+  if (hints.length === 0)
+    hints.push(
+      'Start from high-importance files before editing lower-level implementation details.',
+    );
+  return hints.slice(0, 4);
+}
+
+export function inferConventions(index: IndexFile): string[] {
+  const conventions: string[] = [];
+  if (index.children.some((c) => ['.ts', '.tsx'].includes(c.ext)))
+    conventions.push('Prefer TypeScript for new source files in this directory.');
+  if (index.children.some((c) => c.ext === '.tsx' && /^[A-Z]/.test(c.name)))
+    conventions.push('Component-like files use PascalCase filenames.');
+  if (index.children.some((c) => /test|spec/i.test(c.name)))
+    conventions.push('Keep tests close to the implementation they validate.');
+  if (index.children.some((c) => c.name === 'README.md'))
+    conventions.push('Update README.md when directory-level usage or setup changes.');
+  if (conventions.length === 0)
+    conventions.push('Preserve the local naming and file-placement patterns already present here.');
+  return conventions.slice(0, 4);
+}
+
+export function inferKeyEntrypoints(index: IndexFile): string[] {
+  const preferred = [
+    'README.md',
+    'package.json',
+    'tsconfig.json',
+    'index.ts',
+    'index.tsx',
+    'main.ts',
+    'main.js',
+    'App.tsx',
+    'App.vue',
+  ];
+  const names = index.children.map((c) => c.name);
+  const selected = preferred.filter((n) => names.includes(n));
+  if (selected.length > 0) return selected.slice(0, 6);
+  return index.children
+    .filter((c) => c.type === 'file' && c.importance === 'high')
+    .map((c) => c.name)
+    .slice(0, 6);
+}
+
+export function buildNotesFile(
+  root: string,
+  dirPath: string,
+  config: FilesenseConfig,
+  index: IndexFile,
+  previous: NotesFile | null,
+  force: boolean,
+): NotesFile {
+  const notesSchemaPath = path.join(root, config.schemaDir, 'FILES.notes.schema.json');
+  const inferred: NotesFile = {
+    $schema: relativeSchemaRef(dirPath, notesSchemaPath),
+    directory_purpose: inferDirectoryPurpose(index),
+    agent_hints: inferAgentHints(index),
+    conventions: inferConventions(index),
+    key_entrypoints: inferKeyEntrypoints(index),
+  };
+  if (!previous || force) return inferred;
+  return {
+    $schema: inferred.$schema,
+    directory_purpose: previous.directory_purpose || inferred.directory_purpose,
+    agent_hints: previous.agent_hints?.length ? previous.agent_hints : inferred.agent_hints,
+    conventions: previous.conventions?.length ? previous.conventions : inferred.conventions,
+    key_entrypoints: previous.key_entrypoints?.length
+      ? previous.key_entrypoints
+      : inferred.key_entrypoints,
+  };
+}

--- a/packages/mcp-filesense/src/engine.ts
+++ b/packages/mcp-filesense/src/engine.ts
@@ -564,7 +564,13 @@ export async function summarize(targetPath: string, force = false): Promise<Summ
       const previous = (await exists(notesPath))
         ? ((await readJson(notesPath)) as NotesFile)
         : null;
-      const next = buildNotesFile(root, dirPath, config, index, previous, force);
+      const next = buildNotesFile(
+        dirPath,
+        schemaPathsForRoot(root, config).notesSchemaPath,
+        index,
+        previous,
+        force,
+      );
 
       if (previous && stableStringify(previous) === stableStringify(next)) {
         summary.notesSkipped += 1;

--- a/packages/mcp-filesense/src/engine.ts
+++ b/packages/mcp-filesense/src/engine.ts
@@ -8,6 +8,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { inferDirectoryPurpose, inferImportance, scoreCandidate } from './engine-helpers.js';
 import { type ComparableIndex, persistDirectoryIndex } from './engine-indexing.js';
+import { buildNotesFile, inferConventions } from './engine-notes.js';
 import { buildQueryResult } from './engine-query.js';
 import type {
   CheckSummary,
@@ -365,96 +366,6 @@ function inferSummary(name: string): string {
   if (ext === '.html') return 'HTML document';
   if (!ext) return 'File without extension';
   return `${ext.slice(1).toUpperCase()} file`;
-}
-
-function inferAgentHints(index: IndexFile): string[] {
-  const hints: string[] = [];
-  const names = new Set(index.children.map((c) => c.name));
-  const entrypoints = inferKeyEntrypoints(index);
-  if (entrypoints.length > 0)
-    hints.push(
-      `Read ${entrypoints.slice(0, 3).join(', ')} first for local entrypoints and conventions.`,
-    );
-  if (names.has('package.json'))
-    hints.push('Inspect package.json before changing scripts, package metadata, or dependencies.');
-  if (names.has('tsconfig.json'))
-    hints.push('Respect tsconfig.json compiler settings when adding or moving TypeScript files.');
-  if (
-    index.children.some((c) => c.type === 'dir') &&
-    index.children.filter((c) => c.type === 'file').length <= 2
-  ) {
-    hints.push(
-      'Descend into child directories before making edits here; this level is mostly structural.',
-    );
-  }
-  if (hints.length === 0)
-    hints.push(
-      'Start from high-importance files before editing lower-level implementation details.',
-    );
-  return hints.slice(0, 4);
-}
-
-function inferConventions(index: IndexFile): string[] {
-  const conventions: string[] = [];
-  if (index.children.some((c) => ['.ts', '.tsx'].includes(c.ext)))
-    conventions.push('Prefer TypeScript for new source files in this directory.');
-  if (index.children.some((c) => c.ext === '.tsx' && /^[A-Z]/.test(c.name)))
-    conventions.push('Component-like files use PascalCase filenames.');
-  if (index.children.some((c) => /test|spec/i.test(c.name)))
-    conventions.push('Keep tests close to the implementation they validate.');
-  if (index.children.some((c) => c.name === 'README.md'))
-    conventions.push('Update README.md when directory-level usage or setup changes.');
-  if (conventions.length === 0)
-    conventions.push('Preserve the local naming and file-placement patterns already present here.');
-  return conventions.slice(0, 4);
-}
-
-function inferKeyEntrypoints(index: IndexFile): string[] {
-  const preferred = [
-    'README.md',
-    'package.json',
-    'tsconfig.json',
-    'index.ts',
-    'index.tsx',
-    'main.ts',
-    'main.js',
-    'App.tsx',
-    'App.vue',
-  ];
-  const names = index.children.map((c) => c.name);
-  const selected = preferred.filter((n) => names.includes(n));
-  if (selected.length > 0) return selected.slice(0, 6);
-  return index.children
-    .filter((c) => c.type === 'file' && c.importance === 'high')
-    .map((c) => c.name)
-    .slice(0, 6);
-}
-
-function buildNotesFile(
-  root: string,
-  dirPath: string,
-  config: FilesenseConfig,
-  index: IndexFile,
-  previous: NotesFile | null,
-  force: boolean,
-): NotesFile {
-  const inferred: NotesFile = {
-    $schema: relativeSchemaRef(dirPath, schemaPathsForRoot(root, config).notesSchemaPath),
-    directory_purpose: inferDirectoryPurpose(index),
-    agent_hints: inferAgentHints(index),
-    conventions: inferConventions(index),
-    key_entrypoints: inferKeyEntrypoints(index),
-  };
-  if (!previous || force) return inferred;
-  return {
-    $schema: inferred.$schema,
-    directory_purpose: previous.directory_purpose || inferred.directory_purpose,
-    agent_hints: previous.agent_hints?.length ? previous.agent_hints : inferred.agent_hints,
-    conventions: previous.conventions?.length ? previous.conventions : inferred.conventions,
-    key_entrypoints: previous.key_entrypoints?.length
-      ? previous.key_entrypoints
-      : inferred.key_entrypoints,
-  };
 }
 
 // ─── Core Operations ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Linked Issue Or Context

Closes #230

## Summary

- Extracted FILES.notes.json inference and result-building helpers from `packages/mcp-filesense/src/engine.ts` into `engine-notes.ts`.
- Kept public `summarize` API, MCP tool schemas/response shapes, persisted index format, and persisted notes format unchanged.
- Added focused helper tests for inferred notes shape, human-authored field preservation, force overwrite, canonical schema path ownership, and `navigate` convention reuse.

## Impact Scope

- `packages/mcp-filesense/src/engine.ts`
- `packages/mcp-filesense/src/engine-notes.ts`
- `packages/mcp-filesense/src/engine-notes.test.ts`
- `docs/superpowers/plans/2026-06-08-filesense-notes-generation-helpers.md`

## GitNexus Impact Summary

- Risk level: HIGH
- Critical skeleton changes: mcp-boundary files under `packages/mcp-filesense/src/`; no public MCP tool schema, response shape, query shaping, scoring, indexing helper, or persisted file format changes.
- GitNexus impact: `impact buildNotesFile` and `impact summarize` were LOW; `impact inferAgentHints`, `impact inferConventions`, and `impact inferKeyEntrypoints` were HIGH because they feed `summarize`, `handleFilesenseTool`, and for conventions also `navigate`. Maintainer authorization allowed continuing despite HIGH symbol impact. After re-indexing, `detect_changes --scope staged` reported 4 files / 10 symbols, Risk level medium, affected flow `BuildNotesFile -> InferKeyEntrypoints`. The follow-up repo-guard fix ran `detect_changes --scope unstaged`; GitNexus reported 3 files / 1 symbol, Risk level medium, with a line-shifted symbol mapping, while the actual diff was the schema path parameter handoff.
- Verification: `pnpm agent:bootstrap`; `pnpm quality:predev`; red/green `pnpm --filter @frontagent/mcp-filesense test -- src/engine-notes.test.ts`; `pnpm --filter @frontagent/mcp-filesense test`; `pnpm --filter @frontagent/mcp-filesense typecheck`; `pnpm quality:precommit`; pre-push `pnpm quality:local`. Repo Guard requested preserving canonical notes schema path ownership; fixed by passing `schemaPathsForRoot(root, config).notesSchemaPath` into `buildNotesFile` and adding a regression test.

## Verification

- `pnpm --filter @frontagent/mcp-filesense test`: 5 files, 38 tests passed.
- `pnpm --filter @frontagent/mcp-filesense typecheck`: passed.
- `pnpm quality:precommit`: lint, typecheck, tests, workflow tests passed.
- `pnpm quality:local`: contract, CI-quality lint/typecheck/test/workflow tests/build/package passed.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.
