### PR TITLE
refactor(vscode): split webview style template

### DIFF
--- a/apps/vscode/src/webview-html.test.ts
+++ b/apps/vscode/src/webview-html.test.ts
@@ -2,12 +2,17 @@ import { describe, expect, it } from 'vitest';
 import {
   getWebviewHtml,
   nonce,
+  renderWebviewBaseStyles,
   renderWebviewBodySection,
+  renderWebviewComposerStyles,
   renderWebviewConfigScript,
   renderWebviewContextScript,
   renderWebviewErrorScript,
   renderWebviewEventScript,
+  renderWebviewHeaderStyles,
   renderWebviewMessageScript,
+  renderWebviewMessageStyles,
+  renderWebviewMotionStyles,
   renderWebviewScriptSection,
   renderWebviewStateScript,
   renderWebviewStyleSection,
@@ -44,6 +49,30 @@ describe('VS Code webview HTML nonce handling', () => {
 
     expect(styleNonce).toBeDefined();
     expect(styleSection).toBe(renderWebviewStyleSection(styleNonce ?? ''));
+  });
+
+  it('assembles the style section from focused CSS helpers', () => {
+    const styleNonce = 'style-test-nonce';
+    const section = renderWebviewStyleSection(styleNonce);
+    const helpers = [
+      renderWebviewBaseStyles(),
+      renderWebviewHeaderStyles(),
+      renderWebviewMessageStyles(),
+      renderWebviewComposerStyles(),
+      renderWebviewMotionStyles(),
+    ];
+
+    expect(section).toBe(`  <style nonce="${styleNonce}">
+${helpers.join('\n')}
+  </style>`);
+    expect(section).toContain(':root {');
+    expect(section).toContain('--accent: var(--vscode-button-background);');
+    expect(section).toContain('.config-banner.ready {');
+    expect(section).toContain('.messages {');
+    expect(section).toContain('.live-dot {');
+    expect(section).toContain('.composer-card:focus-within {');
+    expect(section).toContain('#prompt {');
+    expect(section).toContain('@media (prefers-reduced-motion: no-preference) {');
   });
 
   it('renders the script bootstrapping section through a focused renderer', () => {

--- a/apps/vscode/src/webview-html.ts
+++ b/apps/vscode/src/webview-html.ts
@@ -9,9 +9,8 @@ export function nonce(): string {
     .replace(/=+$/, '');
 }
 
-export function renderWebviewStyleSection(styleNonce: string): string {
-  return `  <style nonce="${styleNonce}">
-    :root {
+export function renderWebviewBaseStyles(): string {
+  return `    :root {
       color-scheme: light dark;
       --gap: 10px;
       --radius: 8px;
@@ -84,8 +83,11 @@ export function renderWebviewStyleSection(styleNonce: string): string {
       font-size: 11px;
       line-height: 1.6;
       white-space: nowrap;
-    }
-    .config-banner {
+    }`;
+}
+
+export function renderWebviewHeaderStyles(): string {
+  return `    .config-banner {
       display: grid;
       grid-template-columns: 1fr auto;
       gap: 8px;
@@ -164,8 +166,11 @@ export function renderWebviewStyleSection(styleNonce: string): string {
       min-width: 30px;
       padding-inline: 8px;
     }
-    button:disabled { opacity: 0.55; cursor: not-allowed; }
-    .messages {
+    button:disabled { opacity: 0.55; cursor: not-allowed; }`;
+}
+
+export function renderWebviewMessageStyles(): string {
+  return `    .messages {
       min-height: 0;
       overflow: auto;
       padding: 14px 12px 12px;
@@ -299,8 +304,11 @@ export function renderWebviewStyleSection(styleNonce: string): string {
       display: grid;
       grid-template-columns: 1fr 1fr;
       gap: 8px;
-    }
-    .composer {
+    }`;
+}
+
+export function renderWebviewComposerStyles(): string {
+  return `    .composer {
       display: grid;
       gap: 8px;
       padding: 8px 10px 10px;
@@ -472,8 +480,11 @@ export function renderWebviewStyleSection(styleNonce: string): string {
     }
     .muted { color: var(--muted); }
     .danger { color: var(--danger); }
-    .hidden { display: none; }
-    @media (prefers-reduced-motion: no-preference) {
+    .hidden { display: none; }`;
+}
+
+export function renderWebviewMotionStyles(): string {
+  return `    @media (prefers-reduced-motion: no-preference) {
       .live-dot {
         animation: pulse 1.4s ease-in-out infinite;
       }
@@ -488,7 +499,20 @@ export function renderWebviewStyleSection(styleNonce: string): string {
         0%, 45% { opacity: 1; }
         46%, 100% { opacity: 0; }
       }
-    }
+    }`;
+}
+
+export function renderWebviewStyleSection(styleNonce: string): string {
+  const styles = [
+    renderWebviewBaseStyles(),
+    renderWebviewHeaderStyles(),
+    renderWebviewMessageStyles(),
+    renderWebviewComposerStyles(),
+    renderWebviewMotionStyles(),
+  ];
+
+  return `  <style nonce="${styleNonce}">
+${styles.join('\n')}
   </style>`;
 }
 

--- a/docs/superpowers/plans/2026-06-09-vscode-webview-style-template.md
+++ b/docs/superpowers/plans/2026-06-09-vscode-webview-style-template.md
@@ -1,0 +1,43 @@
+# VS Code Webview Style Template Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split `renderWebviewStyleSection` into focused CSS template helpers while preserving the public composer and generated webview styles.
+
+**Architecture:** Keep `apps/vscode/src/webview-html.ts` as the webview renderer module. Add small CSS helpers grouped by responsibility, and keep `renderWebviewStyleSection(styleNonce)` as the exported nonce-wrapping composer that joins those helpers in the existing order.
+
+**Tech Stack:** TypeScript, VS Code webview HTML string rendering, Vitest, GitNexus.
+
+---
+
+## GitNexus Impact
+
+- `npx gitnexus impact -r <worktree> renderWebviewStyleSection --direction upstream`: LOW risk; 0 direct impacted symbols, 0 affected processes, 0 affected modules.
+- `npx gitnexus context -r <worktree> renderWebviewStyleSection`: symbol participates in `ResolveWebviewView -> RenderWebviewStyleSection`; incoming references are from `apps/vscode/src/webview-html.test.ts`.
+- User authorization covers proceeding even if later impact reports HIGH/CRITICAL; current style composer impact is LOW.
+
+## Files
+
+- Modify: `apps/vscode/src/webview-html.ts`
+- Modify: `apps/vscode/src/webview-html.test.ts`
+- Create: `docs/superpowers/plans/2026-06-09-vscode-webview-style-template.md`
+
+## Tasks
+
+- [x] Add focused tests in `apps/vscode/src/webview-html.test.ts` that import the new CSS helper exports and assert `renderWebviewStyleSection(styleNonce)` preserves the nonce wrapper and helper output order.
+- [x] Run `pnpm --dir apps/vscode test -- src/webview-html.test.ts` and confirm the new helper import test fails before implementation.
+- [x] Extract CSS fragments in `apps/vscode/src/webview-html.ts` into helper functions for design tokens/base layout, header/config controls, messages/live output, composer/details, and motion utilities.
+- [x] Keep `renderWebviewStyleSection(styleNonce)` exported as the public composer and ensure it joins the helper fragments without changing IDs, classes, CSP nonce handling, webview protocol, or style semantics.
+- [x] Run focused tests, typecheck, `pnpm quality:precommit`, and `npx gitnexus detect_changes -r <worktree>` before committing.
+- [ ] Open a PR to `develop` with `Closes #240` and a GitNexus Impact Summary, then watch repo-guard comments for up to 5 minutes.
+
+## CSS Equivalence Check
+
+- `node -e <static comparison>` reconstructed the new helper output and compared it to `origin/develop` for nonce `equivalence-nonce`: equal, 11915 bytes, 5 helpers.
+
+## Verification
+
+- `pnpm --dir apps/vscode test -- src/webview-html.test.ts`: passed, 7 tests.
+- `pnpm typecheck`: passed through Turbo.
+- `pnpm quality:precommit`: passed.
+- `npx gitnexus detect_changes -r <worktree>`: MEDIUM risk, 3 files, 2 symbols; affected flows are `ResolveWebviewView -> RenderWebviewStyleSection` and `ResolveWebviewView -> RenderWebviewStateScript`. `renderWebviewStateScript` is adjacent range attribution from line movement; its code body was not changed.


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #240

## Summary

- Split the VS Code webview style template into focused CSS helper renderers.
- Kept `renderWebviewStyleSection(styleNonce)` as the public composer and nonce wrapper.
- Added focused tests for helper assembly, nonce preservation, and key CSS selectors.

## Impact Scope

- `apps/vscode/src/webview-html.ts`
- `apps/vscode/src/webview-html.test.ts`
- `docs/superpowers/plans/2026-06-09-vscode-webview-style-template.md`

## GitNexus Impact Summary

- Risk level: MEDIUM from final `npx gitnexus detect_changes -r /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-vscode-webview-style-template`.
- Critical skeleton changes: No. GitNexus contract reported no critical contract surface changed.
- GitNexus impact: pre-edit `renderWebviewStyleSection` upstream impact was LOW, with 0 direct impacted symbols, 0 affected processes, and 0 affected modules. Context placed it in `ResolveWebviewView -> RenderWebviewStyleSection`, with tests as incoming references. Final detect_changes reported 3 files, 2 symbols, and affected flows `ResolveWebviewView -> RenderWebviewStyleSection` and `ResolveWebviewView -> RenderWebviewStateScript`; `renderWebviewStateScript` is adjacent range attribution from moving the style section boundary, not a body edit.
- Verification: static CSS equivalence comparison against `origin/develop` for nonce `equivalence-nonce` was byte-equal at 11915 bytes across 5 helpers.

## Verification

- `pnpm agent:bootstrap`
- `pnpm quality:predev`
- `pnpm --dir apps/vscode test -- src/webview-html.test.ts` (red: missing helper export; green: 7 tests passed)
- `pnpm typecheck`
- `pnpm quality:precommit`
- `npx gitnexus detect_changes -r /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-vscode-webview-style-template`
- `git push` pre-push hook ran `pnpm quality:local`, including `pnpm quality:ci` and VSIX packaging; passed.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.
