### PR TITLE
Extract ContextManager filesystem fact updates

### DIFF
--- a/docs/superpowers/plans/2026-06-08-contextmanager-filesystem-facts.md
+++ b/docs/superpowers/plans/2026-06-08-contextmanager-filesystem-facts.md
@@ -1,0 +1,136 @@
+# ContextManager Filesystem Facts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `ContextManager.updateFileSystemFacts` low-level filesystem fact mutation into a focused helper while preserving the public facade and behavior.
+
+**Architecture:** Keep `ContextManager.updateFileSystemFacts(taskId, toolName, params, result)` as the public API and revision-bump owner. Add `packages/core/src/context/filesystem-facts-update.ts` with a pure mutating helper that receives `ProjectFacts`, tool metadata, and tool result, returning whether facts changed. The helper owns filesense deltas, filesense index enrichment, file/list/search tool-result contracts, and set/map mutation semantics.
+
+**Tech Stack:** TypeScript, Vitest, existing `ProjectFacts` types and context helper utilities.
+
+---
+
+### Task 1: Focused Helper Contract Test
+
+**Files:**
+- Modify: `packages/core/src/context/context-manager.test.ts`
+- Create later: `packages/core/src/context/filesystem-facts-update.ts`
+
+- [ ] **Step 1: Add a failing helper-level test**
+
+Add an import:
+
+```ts
+import { updateFilesystemFactsFromToolResult } from './filesystem-facts-update.js';
+```
+
+Add this test in `describe('updateFileSystemFacts', ...)`:
+
+```ts
+it('keeps filesystem helper mutations independent from revision bumping', () => {
+  const manager = new ContextManager();
+  const context = manager.createContext(makeTask({ id: 't1' }));
+
+  const changed = updateFilesystemFactsFromToolResult(context.facts, 'search_code', {}, {
+    success: true,
+    files: ['src/app.ts'],
+  });
+
+  expect(changed).toBe(true);
+  expect(context.facts.filesystem.existingFiles.has('src/app.ts')).toBe(true);
+  expect(context.facts.filesystem.existingDirectories.has('src')).toBe(true);
+  expect(context.facts.revision).toBe(0);
+});
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+pnpm --filter @frontagent/core test -- src/context/context-manager.test.ts
+```
+
+Expected: FAIL because `./filesystem-facts-update.js` does not exist yet.
+
+### Task 2: Extract Filesystem Facts Helper
+
+**Files:**
+- Create: `packages/core/src/context/filesystem-facts-update.ts`
+- Modify: `packages/core/src/context/context-manager.ts`
+
+- [ ] **Step 1: Create the helper module**
+
+Move the existing low-level filesystem fact mutation logic into:
+
+```ts
+export function updateFilesystemFactsFromToolResult(
+  facts: ProjectFacts,
+  toolName: string,
+  params: Record<string, unknown>,
+  result: { success?: boolean; error?: string; [key: string]: unknown },
+): boolean
+```
+
+Use helper-local `addToSet`, `removeFromSet`, and `setStringArrayMap` functions with the same semantics currently used by `ContextManager.updateFileSystemFacts`.
+
+- [ ] **Step 2: Keep the ContextManager facade**
+
+Replace the body of `ContextManager.updateFileSystemFacts` after context lookup with:
+
+```ts
+if (updateFilesystemFactsFromToolResult(context.facts, toolName, params, result)) {
+  this.bumpFactsRevision(context.facts);
+}
+```
+
+Do not rename `ContextManager.updateFileSystemFacts` and do not change its parameters or return type.
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @frontagent/core test -- src/context/context-manager.test.ts
+```
+
+Expected: PASS.
+
+### Task 3: Verification and PR Prep
+
+**Files:**
+- Verify all changed files.
+
+- [ ] **Step 1: Run required checks**
+
+Run:
+
+```bash
+pnpm --filter @frontagent/core typecheck
+npx gitnexus detect_changes --scope all --repo FrontAgent
+```
+
+Expected: typecheck exits 0; `detect_changes` reports only the plan, context manager facade, helper module, and focused test scope.
+
+- [ ] **Step 2: Run broader gate if needed**
+
+Because this touches core context fact propagation, run:
+
+```bash
+pnpm quality:precommit
+```
+
+Expected: exits 0.
+
+- [ ] **Step 3: Open PR**
+
+Push `improve/contextmanager-filesystem-facts` and open a PR to `develop` with `Closes #233` and a GitNexus Impact Summary containing:
+
+```md
+Risk level:
+Critical skeleton changes:
+GitNexus impact:
+Verification:
+```
+
+Use `detect_changes` with an underscore in the PR body.

