### PR TITLE
refactor(filesense): extract schema orchestration helpers

### DIFF
--- a/docs/superpowers/plans/2026-06-09-filesense-schema-orchestration.md
+++ b/docs/superpowers/plans/2026-06-09-filesense-schema-orchestration.md
@@ -1,0 +1,59 @@
+# Filesense Schema Orchestration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract mcp-filesense schema path/build/write helpers from `engine.ts` into a focused internal module without changing generated schema contents or Filesense indexing/query behavior.
+
+**Architecture:** Keep `engine.ts` as the operation orchestrator and move schema path resolution, relative schema refs, schema builders, and idempotent schema file writes into `packages/mcp-filesense/src/engine-schema.ts`. Engine callers continue to ask for schema paths and refs through the helper module, preserving the existing public API and MCP tool contracts.
+
+**Tech Stack:** TypeScript ESM, Node `fs`/`path`, Vitest.
+
+---
+
+## GitNexus Impact Summary
+
+- `ensureSchemaFiles`: LOW risk, 3 direct callers (`init`, `syncIndexes`, `summarize`), 2 affected processes (`handleFilesenseTool`, `summarize`).
+- `buildIndexSchema`: LOW risk, direct caller `ensureSchemaFiles`, same affected processes.
+- `buildNotesSchema`: LOW risk, direct caller `ensureSchemaFiles`, same affected processes.
+- `schemaPathsForRoot`: HIGH risk, 4 direct callers (`ensureSchemaFiles`, `writeDirectoryIndex`, `summarize`, `check`), indirectly affects `init`, `syncIndexes`, `syncAndSummarize`, `handleFilesenseTool`, and `engine.test.ts`. User authorized continuing; tests must lock paths and generated contents.
+
+## Files
+
+- Create: `packages/mcp-filesense/src/engine-schema.ts`
+- Modify: `packages/mcp-filesense/src/engine.ts`
+- Modify: `packages/mcp-filesense/src/engine.test.ts`
+
+### Task 1: Lock Generated Schema Behavior
+
+- [ ] Add a focused Vitest case in `engine.test.ts` that initializes a custom `schemaDir`, then asserts:
+  - `custom-schemas/FILES.schema.json` and `custom-schemas/FILES.notes.schema.json` exist.
+  - Root `FILES.json.$schema` points to `custom-schemas/FILES.schema.json`.
+  - Nested `FILES.json.$schema` points to `../custom-schemas/FILES.schema.json`.
+  - Root `FILES.notes.json.$schema` points to `custom-schemas/FILES.notes.schema.json`.
+  - Schema `$id`, `title`, required fields, and notes properties remain unchanged.
+- [ ] Run the focused test before implementation and confirm the new extraction-facing assertions fail or establish the current behavior baseline.
+
+### Task 2: Extract Schema Helpers
+
+- [ ] Move schema helper code from `engine.ts` to `engine-schema.ts`:
+  - `schemaPathsForRoot`
+  - `relativeSchemaRef`
+  - `ensureSchemaFiles`
+  - `buildIndexSchema`
+  - `buildNotesSchema`
+- [ ] Pass small dependencies into `ensureSchemaFiles` (`exists`, `readJson`, `writeJson`, `stableStringify`) so file IO behavior remains owned by `engine.ts`.
+- [ ] Export only helpers needed by `engine.ts`.
+
+### Task 3: Rewire Engine Orchestration
+
+- [ ] Import `ensureSchemaFiles`, `relativeSchemaRef`, and `schemaPathsForRoot` from `engine-schema.ts`.
+- [ ] Replace local helper calls without changing `init`, `syncIndexes`, `summarize`, `check`, `query`, indexing, or MCP tool output behavior.
+- [ ] Remove the old schema helper definitions from `engine.ts`.
+
+### Task 4: Verify
+
+- [ ] Run focused tests: `pnpm --filter @frontagent/mcp-filesense test -- engine.test.ts`.
+- [ ] Run package typecheck: `pnpm --filter @frontagent/mcp-filesense typecheck`.
+- [ ] Run repository gate: `pnpm quality:precommit`.
+- [ ] Run GitNexus final diff analysis: `npx gitnexus detect-changes --scope all --repo <worktree-path>`.
+- [ ] Include `Closes #244` and the GitNexus impact summary in the PR body.

