### PR TITLE
Extract MemoryStore persistence writers

### DIFF
--- a/docs/superpowers/plans/2026-06-09-memorystore-persistence-writers.md
+++ b/docs/superpowers/plans/2026-06-09-memorystore-persistence-writers.md
@@ -1,0 +1,35 @@
+# MemoryStore Persistence Writers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `MemoryStore` persistence writer logic into a focused internal helper while preserving public `MemoryStore.persist()` behavior and all on-disk memory formats.
+
+**Architecture:** Keep `MemoryStore` as the public single-writer entry and filesystem owner. Move pure topic/index/gateway payload construction into `packages/core/src/memory/persistence-writers.ts`, so `store.ts` still performs reads/writes, error isolation, and gateway capture timing.
+
+**Tech Stack:** TypeScript, Vitest, existing `packages/core` memory types.
+
+---
+
+## Blast Radius
+
+- `MemoryStore.persist`: LOW. Direct upstream: `packages/core/src/memory/store.test.ts`; affected processes: none.
+- `persistGateway`: LOW. Direct upstream: `MemoryStore.persist`; second-order: `store.test.ts`; affected processes: none.
+- `persistProjectStructure`: LOW. Direct upstream: `MemoryStore.persist`; second-order: `store.test.ts`; affected processes: none.
+- `persistDependencies`: LOW. Direct upstream: `MemoryStore.persist`; second-order: `store.test.ts`; affected processes: none.
+- `persistErrors`: LOW. Direct upstream: `MemoryStore.persist`; second-order: `store.test.ts`; affected processes: none.
+- `rebuildIndex`: LOW. Direct upstream: `MemoryStore.persist`; second-order: `store.test.ts`; affected processes: none.
+
+## Files
+
+- Create: `packages/core/src/memory/persistence-writers.ts`
+- Modify: `packages/core/src/memory/store.ts`
+- Modify: `packages/core/src/memory/store.test.ts`
+
+## Tasks
+
+- [ ] Add focused tests in `store.test.ts` that assert persistence writes include project structure, dependencies, errors, facts snapshot, rebuilt index, and Gateway draft content after helper extraction.
+- [ ] Run `pnpm --dir packages/core exec vitest run src/memory/store.test.ts` and confirm the new helper import path fails before implementation.
+- [ ] Create `persistence-writers.ts` with pure functions for project structure topic, dependencies topic, errors topic, memory index, gateway capture text, and file path tags.
+- [ ] Update `MemoryStore.persist()` to delegate construction to the helper while retaining `writeFactsSnapshot`, `loadTopic`, `writeTopic`, `writeIndex`, local persistence error swallowing, and Gateway capture after the local try/catch.
+- [ ] Run focused memory tests, then `pnpm --dir packages/core typecheck`, then `pnpm quality:precommit`.
+- [ ] Run `npx gitnexus detect-changes --scope all --repo <current-worktree>` and include the result in the PR body with `Closes #241`.