--- a/packages/core/src/context/context-manager.test.ts
+++ b/packages/core/src/context/context-manager.test.ts
@@ -7,6 +7,7 @@ import {
   mergeProjectFactsUpdate,
   projectFactsFromSnapshot,
 } from './facts-merge-helpers.js';
+import { updateFilesystemFactsFromToolResult } from './filesystem-facts-update.js';
 
 function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
   return {
@@ -310,6 +311,26 @@ describe('ContextManager', () => {
   });
 
   describe('updateFileSystemFacts', () => {
+    it('keeps filesystem helper mutations independent from revision bumping', () => {
+      const manager = new ContextManager();
+      const context = manager.createContext(makeTask({ id: 't1' }));
+
+      const changed = updateFilesystemFactsFromToolResult(
+        context.facts,
+        'search_code',
+        {},
+        {
+          success: true,
+          files: ['src/app.ts'],
+        },
+      );
+
+      expect(changed).toBe(true);
+      expect(context.facts.filesystem.existingFiles.has('src/app.ts')).toBe(true);
+      expect(context.facts.filesystem.existingDirectories.has('src')).toBe(true);
+      expect(context.facts.revision).toBe(0);
+    });
+
     it('records existing file on create_file success', () => {
       const manager = new ContextManager();
       manager.createContext(makeTask({ id: 't1' }));

--- a/packages/core/src/context/context-manager.ts
+++ b/packages/core/src/context/context-manager.ts
@@ -15,11 +15,8 @@ import {
   mergeProjectFactsUpdate,
   projectFactsFromSnapshot,
 } from './facts-merge-helpers.js';
-import {
-  formatFilesenseNavigationContext,
-  normalizeFilesenseNavigation,
-  parentDirectoriesForPath,
-} from './helpers.js';
+import { updateFilesystemFactsFromToolResult } from './filesystem-facts-update.js';
+import { formatFilesenseNavigationContext, normalizeFilesenseNavigation } from './helpers.js';
 import { updateModuleDependencyGraphFromToolResult } from './module-dependency-graph.js';
 
 /**
@@ -89,19 +86,6 @@ export class ContextManager {
 
   private removeFromSet(set: Set<string>, value: string): boolean {
     return set.delete(value);
-  }
-
-  private setStringArrayMap(map: Map<string, string[]>, key: string, value: string[]): boolean {
-    const previous = map.get(key);
-    if (
-      previous &&
-      previous.length === value.length &&
-      previous.every((item, idx) => item === value[idx])
-    ) {
-      return false;
-    }
-    map.set(key, value);
-    return true;
   }
 
   /**
@@ -326,169 +310,8 @@ export class ContextManager {
     const context = this.contexts.get(taskId);
     if (!context) return;
 
-    const { facts } = context;
-    let changed = false;
-
-    // Handle filesense navigation results - consume explicit factsDelta instead of guessing result shape.
-    if (toolName.startsWith('filesense_')) {
-      const data = result.data as
-        | { factsDelta?: { existingFiles?: string[]; existingDirectories?: string[] } }
-        | undefined;
-      const factsDelta = data?.factsDelta;
-      if (result.success && factsDelta) {
-        for (const file of factsDelta.existingFiles ?? []) {
-          changed = this.addToSet(facts.filesystem.existingFiles, file) || changed;
-          changed = this.removeFromSet(facts.filesystem.nonExistentPaths, file) || changed;
-        }
-        for (const dir of factsDelta.existingDirectories ?? []) {
-          changed = this.addToSet(facts.filesystem.existingDirectories, dir) || changed;
-          changed = this.removeFromSet(facts.filesystem.nonExistentPaths, dir) || changed;
-        }
-      }
-    }
-
-    // Handle filesense tool results - enrich ProjectFacts from index data
-    if (
-      toolName === 'filesense_sync' ||
-      toolName === 'filesense_sync_and_summarize' ||
-      toolName === 'filesense_query'
-    ) {
-      if (result.success && result.data) {
-        const data = result.data as Record<string, unknown>;
-
-        // For query results, extract file/directory existence from the index
-        const index = (data.index ?? (data as { sync?: unknown }).sync) as
-          | { children?: Array<{ name: string; path: string; type: string }> }
-          | undefined;
-        if (index?.children) {
-          for (const child of index.children) {
-            if (child.type === 'file') {
-              changed = this.addToSet(facts.filesystem.existingFiles, child.path) || changed;
-              changed =
-                this.removeFromSet(facts.filesystem.nonExistentPaths, child.path) || changed;
-            } else if (child.type === 'dir') {
-              changed = this.addToSet(facts.filesystem.existingDirectories, child.path) || changed;
-              changed =
-                this.removeFromSet(facts.filesystem.nonExistentPaths, child.path) || changed;
-            }
-          }
-        }
-
-        // For sync results, mark the root as existing directory
-        const root = data.root as string | undefined;
-        if (root) {
-          changed = this.addToSet(facts.filesystem.existingDirectories, root) || changed;
-        }
-      }
-    }
-
-    switch (toolName) {
-      case 'create_file':
-      case 'apply_patch': {
-        const path = params.path as string;
-        if (result.success) {
-          changed = this.addToSet(facts.filesystem.existingFiles, path) || changed;
-          changed = this.removeFromSet(facts.filesystem.nonExistentPaths, path) || changed;
-        } else if (result.error?.includes('not found')) {
-          changed = this.addToSet(facts.filesystem.nonExistentPaths, path) || changed;
-        }
-        break;
-      }
-      case 'read_file': {
-        const path = params.path as string;
-        // 🔧 修复：检查 skipped 和 exists 字段，正确记录不存在的文件
-        if (result.success && !result.skipped) {
-          // 真正成功读取了文件
-          changed = this.addToSet(facts.filesystem.existingFiles, path) || changed;
-          changed = this.removeFromSet(facts.filesystem.nonExistentPaths, path) || changed;
-        } else if (result.skipped && result.exists === false) {
-          // 步骤被跳过且文件不存在
-          changed = this.addToSet(facts.filesystem.nonExistentPaths, path) || changed;
-          changed = this.removeFromSet(facts.filesystem.existingFiles, path) || changed;
-        } else if (
-          result.error?.includes('not found') ||
-          result.error?.includes('does not exist')
-        ) {
-          // 明确的文件不存在错误
-          changed = this.addToSet(facts.filesystem.nonExistentPaths, path) || changed;
-          changed = this.removeFromSet(facts.filesystem.existingFiles, path) || changed;
-        }
-        break;
-      }
-      case 'list_directory': {
-        const path = params.path as string;
-        // 🔧 修复：同样检查 skipped 字段
-        if (result.success && !result.skipped && Array.isArray(result.entries)) {
-          changed = this.addToSet(facts.filesystem.existingDirectories, path) || changed;
-
-          // 🔧 关键修复：从目录内容推断文件存在性
-          // list_directory 返回的 entries 是 FileInfo[] 对象数组
-          // FileInfo = { name: string, path: string, type: 'file' | 'directory', size?, modifiedAt? }
-          const entries = result.entries as Array<{ name: string; path: string; type: string }>;
-
-          // 存储路径字符串用于 directoryContents
-          changed =
-            this.setStringArrayMap(
-              facts.filesystem.directoryContents,
-              path,
-              entries.map((e) => e.path),
-            ) || changed;
-
-          // 将目录中的文件/子目录添加到相应的集合
-          for (const entry of entries) {
-            if (entry.type === 'file') {
-              changed = this.addToSet(facts.filesystem.existingFiles, entry.path) || changed;
-              changed =
-                this.removeFromSet(facts.filesystem.nonExistentPaths, entry.path) || changed;
-            } else if (entry.type === 'directory') {
-              changed = this.addToSet(facts.filesystem.existingDirectories, entry.path) || changed;
-              changed =
-                this.removeFromSet(facts.filesystem.nonExistentPaths, entry.path) || changed;
-            }
-          }
-        } else if (result.skipped || result.error?.includes('not found')) {
-          changed = this.addToSet(facts.filesystem.nonExistentPaths, path) || changed;
-        }
-        break;
-      }
-      case 'search_code': {
-        if (!result.success) {
-          break;
-        }
-
-        const files = new Set<string>();
-
-        if (Array.isArray(result.files)) {
-          for (const file of result.files) {
-            if (typeof file === 'string') {
-              files.add(file);
-            }
-          }
-        }
-
-        if (Array.isArray(result.matches)) {
-          for (const match of result.matches as Array<{ file?: unknown }>) {
-            if (typeof match.file === 'string') {
-              files.add(match.file);
-            }
-          }
-        }
-
-        for (const file of files) {
-          changed = this.addToSet(facts.filesystem.existingFiles, file) || changed;
-          changed = this.removeFromSet(facts.filesystem.nonExistentPaths, file) || changed;
-
-          for (const parent of parentDirectoriesForPath(file)) {
-            changed = this.addToSet(facts.filesystem.existingDirectories, parent) || changed;
-            changed = this.removeFromSet(facts.filesystem.nonExistentPaths, parent) || changed;
-          }
-        }
-        break;
-      }
-    }
-
-    if (changed) {
-      this.bumpFactsRevision(facts);
+    if (updateFilesystemFactsFromToolResult(context.facts, toolName, params, result)) {
+      this.bumpFactsRevision(context.facts);
     }
   }
 

--- a/packages/core/src/context/filesystem-facts-update.ts
+++ b/packages/core/src/context/filesystem-facts-update.ts
@@ -1,0 +1,180 @@
+import type { ProjectFacts } from '../types.js';
+import { parentDirectoriesForPath } from './helpers.js';
+
+type ToolResult = { success?: boolean; error?: string; [key: string]: unknown };
+
+function addToSet(set: Set<string>, value: string): boolean {
+  const before = set.size;
+  set.add(value);
+  return set.size !== before;
+}
+
+function removeFromSet(set: Set<string>, value: string): boolean {
+  return set.delete(value);
+}
+
+function setStringArrayMap(map: Map<string, string[]>, key: string, value: string[]): boolean {
+  const previous = map.get(key);
+  if (
+    previous &&
+    previous.length === value.length &&
+    previous.every((item, idx) => item === value[idx])
+  ) {
+    return false;
+  }
+  map.set(key, value);
+  return true;
+}
+
+export function updateFilesystemFactsFromToolResult(
+  facts: ProjectFacts,
+  toolName: string,
+  params: Record<string, unknown>,
+  result: ToolResult,
+): boolean {
+  let changed = false;
+
+  // Handle filesense navigation results - consume explicit factsDelta instead of guessing result shape.
+  if (toolName.startsWith('filesense_')) {
+    const data = result.data as
+      | { factsDelta?: { existingFiles?: string[]; existingDirectories?: string[] } }
+      | undefined;
+    const factsDelta = data?.factsDelta;
+    if (result.success && factsDelta) {
+      for (const file of factsDelta.existingFiles ?? []) {
+        changed = addToSet(facts.filesystem.existingFiles, file) || changed;
+        changed = removeFromSet(facts.filesystem.nonExistentPaths, file) || changed;
+      }
+      for (const dir of factsDelta.existingDirectories ?? []) {
+        changed = addToSet(facts.filesystem.existingDirectories, dir) || changed;
+        changed = removeFromSet(facts.filesystem.nonExistentPaths, dir) || changed;
+      }
+    }
+  }
+
+  // Handle filesense tool results - enrich ProjectFacts from index data
+  if (
+    toolName === 'filesense_sync' ||
+    toolName === 'filesense_sync_and_summarize' ||
+    toolName === 'filesense_query'
+  ) {
+    if (result.success && result.data) {
+      const data = result.data as Record<string, unknown>;
+
+      // For query results, extract file/directory existence from the index
+      const index = (data.index ?? (data as { sync?: unknown }).sync) as
+        | { children?: Array<{ name: string; path: string; type: string }> }
+        | undefined;
+      if (index?.children) {
+        for (const child of index.children) {
+          if (child.type === 'file') {
+            changed = addToSet(facts.filesystem.existingFiles, child.path) || changed;
+            changed = removeFromSet(facts.filesystem.nonExistentPaths, child.path) || changed;
+          } else if (child.type === 'dir') {
+            changed = addToSet(facts.filesystem.existingDirectories, child.path) || changed;
+            changed = removeFromSet(facts.filesystem.nonExistentPaths, child.path) || changed;
+          }
+        }
+      }
+
+      // For sync results, mark the root as existing directory
+      const root = data.root as string | undefined;
+      if (root) {
+        changed = addToSet(facts.filesystem.existingDirectories, root) || changed;
+      }
+    }
+  }
+
+  switch (toolName) {
+    case 'create_file':
+    case 'apply_patch': {
+      const path = params.path as string;
+      if (result.success) {
+        changed = addToSet(facts.filesystem.existingFiles, path) || changed;
+        changed = removeFromSet(facts.filesystem.nonExistentPaths, path) || changed;
+      } else if (result.error?.includes('not found')) {
+        changed = addToSet(facts.filesystem.nonExistentPaths, path) || changed;
+      }
+      break;
+    }
+    case 'read_file': {
+      const path = params.path as string;
+      // Check skipped and exists fields to correctly record missing files.
+      if (result.success && !result.skipped) {
+        changed = addToSet(facts.filesystem.existingFiles, path) || changed;
+        changed = removeFromSet(facts.filesystem.nonExistentPaths, path) || changed;
+      } else if (result.skipped && result.exists === false) {
+        changed = addToSet(facts.filesystem.nonExistentPaths, path) || changed;
+        changed = removeFromSet(facts.filesystem.existingFiles, path) || changed;
+      } else if (result.error?.includes('not found') || result.error?.includes('does not exist')) {
+        changed = addToSet(facts.filesystem.nonExistentPaths, path) || changed;
+        changed = removeFromSet(facts.filesystem.existingFiles, path) || changed;
+      }
+      break;
+    }
+    case 'list_directory': {
+      const path = params.path as string;
+      if (result.success && !result.skipped && Array.isArray(result.entries)) {
+        changed = addToSet(facts.filesystem.existingDirectories, path) || changed;
+
+        const entries = result.entries as Array<{ name: string; path: string; type: string }>;
+
+        changed =
+          setStringArrayMap(
+            facts.filesystem.directoryContents,
+            path,
+            entries.map((e) => e.path),
+          ) || changed;
+
+        for (const entry of entries) {
+          if (entry.type === 'file') {
+            changed = addToSet(facts.filesystem.existingFiles, entry.path) || changed;
+            changed = removeFromSet(facts.filesystem.nonExistentPaths, entry.path) || changed;
+          } else if (entry.type === 'directory') {
+            changed = addToSet(facts.filesystem.existingDirectories, entry.path) || changed;
+            changed = removeFromSet(facts.filesystem.nonExistentPaths, entry.path) || changed;
+          }
+        }
+      } else if (result.skipped || result.error?.includes('not found')) {
+        changed = addToSet(facts.filesystem.nonExistentPaths, path) || changed;
+      }
+      break;
+    }
+    case 'search_code': {
+      if (!result.success) {
+        break;
+      }
+
+      const files = new Set<string>();
+
+      if (Array.isArray(result.files)) {
+        for (const file of result.files) {
+          if (typeof file === 'string') {
+            files.add(file);
+          }
+        }
+      }
+
+      if (Array.isArray(result.matches)) {
+        for (const match of result.matches as Array<{ file?: unknown }>) {
+          if (typeof match.file === 'string') {
+            files.add(match.file);
+          }
+        }
+      }
+
+      for (const file of files) {
+        changed = addToSet(facts.filesystem.existingFiles, file) || changed;
+        changed = removeFromSet(facts.filesystem.nonExistentPaths, file) || changed;
+
+        for (const parent of parentDirectoriesForPath(file)) {
+          changed = addToSet(facts.filesystem.existingDirectories, parent) || changed;
+          changed = removeFromSet(facts.filesystem.nonExistentPaths, parent) || changed;
+        }
+      }
+      break;
+    }
+  }
+
+  return changed;
+}


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #233

## Summary

- Extracted low-level filesystem fact mutation/tool-result handling from `ContextManager.updateFileSystemFacts` into `packages/core/src/context/filesystem-facts-update.ts`.
- Kept `ContextManager.updateFileSystemFacts` as the public facade and left revision bumping in `ContextManager`.
- Added a focused helper contract test and the requested implementation plan doc.

## Impact Scope

- Context filesystem fact propagation only: filesense factsDelta/index data, create/apply/read/list/search tool result handling, set/map mutation, and revision bump behavior.
- Public API diff: empty. `ContextManager.updateFileSystemFacts` signature and return type are unchanged.

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: No
- GitNexus impact: `gitnexus impact updateFileSystemFacts --direction upstream --file packages/core/src/context/context-manager.ts --kind Method --include-tests --repo FrontAgent` reported 1 direct dependent (`packages/core/src/context/context-manager.test.ts`), 0 affected processes, 0 affected modules. `gitnexus impact setStringArrayMap --direction upstream --file packages/core/src/context/context-manager.ts --kind Method --include-tests --repo FrontAgent` reported LOW risk through `updateFileSystemFacts` to the same test file. `gitnexus detect_changes --scope staged --repo FrontAgent` after refreshing the index reported 4 files, 17 symbols, 0 affected processes, risk level low.
- Verification: `pnpm agent:bootstrap`; `pnpm quality:predev`; RED check with `pnpm --filter @frontagent/core test -- src/context/context-manager.test.ts` failed before helper creation due missing `./filesystem-facts-update.js`; `pnpm --filter @frontagent/core test -- src/context/context-manager.test.ts`; `pnpm --filter @frontagent/core typecheck`; `pnpm quality:precommit`; pre-push `pnpm quality:local`.

## Verification

- `pnpm --filter @frontagent/core test -- src/context/context-manager.test.ts` - 57 tests passed.
- `pnpm --filter @frontagent/core typecheck` - passed after building workspace dependencies with `pnpm --filter @frontagent/core... build`.
- `pnpm quality:precommit` - passed.
- Pre-push `pnpm quality:local` - passed, including `pnpm quality:ci` and build/package.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.