### PR TITLE
Decompose VS Code webview script template renderer

### DIFF
--- a/apps/vscode/src/webview-html.test.ts
+++ b/apps/vscode/src/webview-html.test.ts
@@ -3,7 +3,13 @@ import {
   getWebviewHtml,
   nonce,
   renderWebviewBodySection,
+  renderWebviewConfigScript,
+  renderWebviewContextScript,
+  renderWebviewErrorScript,
+  renderWebviewEventScript,
+  renderWebviewMessageScript,
   renderWebviewScriptSection,
+  renderWebviewStateScript,
   renderWebviewStyleSection,
 } from './webview-html.js';
 
@@ -47,6 +53,39 @@ describe('VS Code webview HTML nonce handling', () => {
 
     expect(scriptNonce).toBeDefined();
     expect(scriptSection).toBe(renderWebviewScriptSection(scriptNonce ?? ''));
+  });
+
+  it('assembles the script section from focused template helpers', () => {
+    const scriptNonce = 'script-test-nonce';
+    const section = renderWebviewScriptSection(scriptNonce);
+    const helpers = [
+      renderWebviewStateScript(),
+      renderWebviewConfigScript(),
+      renderWebviewContextScript(),
+      renderWebviewMessageScript(),
+      renderWebviewEventScript(),
+      renderWebviewErrorScript(),
+    ];
+
+    expect(section).toBe(`  <script nonce="${scriptNonce}">
+${helpers.join('\n')}
+
+    vscode.postMessage({ type: 'ready' });
+  </script>`);
+    expect(section).toContain('acquireVsCodeApi()');
+    expect(section).toContain("vscode.postMessage({ type: 'ready' });");
+    expect(section).toContain("type: 'send'");
+    expect(section).toContain("type: 'saveConfig'");
+    expect(section).toContain("type: 'approve'");
+    expect(section).toContain("type: 'reject'");
+    expect(section).toContain("type: 'webviewError'");
+    expect(section).toContain("$('composer').addEventListener('submit'");
+    expect(section).toContain("$('contextFiles').addEventListener('click'");
+    expect(section).toContain("window.addEventListener('message'");
+    expect(section).toContain("window.addEventListener('error'");
+    expect(section).toContain("window.addEventListener('unhandledrejection'");
+    expect(section).toContain('data-remove-file');
+    expect(section).toContain(`replace(/[&<>"']/g`);
   });
 
   it('renders the body markup through a focused renderer', () => {

--- a/apps/vscode/src/webview-html.ts
+++ b/apps/vscode/src/webview-html.ts
@@ -492,9 +492,8 @@ export function renderWebviewStyleSection(styleNonce: string): string {
   </style>`;
 }
 
-export function renderWebviewScriptSection(scriptNonce: string): string {
-  return `  <script nonce="${scriptNonce}">
-    const vscode = acquireVsCodeApi();
+export function renderWebviewStateScript(): string {
+  return `    const vscode = acquireVsCodeApi();
     let state = null;
     let activeMode = 'query';
     let lastComposer = '';
@@ -504,11 +503,6 @@ export function renderWebviewScriptSection(scriptNonce: string): string {
     const browserUrl = $('browserUrl');
     const modeSelect = $('modeSelect');
     const detailsPanel = $('detailsPanel');
-    const modeCopy = {
-      query: { label: 'Ask', description: 'Explain and answer' },
-      modify: { label: 'Agent Edit', description: 'Plan and change code' },
-      debug: { label: 'Debug', description: 'Trace and fix failures' }
-    };
 
     function render(next) {
       state = next;
@@ -529,7 +523,15 @@ export function renderWebviewScriptSection(scriptNonce: string): string {
         browserUrl.value = next.browserUrl || '';
         lastBrowserUrl = next.browserUrl || '';
       }
-    }
+    }`;
+}
+
+export function renderWebviewConfigScript(): string {
+  return `    const modeCopy = {
+      query: { label: 'Ask', description: 'Explain and answer' },
+      modify: { label: 'Agent Edit', description: 'Plan and change code' },
+      debug: { label: 'Debug', description: 'Trace and fix failures' }
+    };
 
     function renderConfig(config) {
       const missing = config.missing || [];
@@ -551,9 +553,11 @@ export function renderWebviewScriptSection(scriptNonce: string): string {
     function renderMode() {
       if (document.activeElement !== modeSelect) modeSelect.value = activeMode;
       $('modeDescription').textContent = modeCopy[activeMode]?.description || '';
-    }
+    }`;
+}
 
-    function renderContext(next) {
+export function renderWebviewContextScript(): string {
+  return `    function renderContext(next) {
       $('contextFiles').innerHTML = next.contextFiles.length
         ? next.contextFiles.map((file) => \`<span class="chip">\${escapeHtml(file)}<button type="button" data-remove-file="\${escapeHtml(file)}">x</button></span>\`).join('')
         : '<span class="context-empty">No files attached</span>';
@@ -561,7 +565,48 @@ export function renderWebviewScriptSection(scriptNonce: string): string {
       $('selectionPreview').textContent = next.selectionPreview ? \`Selection context:\\n\${next.selectionPreview}\` : '';
     }
 
-    function renderMessages(next) {
+    function renderDetails(next) {
+      detailsPanel.open = !next.detailsCollapsed;
+      $('activityLabel').textContent = next.lastActivityLabel || '等待开始';
+      $('operation').textContent = next.currentOperation || '';
+      $('phaseCount').textContent = next.phases.length ? \`(\${next.phases.length})\` : '';
+      $('phases').innerHTML = next.phases.length ? next.phases.map((phase) => \`
+        <div class="phase">
+          <div class="phase-head">
+            <strong>\${escapeHtml(phase.name)}</strong>
+            <span class="badge \${escapeHtml(phase.status)}">\${escapeHtml(phase.status)}</span>
+          </div>
+          <div class="steps">
+            \${phase.steps.map((step) => \`
+              <div class="step">
+                <span class="badge \${escapeHtml(step.status)}">\${escapeHtml(step.status)}</span>
+                <div>
+                  <div>\${escapeHtml(step.description)}</div>
+                  <div class="muted mono">\${escapeHtml(step.tool)} · \${escapeHtml(step.action)}</div>
+                  \${step.error ? \`<div class="danger">\${escapeHtml(step.error)}</div>\` : ''}
+                </div>
+              </div>\`).join('')}
+          </div>
+        </div>\`).join('') : 'No plan yet.';
+      $('ragMeta').textContent = next.ragSearchMode ? \`\${next.ragSearchMode}\${next.ragReranked ? ' · reranked' : ''}\` : '';
+      $('rag').innerHTML = next.ragMatches.length
+        ? next.ragMatches.map((match) => \`<div><strong>\${escapeHtml(match.title)}</strong><div class="muted mono">\${escapeHtml(match.path || '')}</div></div>\`).join('')
+        : 'No matches yet.';
+    }
+
+    function escapeHtml(value) {
+      return String(value ?? '').replace(/[&<>"']/g, (char) => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+      }[char]));
+    }`;
+}
+
+export function renderWebviewMessageScript(): string {
+  return `    function renderMessages(next) {
       const parts = [];
       if (!next.messages.length && !next.streamText && !next.approval) {
         parts.push('<div class="empty"><strong>Start with FrontAgent</strong><br>Ask a question, switch to Agent Edit for code changes, or attach a file, selection, and browser URL for richer context.</div>');
@@ -612,48 +657,11 @@ export function renderWebviewScriptSection(scriptNonce: string): string {
       }
       $('messages').innerHTML = parts.join('');
       $('messages').scrollTop = $('messages').scrollHeight;
-    }
+    }`;
+}
 
-    function renderDetails(next) {
-      detailsPanel.open = !next.detailsCollapsed;
-      $('activityLabel').textContent = next.lastActivityLabel || '等待开始';
-      $('operation').textContent = next.currentOperation || '';
-      $('phaseCount').textContent = next.phases.length ? \`(\${next.phases.length})\` : '';
-      $('phases').innerHTML = next.phases.length ? next.phases.map((phase) => \`
-        <div class="phase">
-          <div class="phase-head">
-            <strong>\${escapeHtml(phase.name)}</strong>
-            <span class="badge \${escapeHtml(phase.status)}">\${escapeHtml(phase.status)}</span>
-          </div>
-          <div class="steps">
-            \${phase.steps.map((step) => \`
-              <div class="step">
-                <span class="badge \${escapeHtml(step.status)}">\${escapeHtml(step.status)}</span>
-                <div>
-                  <div>\${escapeHtml(step.description)}</div>
-                  <div class="muted mono">\${escapeHtml(step.tool)} · \${escapeHtml(step.action)}</div>
-                  \${step.error ? \`<div class="danger">\${escapeHtml(step.error)}</div>\` : ''}
-                </div>
-              </div>\`).join('')}
-          </div>
-        </div>\`).join('') : 'No plan yet.';
-      $('ragMeta').textContent = next.ragSearchMode ? \`\${next.ragSearchMode}\${next.ragReranked ? ' · reranked' : ''}\` : '';
-      $('rag').innerHTML = next.ragMatches.length
-        ? next.ragMatches.map((match) => \`<div><strong>\${escapeHtml(match.title)}</strong><div class="muted mono">\${escapeHtml(match.path || '')}</div></div>\`).join('')
-        : 'No matches yet.';
-    }
-
-    function escapeHtml(value) {
-      return String(value ?? '').replace(/[&<>"']/g, (char) => ({
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;',
-        '"': '&quot;',
-        "'": '&#39;'
-      }[char]));
-    }
-
-    $('composer').addEventListener('submit', (event) => {
+export function renderWebviewEventScript(): string {
+  return `    $('composer').addEventListener('submit', (event) => {
       event.preventDefault();
       const task = prompt.value.trim();
       if (!task) return;
@@ -706,8 +714,11 @@ export function renderWebviewScriptSection(scriptNonce: string): string {
     window.addEventListener('message', (event) => {
       const message = event.data;
       if (message.type === 'state') render(message.state);
-    });
-    window.addEventListener('error', (event) => {
+    });`;
+}
+
+export function renderWebviewErrorScript(): string {
+  return `    window.addEventListener('error', (event) => {
       vscode.postMessage({
         type: 'webviewError',
         message: event.message || 'Unknown webview error',
@@ -721,7 +732,21 @@ export function renderWebviewScriptSection(scriptNonce: string): string {
         message: reason?.message || String(reason || 'Unhandled webview rejection'),
         stack: reason?.stack
       });
-    });
+    });`;
+}
+
+export function renderWebviewScriptSection(scriptNonce: string): string {
+  const scripts = [
+    renderWebviewStateScript(),
+    renderWebviewConfigScript(),
+    renderWebviewContextScript(),
+    renderWebviewMessageScript(),
+    renderWebviewEventScript(),
+    renderWebviewErrorScript(),
+  ];
+
+  return `  <script nonce="${scriptNonce}">
+${scripts.join('\n')}
 
     vscode.postMessage({ type: 'ready' });
   </script>`;

--- a/docs/superpowers/plans/2026-06-08-vscode-webview-script-template.md
+++ b/docs/superpowers/plans/2026-06-08-vscode-webview-script-template.md
@@ -1,0 +1,39 @@
+# VS Code Webview Script Template Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Decompose `renderWebviewScriptSection` so it mainly assembles focused script template fragments while preserving generated webview behavior.
+
+**Architecture:** Keep `apps/vscode/src/webview-html.ts` as the existing renderer module. Add small script-fragment helpers for state/render orchestration, config/mode rendering, context/details rendering, messages, event wiring, and error reporting; `renderWebviewScriptSection` remains the nonce wrapper and assembly point.
+
+**Tech Stack:** TypeScript, VS Code webview HTML string rendering, Vitest.
+
+---
+
+## GitNexus Impact
+
+- `npx gitnexus impact renderWebviewScriptSection --direction upstream --file apps/vscode/src/webview-html.ts --kind Function --include-tests --repo <worktree>`: LOW risk; 1 direct affected symbol, `apps/vscode/src/webview-html.test.ts`; 0 affected processes/modules.
+- `npx gitnexus context renderWebviewScriptSection --file apps/vscode/src/webview-html.ts --repo <worktree>`: participates in `ResolveWebviewView -> getWebviewHtml -> renderWebviewScriptSection`.
+- `npx gitnexus query "VS Code webview HTML render script section" --repo <worktree> --limit 5`: top process is the VS Code webview render path.
+
+## Files
+
+- Modify: `apps/vscode/src/webview-html.ts`
+- Modify: `apps/vscode/src/webview-html.test.ts`
+
+## Tasks
+
+- [x] Add a focused test that imports the new script helper exports and verifies `renderWebviewScriptSection` assembles those helpers in order while keeping the nonce wrapper.
+- [x] Run `pnpm --filter frontagent test -- src/webview-html.test.ts` and confirm the test fails because the helper exports do not exist yet.
+- [x] Extract script template fragments into focused helper functions in `apps/vscode/src/webview-html.ts`; keep the generated IDs, classes, messages, state fields, UI text, and event handlers unchanged.
+- [x] Run `pnpm --filter frontagent test -- src/webview-html.test.ts` and confirm the focused test passes.
+- [x] Run `pnpm --filter frontagent typecheck`.
+- [x] Run `npx gitnexus detect_changes --scope all --repo <worktree>` and record the final diff impact.
+- [x] Run `pnpm quality:precommit` if the diff impact or PR risk warrants the broader gate.
+
+## Final Diff Impact
+
+- `npx gitnexus detect_changes --scope all --repo <worktree>`: MEDIUM risk; 3 files, 2 changed symbols; affected flows are `ResolveWebviewView -> RenderWebviewScriptSection` and `ResolveWebviewView -> RenderWebviewBodySection`.
+- `renderWebviewBodySection` is reported because the adjacent script extraction moved the following symbol range; body markup/extraction was not edited.
+- After rebasing onto latest `origin/develop`, `npx gitnexus detect_changes --scope compare --base-ref origin/develop --repo <worktree>` reported MEDIUM risk; 3 files, 1 changed indexed symbol; affected flow `ResolveWebviewView -> Nonce`. This is GitNexus range attribution for the webview renderer diff; nonce/CSP behavior was not edited.
+- `pnpm quality:precommit`: passed.


### PR DESCRIPTION
## Linked Issue Or Context

Closes #234

## Summary

- Split the VS Code webview script template into focused state, config, context/details, message, event, and error script helpers.
- Kept `renderWebviewScriptSection` as the nonce wrapper and assembly point.
- Added focused webview HTML coverage for helper-based script assembly plus key protocol/event/error/escaping fragments.

## Impact Scope

- `apps/vscode/src/webview-html.ts` script template decomposition only.
- `apps/vscode/src/webview-html.test.ts` focused assembly and behavior-fragment coverage.
- `docs/superpowers/plans/2026-06-08-vscode-webview-script-template.md` implementation plan.
- No body/style extraction, CSP/nonce, webview message protocol, state shape, UI text, IDs/classes, or event semantics changes intended.

## GitNexus Impact Summary

- Risk level: MEDIUM
- Critical skeleton changes: none; touched VS Code webview renderer/test and a plan doc, outside the configured critical skeleton categories.
- GitNexus impact: impact on `renderWebviewScriptSection` before edits was LOW with 1 direct affected test file and 0 affected processes/modules; context showed `ResolveWebviewView -> getWebviewHtml -> renderWebviewScriptSection`; query for VS Code webview HTML script rendering returned that same render path as the top process. Before rebase, `detect_changes` reported 3 files, 2 changed symbols, MEDIUM risk, and affected flows `ResolveWebviewView -> RenderWebviewScriptSection` plus adjacent `ResolveWebviewView -> RenderWebviewBodySection`. After rebasing onto latest `origin/develop`, `detect_changes --scope compare --base-ref origin/develop` reported 3 files, 1 indexed changed symbol, MEDIUM risk, and affected flow `ResolveWebviewView -> Nonce`; this is GitNexus range attribution for the webview renderer diff, and nonce/CSP behavior was not edited.
- Verification: `pnpm agent:bootstrap` passed; `pnpm quality:predev` passed; `pnpm --filter frontagent test -- src/webview-html.test.ts` failed first on missing helper export, then passed with 6 tests; `pnpm --filter frontagent typecheck` passed; `pnpm quality:precommit` passed; push hook `pnpm quality:local` passed before and after rebase.

## Verification

- `pnpm agent:bootstrap`
- `pnpm quality:predev`
- `pnpm --filter frontagent test -- src/webview-html.test.ts`
- `pnpm --filter frontagent typecheck`
- `pnpm quality:precommit`
- `pnpm quality:local` via pre-push hook
- `npx gitnexus detect_changes --scope compare --base-ref origin/develop --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-vscode-webview-script-template`

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.