--- a/packages/core/src/memory/persistence-writers.ts
+++ b/packages/core/src/memory/persistence-writers.ts
@@ -1,0 +1,194 @@
+import type { ProjectFactsSnapshot } from '../types.js';
+import type { MemoryEntry, MemoryIndex, MemoryTopic, PersistenceInput } from './types.js';
+import { MEMORY_INDEX_VERSION } from './types.js';
+
+export function buildProjectStructureTopic(
+  input: PersistenceInput,
+  existingEntries: MemoryEntry[],
+  now = new Date().toISOString(),
+): MemoryTopic {
+  const entries = cloneEntries(existingEntries);
+
+  for (const filePath of input.createdFiles) {
+    const existingEntry = entries.find((entry) => entry.key === filePath);
+    if (existingEntry) {
+      existingEntry.updatedAt = now;
+      continue;
+    }
+    entries.push({
+      key: filePath,
+      content: `File created during task: "${input.taskDescription}"`,
+      updatedAt: now,
+      tags: inferPersistenceTags(filePath),
+    });
+  }
+
+  const capped = entries.slice(-200);
+
+  return {
+    meta: {
+      id: 'project-structure',
+      title: 'Project Structure',
+      summary: `${capped.length} tracked files`,
+      updatedAt: now,
+      charCount: 0,
+    },
+    entries: capped,
+  };
+}
+
+export function buildDependenciesTopic(
+  input: PersistenceInput,
+  existingEntries: MemoryEntry[],
+  now = new Date().toISOString(),
+): MemoryTopic | null {
+  const entries = cloneEntries(existingEntries);
+
+  for (const pkg of input.dependencyChanges.installed) {
+    const existingEntry = entries.find((entry) => entry.key === pkg);
+    if (existingEntry) {
+      existingEntry.content = 'Installed';
+      existingEntry.updatedAt = now;
+      continue;
+    }
+    entries.push({
+      key: pkg,
+      content: 'Installed',
+      updatedAt: now,
+      tags: ['dependency', 'npm'],
+    });
+  }
+
+  for (const pkg of input.dependencyChanges.missing) {
+    const existingEntry = entries.find((entry) => entry.key === pkg);
+    if (!existingEntry) {
+      entries.push({
+        key: pkg,
+        content: 'Known missing dependency',
+        updatedAt: now,
+        tags: ['dependency', 'missing'],
+      });
+    }
+  }
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return {
+    meta: {
+      id: 'dependencies',
+      title: 'Dependencies',
+      summary: `${entries.length} tracked packages`,
+      updatedAt: now,
+      charCount: 0,
+    },
+    entries,
+  };
+}
+
+export function buildErrorsTopic(
+  input: PersistenceInput,
+  existingEntries: MemoryEntry[],
+  now = new Date().toISOString(),
+): MemoryTopic | null {
+  if (input.errorResolutions.length === 0) {
+    return null;
+  }
+
+  const entries = cloneEntries(existingEntries);
+
+  for (const resolution of input.errorResolutions) {
+    const key = `${resolution.errorType}: ${resolution.errorMessage}`.slice(0, 120);
+    const existingEntry = entries.find((entry) => entry.key === key);
+
+    if (existingEntry) {
+      existingEntry.content = resolution.resolution;
+      existingEntry.updatedAt = now;
+      continue;
+    }
+
+    entries.push({
+      key,
+      content: resolution.resolution,
+      updatedAt: now,
+      tags: ['error', resolution.errorType],
+    });
+  }
+
+  const capped = entries.slice(-50);
+
+  return {
+    meta: {
+      id: 'errors',
+      title: 'Error Resolutions',
+      summary: `${capped.length} recorded resolutions`,
+      updatedAt: now,
+      charCount: 0,
+    },
+    entries: capped,
+  };
+}
+
+export function buildMemoryIndex(
+  snapshot: ProjectFactsSnapshot,
+  topics: MemoryTopic['meta'][],
+  now = new Date().toISOString(),
+): MemoryIndex {
+  return {
+    version: MEMORY_INDEX_VERSION,
+    projectRoot: snapshot.project.buildStatus ? '(from snapshot)' : '',
+    updatedAt: now,
+    topics,
+  };
+}
+
+export function renderGatewayCapture(input: PersistenceInput): string {
+  const lines = [`Task: ${input.taskDescription}`];
+
+  if (input.createdFiles.length > 0) {
+    lines.push(`Created files: ${input.createdFiles.join(', ')}`);
+  }
+  if (input.dependencyChanges.installed.length > 0) {
+    lines.push(`Installed dependencies: ${input.dependencyChanges.installed.join(', ')}`);
+  }
+  if (input.dependencyChanges.missing.length > 0) {
+    lines.push(`Missing dependencies: ${input.dependencyChanges.missing.join(', ')}`);
+  }
+  if (input.errorResolutions.length > 0) {
+    lines.push('Error resolutions:');
+    for (const resolution of input.errorResolutions) {
+      lines.push(
+        `- ${resolution.errorType}: ${resolution.errorMessage} -> ${resolution.resolution}`,
+      );
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function inferPersistenceTags(filePath: string): string[] {
+  const tags: string[] = [];
+  const lower = filePath.toLowerCase();
+
+  if (lower.includes('/components/')) tags.push('component');
+  if (lower.includes('/pages/') || lower.includes('/views/')) tags.push('page');
+  if (lower.includes('/store/') || lower.includes('/stores/')) tags.push('store');
+  if (lower.includes('/api/') || lower.includes('/services/')) tags.push('api');
+  if (lower.includes('/utils/') || lower.includes('/helpers/')) tags.push('util');
+  if (lower.endsWith('.test.ts') || lower.endsWith('.test.tsx') || lower.endsWith('.spec.ts')) {
+    tags.push('test');
+  }
+  if (lower.endsWith('.css') || lower.endsWith('.scss') || lower.endsWith('.less')) {
+    tags.push('style');
+  }
+
+  return tags;
+}
+
+function cloneEntries(entries: MemoryEntry[]): MemoryEntry[] {
+  return entries.map((entry) => ({
+    ...entry,
+    tags: [...entry.tags],
+  }));
+}

--- a/packages/core/src/memory/store.test.ts
+++ b/packages/core/src/memory/store.test.ts
@@ -10,6 +10,12 @@ import {
 import { join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ProjectFactsSnapshot } from '../types.js';
+import {
+  buildDependenciesTopic,
+  buildErrorsTopic,
+  buildProjectStructureTopic,
+  inferPersistenceTags,
+} from './persistence-writers.js';
 import { MemoryStore } from './store.js';
 import type { PersistenceInput } from './types.js';
 import {
@@ -118,6 +124,38 @@ describe('MemoryStore', () => {
   // -------------------------------------------------------------------------
   // CRUD Operations
   // -------------------------------------------------------------------------
+
+  describe('persistence writer helpers', () => {
+    it('builds topic outputs without filesystem dependencies', () => {
+      const input: PersistenceInput = {
+        factsSnapshot: createFactsSnapshot(),
+        createdFiles: ['src/components/Button.tsx', 'src/utils/format.ts'],
+        errorResolutions: [
+          {
+            errorType: 'TypeError',
+            errorMessage: 'Cannot read property x',
+            resolution: 'Add null check',
+          },
+        ],
+        dependencyChanges: { installed: ['react'], missing: ['zod'] },
+        taskDescription: 'Persist memory writer outputs',
+      };
+
+      const projectTopic = buildProjectStructureTopic(input, []);
+      const dependenciesTopic = buildDependenciesTopic(input, []);
+      const errorsTopic = buildErrorsTopic(input, []);
+
+      expect(projectTopic.entries.map((entry) => entry.key)).toEqual([
+        'src/components/Button.tsx',
+        'src/utils/format.ts',
+      ]);
+      expect(projectTopic.entries[0].tags).toEqual(['component']);
+      expect(projectTopic.entries[1].tags).toEqual(['util']);
+      expect(dependenciesTopic?.entries.map((entry) => entry.key)).toEqual(['react', 'zod']);
+      expect(errorsTopic?.entries[0].key).toBe('TypeError: Cannot read property x');
+      expect(inferPersistenceTags('src/App.test.ts')).toEqual(['test']);
+    });
+  });
 
   describe('CRUD operations', () => {
     it('loadIndex returns null when index file does not exist', () => {

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -3,6 +3,13 @@ import { basename, join } from 'node:path';
 import { logger } from '@frontagent/shared';
 import type { ProjectFactsSnapshot } from '../types.js';
 import { OpenMemoryGatewayAdapter, type OpenMemoryGatewayRecord } from './open-memory-gateway.js';
+import {
+  buildDependenciesTopic,
+  buildErrorsTopic,
+  buildMemoryIndex,
+  buildProjectStructureTopic,
+  renderGatewayCapture,
+} from './persistence-writers.js';
 import { buildPreload, selectRecallResultsWithinBudget } from './preload-recall-helpers.js';
 import type {
   MemoryConfig,
@@ -527,83 +534,15 @@ export class MemoryStore {
   private persistProjectStructure(input: PersistenceInput): void {
     const topicId = 'project-structure';
     const existing = this.loadTopic(topicId);
-    const entries: MemoryEntry[] = existing?.entries.slice() ?? [];
-    const now = new Date().toISOString();
-
-    // Add newly created files
-    for (const filePath of input.createdFiles) {
-      const existingEntry = entries.find((e) => e.key === filePath);
-      if (existingEntry) {
-        existingEntry.updatedAt = now;
-        continue;
-      }
-      entries.push({
-        key: filePath,
-        content: `File created during task: "${input.taskDescription}"`,
-        updatedAt: now,
-        tags: this.inferTags(filePath),
-      });
-    }
-
-    // Cap entries to prevent unbounded growth
-    const capped = entries.slice(-200);
-
-    this.writeTopic({
-      meta: {
-        id: topicId,
-        title: 'Project Structure',
-        summary: `${capped.length} tracked files`,
-        updatedAt: now,
-        charCount: 0,
-      },
-      entries: capped,
-    });
+    this.writeTopic(buildProjectStructureTopic(input, existing?.entries ?? []));
   }
 
   private persistDependencies(input: PersistenceInput): void {
     const topicId = 'dependencies';
     const existing = this.loadTopic(topicId);
-    const entries: MemoryEntry[] = existing?.entries.slice() ?? [];
-    const now = new Date().toISOString();
-
-    for (const pkg of input.dependencyChanges.installed) {
-      const existingEntry = entries.find((e) => e.key === pkg);
-      if (existingEntry) {
-        existingEntry.content = 'Installed';
-        existingEntry.updatedAt = now;
-        continue;
-      }
-      entries.push({
-        key: pkg,
-        content: 'Installed',
-        updatedAt: now,
-        tags: ['dependency', 'npm'],
-      });
-    }
-
-    for (const pkg of input.dependencyChanges.missing) {
-      const existingEntry = entries.find((e) => e.key === pkg);
-      if (!existingEntry) {
-        entries.push({
-          key: pkg,
-          content: 'Known missing dependency',
-          updatedAt: now,
-          tags: ['dependency', 'missing'],
-        });
-      }
-    }
-
-    if (entries.length > 0) {
-      this.writeTopic({
-        meta: {
-          id: topicId,
-          title: 'Dependencies',
-          summary: `${entries.length} tracked packages`,
-          updatedAt: now,
-          charCount: 0,
-        },
-        entries,
-      });
+    const topic = buildDependenciesTopic(input, existing?.entries ?? []);
+    if (topic) {
+      this.writeTopic(topic);
     }
   }
 
@@ -612,40 +551,10 @@ export class MemoryStore {
 
     const topicId = 'errors';
     const existing = this.loadTopic(topicId);
-    const entries: MemoryEntry[] = existing?.entries.slice() ?? [];
-    const now = new Date().toISOString();
-
-    for (const resolution of input.errorResolutions) {
-      const key = `${resolution.errorType}: ${resolution.errorMessage}`.slice(0, 120);
-      const existingEntry = entries.find((e) => e.key === key);
-
-      if (existingEntry) {
-        existingEntry.content = resolution.resolution;
-        existingEntry.updatedAt = now;
-        continue;
-      }
-
-      entries.push({
-        key,
-        content: resolution.resolution,
-        updatedAt: now,
-        tags: ['error', resolution.errorType],
-      });
+    const topic = buildErrorsTopic(input, existing?.entries ?? []);
+    if (topic) {
+      this.writeTopic(topic);
     }
-
-    // Keep only the most recent 50 error resolutions
-    const capped = entries.slice(-50);
-
-    this.writeTopic({
-      meta: {
-        id: topicId,
-        title: 'Error Resolutions',
-        summary: `${capped.length} recorded resolutions`,
-        updatedAt: now,
-        charCount: 0,
-      },
-      entries: capped,
-    });
   }
 
   private rebuildIndex(snapshot: ProjectFactsSnapshot): void {
@@ -664,33 +573,7 @@ export class MemoryStore {
       }
     }
 
-    const index: MemoryIndex = {
-      version: MEMORY_INDEX_VERSION,
-      projectRoot: snapshot.project.buildStatus ? '(from snapshot)' : '',
-      updatedAt: now,
-      topics,
-    };
-
-    this.writeIndex(index);
-  }
-
-  private inferTags(filePath: string): string[] {
-    const tags: string[] = [];
-    const lower = filePath.toLowerCase();
-
-    if (lower.includes('/components/')) tags.push('component');
-    if (lower.includes('/pages/') || lower.includes('/views/')) tags.push('page');
-    if (lower.includes('/store/') || lower.includes('/stores/')) tags.push('store');
-    if (lower.includes('/api/') || lower.includes('/services/')) tags.push('api');
-    if (lower.includes('/utils/') || lower.includes('/helpers/')) tags.push('util');
-    if (lower.endsWith('.test.ts') || lower.endsWith('.test.tsx') || lower.endsWith('.spec.ts')) {
-      tags.push('test');
-    }
-    if (lower.endsWith('.css') || lower.endsWith('.scss') || lower.endsWith('.less')) {
-      tags.push('style');
-    }
-
-    return tags;
+    this.writeIndex(buildMemoryIndex(snapshot, topics, now));
   }
 
   // ---------------------------------------------------------------------------
@@ -725,28 +608,4 @@ export class MemoryStore {
       return false;
     }
   }
-}
-
-function renderGatewayCapture(input: PersistenceInput): string {
-  const lines = [`Task: ${input.taskDescription}`];
-
-  if (input.createdFiles.length > 0) {
-    lines.push(`Created files: ${input.createdFiles.join(', ')}`);
-  }
-  if (input.dependencyChanges.installed.length > 0) {
-    lines.push(`Installed dependencies: ${input.dependencyChanges.installed.join(', ')}`);
-  }
-  if (input.dependencyChanges.missing.length > 0) {
-    lines.push(`Missing dependencies: ${input.dependencyChanges.missing.join(', ')}`);
-  }
-  if (input.errorResolutions.length > 0) {
-    lines.push('Error resolutions:');
-    for (const resolution of input.errorResolutions) {
-      lines.push(
-        `- ${resolution.errorType}: ${resolution.errorMessage} -> ${resolution.resolution}`,
-      );
-    }
-  }
-
-  return lines.join('\n');
 }


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #241

## Summary

- Extracted MemoryStore persistence topic/index/Gateway payload construction into `packages/core/src/memory/persistence-writers.ts`.
- Kept `MemoryStore.persist()` as the public entry and retained filesystem writes, local persistence error isolation, Gateway capture timing, and existing memory file formats.
- Added focused helper coverage in `store.test.ts` for project structure, dependency, error, and tag writer outputs.

## Impact Scope

- Memory persistence writer construction only.
- No changes to on-disk memory file formats, Open Memory Gateway capture behavior, recall scoring, or preload scoring.

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: YES; memory-boundary files changed: `packages/core/src/memory/persistence-writers.ts`, `packages/core/src/memory/store.ts`, `packages/core/src/memory/store.test.ts`.
- GitNexus impact: `gitnexus detect_changes --scope staged` reported 4 files, 6 symbols, 0 affected processes, risk LOW; pre-edit `gitnexus impact` reported LOW for `MemoryStore.persist`, `persistGateway`, `persistProjectStructure`, `persistDependencies`, `persistErrors`, and `rebuildIndex`, with no affected processes.
- Verification: ran `pnpm agent:bootstrap`, `pnpm quality:predev`, focused memory tests, `pnpm --dir packages/core typecheck`, `pnpm quality:precommit`, and pre-push `pnpm quality:local`.

## Verification

- `pnpm agent:bootstrap`
- `pnpm quality:predev`
- RED: `pnpm --dir packages/core exec vitest run src/memory/store.test.ts` failed on missing `persistence-writers.js` after adding the helper test.
- GREEN: `pnpm --dir packages/core exec vitest run src/memory/store.test.ts` passed, 51 tests.
- `pnpm --dir packages/core typecheck`
- `pnpm quality:precommit`
- Pre-push hook ran `pnpm quality:local`, including `contract:local`, `quality:ci`, and build/package.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.