--- a/packages/mcp-filesense/src/engine-schema.test.ts
+++ b/packages/mcp-filesense/src/engine-schema.test.ts
@@ -1,0 +1,156 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  buildIndexSchema,
+  buildNotesSchema,
+  ensureSchemaFiles,
+  relativeSchemaRef,
+  schemaPathsForRoot,
+} from './engine-schema.js';
+import type { FilesenseConfig } from './types.js';
+
+const TEST_DIR = path.join(import.meta.dirname, '..', '.test-schema-workspace');
+
+const config: FilesenseConfig = {
+  schemaVersion: '1.0',
+  root: '.',
+  recursive: true,
+  indexFile: 'FILES.json',
+  notesFile: 'FILES.notes.json',
+  ignoreFile: '.filesignore',
+  schemaDir: 'custom-schemas',
+  exclude: ['.git', 'node_modules'],
+  hashAlgorithm: 'sha1',
+};
+
+async function ensureClean() {
+  await fs.rm(TEST_DIR, { recursive: true, force: true });
+  await fs.mkdir(TEST_DIR, { recursive: true });
+}
+
+async function exists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJson(targetPath: string): Promise<unknown> {
+  return JSON.parse(await fs.readFile(targetPath, 'utf8')) as unknown;
+}
+
+async function writeJson(targetPath: string, value: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  await fs.writeFile(targetPath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+describe('schema orchestration helpers', () => {
+  beforeEach(ensureClean);
+  afterEach(async () => {
+    await fs.rm(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('resolves generated schema paths and relative refs from nested directories', () => {
+    const paths = schemaPathsForRoot(TEST_DIR, config);
+    expect(paths.indexSchemaPath).toBe(path.join(TEST_DIR, 'custom-schemas', 'FILES.schema.json'));
+    expect(paths.notesSchemaPath).toBe(
+      path.join(TEST_DIR, 'custom-schemas', 'FILES.notes.schema.json'),
+    );
+
+    expect(relativeSchemaRef(TEST_DIR, paths.indexSchemaPath)).toBe(
+      'custom-schemas/FILES.schema.json',
+    );
+    expect(relativeSchemaRef(path.join(TEST_DIR, 'src'), paths.indexSchemaPath)).toBe(
+      '../custom-schemas/FILES.schema.json',
+    );
+    expect(relativeSchemaRef(TEST_DIR, paths.notesSchemaPath)).toBe(
+      'custom-schemas/FILES.notes.schema.json',
+    );
+  });
+
+  it('builds the expected FILES schema contract', () => {
+    const schema = buildIndexSchema(config);
+
+    expect(schema.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
+    expect(schema.$id).toBe('https://filesense.dev/schema/1.0/FILES.schema.json');
+    expect(schema.title).toBe('FILES.json');
+    expect(schema.required).toEqual([
+      'schema_version',
+      'generated_at',
+      'root_relative_path',
+      'directory',
+      'children',
+      'sync',
+    ]);
+    expect(schema.properties).toMatchObject({
+      schema_version: { type: 'string' },
+      children: {
+        type: 'array',
+        items: {
+          required: [
+            'name',
+            'type',
+            'path',
+            'ext',
+            'size',
+            'mtimeMs',
+            'hash',
+            'summary',
+            'importance',
+            'status',
+          ],
+        },
+      },
+      sync: {
+        required: [
+          'child_count',
+          'file_count',
+          'dir_count',
+          'last_full_sync',
+          'last_incremental_sync',
+        ],
+      },
+    });
+  });
+
+  it('builds the expected FILES notes schema contract', () => {
+    const schema = buildNotesSchema(config);
+
+    expect(schema.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
+    expect(schema.$id).toBe('https://filesense.dev/schema/1.0/FILES.notes.schema.json');
+    expect(schema.title).toBe('FILES.notes.json');
+    expect(schema.additionalProperties).toBe(false);
+    expect(schema.properties).toMatchObject({
+      $schema: { type: 'string' },
+      directory_purpose: { type: 'string' },
+      agent_hints: { type: 'array', items: { type: 'string' } },
+      conventions: { type: 'array', items: { type: 'string' } },
+      key_entrypoints: { type: 'array', items: { type: 'string' } },
+    });
+  });
+
+  it('writes generated schema files without rewriting unchanged contents', async () => {
+    const paths = schemaPathsForRoot(TEST_DIR, config);
+    const deps = { exists, readJson, writeJson, stableStringify };
+
+    await ensureSchemaFiles(TEST_DIR, config, deps);
+    const firstIndexSchema = await fs.readFile(paths.indexSchemaPath, 'utf8');
+    const firstNotesSchema = await fs.readFile(paths.notesSchemaPath, 'utf8');
+    const firstIndexMtime = (await fs.stat(paths.indexSchemaPath)).mtimeMs;
+    const firstNotesMtime = (await fs.stat(paths.notesSchemaPath)).mtimeMs;
+
+    await ensureSchemaFiles(TEST_DIR, config, deps);
+
+    expect(await fs.readFile(paths.indexSchemaPath, 'utf8')).toBe(firstIndexSchema);
+    expect(await fs.readFile(paths.notesSchemaPath, 'utf8')).toBe(firstNotesSchema);
+    expect((await fs.stat(paths.indexSchemaPath)).mtimeMs).toBe(firstIndexMtime);
+    expect((await fs.stat(paths.notesSchemaPath)).mtimeMs).toBe(firstNotesMtime);
+  });
+});

--- a/packages/mcp-filesense/src/engine-schema.ts
+++ b/packages/mcp-filesense/src/engine-schema.ts
@@ -1,0 +1,149 @@
+import path from 'node:path';
+import type { FilesenseConfig } from './types.js';
+
+type SchemaFileDeps = {
+  exists: (targetPath: string) => Promise<boolean>;
+  readJson: (targetPath: string) => Promise<unknown>;
+  stableStringify: (value: unknown) => string;
+  writeJson: (targetPath: string, value: unknown) => Promise<void>;
+};
+
+export function schemaPathsForRoot(root: string, config: FilesenseConfig) {
+  return {
+    indexSchemaPath: path.join(root, config.schemaDir, 'FILES.schema.json'),
+    notesSchemaPath: path.join(root, config.schemaDir, 'FILES.notes.schema.json'),
+  };
+}
+
+export function relativeSchemaRef(dirPath: string, schemaPath: string): string {
+  return path.relative(dirPath, schemaPath).replace(/\\/g, '/');
+}
+
+export async function ensureSchemaFiles(
+  root: string,
+  config: FilesenseConfig,
+  deps: SchemaFileDeps,
+): Promise<void> {
+  const paths = schemaPathsForRoot(root, config);
+  const indexSchema = buildIndexSchema(config);
+  const notesSchema = buildNotesSchema(config);
+
+  const readSafe = async (p: string) => {
+    try {
+      return await deps.readJson(p);
+    } catch {
+      return null;
+    }
+  };
+
+  if (
+    !(await deps.exists(paths.indexSchemaPath)) ||
+    deps.stableStringify(await readSafe(paths.indexSchemaPath)) !==
+      deps.stableStringify(indexSchema)
+  ) {
+    await deps.writeJson(paths.indexSchemaPath, indexSchema);
+  }
+  if (
+    !(await deps.exists(paths.notesSchemaPath)) ||
+    deps.stableStringify(await readSafe(paths.notesSchemaPath)) !==
+      deps.stableStringify(notesSchema)
+  ) {
+    await deps.writeJson(paths.notesSchemaPath, notesSchema);
+  }
+}
+
+export function buildIndexSchema(config: FilesenseConfig): Record<string, unknown> {
+  return {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    $id: `https://filesense.dev/schema/${config.schemaVersion}/FILES.schema.json`,
+    title: 'FILES.json',
+    type: 'object',
+    required: [
+      'schema_version',
+      'generated_at',
+      'root_relative_path',
+      'directory',
+      'children',
+      'sync',
+    ],
+    additionalProperties: false,
+    properties: {
+      $schema: { type: 'string' },
+      schema_version: { type: 'string' },
+      generated_at: { type: 'string' },
+      root_relative_path: { type: 'string' },
+      directory: {
+        type: 'object',
+        required: ['name', 'path'],
+        additionalProperties: false,
+        properties: { name: { type: 'string' }, path: { type: 'string' } },
+      },
+      children: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: [
+            'name',
+            'type',
+            'path',
+            'ext',
+            'size',
+            'mtimeMs',
+            'hash',
+            'summary',
+            'importance',
+            'status',
+          ],
+          additionalProperties: false,
+          properties: {
+            name: { type: 'string' },
+            type: { enum: ['file', 'dir'] },
+            path: { type: 'string' },
+            ext: { type: 'string' },
+            size: { type: 'number' },
+            mtimeMs: { type: 'number' },
+            hash: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+            summary: { type: 'string' },
+            importance: { enum: ['high', 'normal'] },
+            status: { enum: ['active'] },
+          },
+        },
+      },
+      sync: {
+        type: 'object',
+        required: [
+          'child_count',
+          'file_count',
+          'dir_count',
+          'last_full_sync',
+          'last_incremental_sync',
+        ],
+        additionalProperties: false,
+        properties: {
+          child_count: { type: 'number' },
+          file_count: { type: 'number' },
+          dir_count: { type: 'number' },
+          last_full_sync: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+          last_incremental_sync: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+        },
+      },
+    },
+  };
+}
+
+export function buildNotesSchema(config: FilesenseConfig): Record<string, unknown> {
+  return {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    $id: `https://filesense.dev/schema/${config.schemaVersion}/FILES.notes.schema.json`,
+    title: 'FILES.notes.json',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      $schema: { type: 'string' },
+      directory_purpose: { type: 'string' },
+      agent_hints: { type: 'array', items: { type: 'string' } },
+      conventions: { type: 'array', items: { type: 'string' } },
+      key_entrypoints: { type: 'array', items: { type: 'string' } },
+    },
+  };
+}

--- a/packages/mcp-filesense/src/engine.ts
+++ b/packages/mcp-filesense/src/engine.ts
@@ -10,6 +10,7 @@ import { inferDirectoryPurpose, inferImportance, scoreCandidate } from './engine
 import { type ComparableIndex, persistDirectoryIndex } from './engine-indexing.js';
 import { buildNotesFile, inferConventions } from './engine-notes.js';
 import { buildQueryResult } from './engine-query.js';
+import { ensureSchemaFiles, relativeSchemaRef, schemaPathsForRoot } from './engine-schema.js';
 import type {
   CheckSummary,
   ChildEntry,
@@ -77,6 +78,8 @@ function sameSet(left: Set<string>, right: Set<string>): boolean {
   return true;
 }
 
+const schemaFileDeps = { exists, readJson, stableStringify, writeJson };
+
 // ─── Config & Ignore ───────────────────────────────────────────────────────────
 
 export async function loadConfig(root: string): Promise<FilesenseConfig> {
@@ -140,142 +143,6 @@ async function resolveRootAndConfig(targetPath: string) {
   const config = await loadConfig(root);
   const ignores = await loadIgnoreMatcher(root, config);
   return { root, config, ignores };
-}
-
-// ─── Schema ────────────────────────────────────────────────────────────────────
-
-function schemaPathsForRoot(root: string, config: FilesenseConfig) {
-  return {
-    indexSchemaPath: path.join(root, config.schemaDir, 'FILES.schema.json'),
-    notesSchemaPath: path.join(root, config.schemaDir, 'FILES.notes.schema.json'),
-  };
-}
-
-function relativeSchemaRef(dirPath: string, schemaPath: string): string {
-  return path.relative(dirPath, schemaPath).replace(/\\/g, '/');
-}
-
-async function ensureSchemaFiles(root: string, config: FilesenseConfig): Promise<void> {
-  const paths = schemaPathsForRoot(root, config);
-  const indexSchema = buildIndexSchema(config);
-  const notesSchema = buildNotesSchema(config);
-
-  const readSafe = async (p: string) => {
-    try {
-      return await readJson(p);
-    } catch {
-      return null;
-    }
-  };
-
-  if (
-    !(await exists(paths.indexSchemaPath)) ||
-    stableStringify(await readSafe(paths.indexSchemaPath)) !== stableStringify(indexSchema)
-  ) {
-    await writeJson(paths.indexSchemaPath, indexSchema);
-  }
-  if (
-    !(await exists(paths.notesSchemaPath)) ||
-    stableStringify(await readSafe(paths.notesSchemaPath)) !== stableStringify(notesSchema)
-  ) {
-    await writeJson(paths.notesSchemaPath, notesSchema);
-  }
-}
-
-function buildIndexSchema(config: FilesenseConfig): Record<string, unknown> {
-  return {
-    $schema: 'https://json-schema.org/draft/2020-12/schema',
-    $id: `https://filesense.dev/schema/${config.schemaVersion}/FILES.schema.json`,
-    title: 'FILES.json',
-    type: 'object',
-    required: [
-      'schema_version',
-      'generated_at',
-      'root_relative_path',
-      'directory',
-      'children',
-      'sync',
-    ],
-    additionalProperties: false,
-    properties: {
-      $schema: { type: 'string' },
-      schema_version: { type: 'string' },
-      generated_at: { type: 'string' },
-      root_relative_path: { type: 'string' },
-      directory: {
-        type: 'object',
-        required: ['name', 'path'],
-        additionalProperties: false,
-        properties: { name: { type: 'string' }, path: { type: 'string' } },
-      },
-      children: {
-        type: 'array',
-        items: {
-          type: 'object',
-          required: [
-            'name',
-            'type',
-            'path',
-            'ext',
-            'size',
-            'mtimeMs',
-            'hash',
-            'summary',
-            'importance',
-            'status',
-          ],
-          additionalProperties: false,
-          properties: {
-            name: { type: 'string' },
-            type: { enum: ['file', 'dir'] },
-            path: { type: 'string' },
-            ext: { type: 'string' },
-            size: { type: 'number' },
-            mtimeMs: { type: 'number' },
-            hash: { anyOf: [{ type: 'string' }, { type: 'null' }] },
-            summary: { type: 'string' },
-            importance: { enum: ['high', 'normal'] },
-            status: { enum: ['active'] },
-          },
-        },
-      },
-      sync: {
-        type: 'object',
-        required: [
-          'child_count',
-          'file_count',
-          'dir_count',
-          'last_full_sync',
-          'last_incremental_sync',
-        ],
-        additionalProperties: false,
-        properties: {
-          child_count: { type: 'number' },
-          file_count: { type: 'number' },
-          dir_count: { type: 'number' },
-          last_full_sync: { anyOf: [{ type: 'string' }, { type: 'null' }] },
-          last_incremental_sync: { anyOf: [{ type: 'string' }, { type: 'null' }] },
-        },
-      },
-    },
-  };
-}
-
-function buildNotesSchema(config: FilesenseConfig): Record<string, unknown> {
-  return {
-    $schema: 'https://json-schema.org/draft/2020-12/schema',
-    $id: `https://filesense.dev/schema/${config.schemaVersion}/FILES.notes.schema.json`,
-    title: 'FILES.notes.json',
-    type: 'object',
-    additionalProperties: false,
-    properties: {
-      $schema: { type: 'string' },
-      directory_purpose: { type: 'string' },
-      agent_hints: { type: 'array', items: { type: 'string' } },
-      conventions: { type: 'array', items: { type: 'string' } },
-      key_entrypoints: { type: 'array', items: { type: 'string' } },
-    },
-  };
 }
 
 // ─── Directory Walking ─────────────────────────────────────────────────────────
@@ -485,7 +352,7 @@ export async function init(targetPath: string): Promise<SyncSummary> {
     );
   }
   const config = await loadConfig(root);
-  await ensureSchemaFiles(root, config);
+  await ensureSchemaFiles(root, config, schemaFileDeps);
   return syncIndexes(root, false);
 }
 
@@ -498,7 +365,7 @@ export async function syncIndexes(
   options: { depth?: number; maxEntries?: number; timeoutMs?: number } = {},
 ): Promise<SyncSummary> {
   const { root, config, ignores } = await resolveRootAndConfig(targetPath);
-  await ensureSchemaFiles(root, config);
+  await ensureSchemaFiles(root, config, schemaFileDeps);
   const summary: SyncSummary = {
     root,
     directoriesScanned: 0,
@@ -538,7 +405,7 @@ export async function syncIndexes(
  */
 export async function summarize(targetPath: string, force = false): Promise<SummarizeSummary> {
   const { root, config, ignores } = await resolveRootAndConfig(targetPath);
-  await ensureSchemaFiles(root, config);
+  await ensureSchemaFiles(root, config, schemaFileDeps);
   const summary: SummarizeSummary = {
     root,
     directoriesScanned: 0,


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #244

## Summary

- Extracted FILES schema path resolution, relative schema refs, schema builders, and idempotent schema writing into `packages/mcp-filesense/src/engine-schema.ts`.
- Kept `engine.ts` focused on filesense orchestration while preserving generated schema contents, schema refs, indexing behavior, summarize/check/query behavior, and MCP tool output contracts.
- Added focused schema tests for custom schema paths, relative refs, generated FILES/FILES.notes schema contracts, and unchanged schema rewrite behavior.

## Impact Scope

- `packages/mcp-filesense/src/engine.ts`
- `packages/mcp-filesense/src/engine-schema.ts`
- `packages/mcp-filesense/src/engine-schema.test.ts`
- `docs/superpowers/plans/2026-06-09-filesense-schema-orchestration.md`

## GitNexus Impact Summary

- Risk level: HIGH
- Critical skeleton changes: mcp-boundary files `packages/mcp-filesense/src/engine.ts`, `packages/mcp-filesense/src/engine-schema.ts`, and `packages/mcp-filesense/src/engine-schema.test.ts`.
- GitNexus impact: `detect_changes` after refreshing the index reported 4 files, 23 changed symbols, 14 affected processes, risk HIGH; pre-edit `impact` covered `ensureSchemaFiles`, `buildIndexSchema`, `buildNotesSchema`, `schemaPathsForRoot`, `writeDirectoryIndex`, `init`, `syncIndexes`, `summarize`, and `check`, with affected flows concentrated in `handleFilesenseTool` schema/read/write paths and `summarize` schema/read paths.
- Verification: schema-focused tests, mcp-filesense engine tests, mcp-filesense typecheck, `pnpm quality:precommit`, and pre-push `pnpm quality:local` passed.

## Verification

- `pnpm agent:bootstrap`
- `pnpm quality:predev`
- `pnpm --filter @frontagent/mcp-filesense test -- src/engine-schema.test.ts` (RED failed before implementation due missing `engine-schema.js`; GREEN passed after extraction: 4 tests)
- `pnpm --filter @frontagent/mcp-filesense test -- src/engine.test.ts` (24 tests passed)
- `pnpm --filter @frontagent/mcp-filesense typecheck`
- `pnpm quality:precommit`
- `npx gitnexus detect-changes --scope staged --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-filesense-schema-orchestration`
- `git push -u origin improve/filesense-schema-orchestration` (pre-push ran `pnpm quality:local`, including contract, CI quality, build, and VSIX package; passed)

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.