### PR TITLE
refactor: decompose executor tool call security handling

### DIFF
--- a/docs/superpowers/plans/2026-06-09-executor-tool-call-security.md
+++ b/docs/superpowers/plans/2026-06-09-executor-tool-call-security.md
@@ -1,0 +1,51 @@
+# Executor Tool-Call Security Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Decompose `Executor.callTool` security, MCP invocation, and result classification into a focused internal helper while preserving public `Executor` APIs and security semantics.
+
+**Architecture:** Keep `Executor.callTool(toolName, args)` as the public coordinator. Add an internal executor helper beside `executor.ts` that owns client lookup, security evaluation/emission, approval handling, MCP invocation, duration annotation, and tool-result success classification. `Executor` remains responsible for tool/client registration and browser URL state updates.
+
+**Tech Stack:** TypeScript, Vitest, GitNexus, existing `SecurityManager`, existing `MCPClient` and `ExecutorConfig` types.
+
+---
+
+## GitNexus Impact
+
+- `callTool`: LOW risk; 3 direct callers (`executeStep`, `validateBeforeExecution`, `rollback`), 2 affected process groups.
+- `enforceSecurity`: HIGH risk; direct caller `callTool`, affected `callTool`, `executeStep`, and `rollback` flows.
+- `emitSecurityDecision`: HIGH risk; direct caller `enforceSecurity`, affected security emission and rollback flows.
+- `isSuccessfulToolResult`: HIGH risk; direct caller `callTool`, affected `callTool`, `executeStep`, and `rollback` flows.
+- User has explicitly authorized continuing when HIGH/CRITICAL impact appears; tests must lock down security decision semantics before refactoring.
+
+## Files
+
+- Create: `packages/core/src/executor/tool-call-handler.ts`
+- Modify: `packages/core/src/executor/executor.ts`
+- Modify: `packages/core/src/executor/executor.test.ts`
+- Create: this plan file
+
+## Tasks
+
+### Task 1: Focused Tool-Call Tests
+
+- [ ] Add executor tests for approved security requests preserving emitted decisions and approved args.
+- [ ] Add executor tests for non-interactive ask decisions returning the existing security-denied result shape.
+- [ ] Add executor tests for browser navigation URL updates only when tool result is successful.
+- [ ] Run focused executor tests and verify the new helper-oriented coverage fails before implementation where behavior is not directly observable.
+
+### Task 2: Extract Helper
+
+- [ ] Create `tool-call-handler.ts` with an internal `ExecutorToolCallHandler` class.
+- [ ] Move security evaluation, audit emission, approval fallback, MCP client invocation, duration annotation, and success classification into the helper without changing result schemas.
+- [ ] Keep `Executor.callTool` public and delegate to the helper using existing maps and config.
+- [ ] Keep `Executor` responsible for assigning `currentBrowserUrl` from successful `browser_navigate`/`navigate` calls.
+
+### Task 3: Verification And PR
+
+- [ ] Run focused executor tests.
+- [ ] Run `pnpm typecheck`.
+- [ ] Run `pnpm quality:precommit`.
+- [ ] Run `npx gitnexus detect-changes --scope all --repo <current-worktree>`.
+- [ ] Open a PR to `develop` with `Closes #242` and a concrete GitNexus Impact Summary.
+- [ ] Monitor repo-guard/CI feedback for up to 5 minutes and apply specific actionable fixes.

--- a/packages/core/src/executor/executor.test.ts
+++ b/packages/core/src/executor/executor.test.ts
@@ -2,6 +2,7 @@ import type { AgentTask, ExecutionStep } from '@frontagent/shared';
 import { describe, expect, it, vi } from 'vitest';
 import type { ExecutorActionSkill } from '../skills/index.js';
 import { createExecutor, Executor } from './executor.js';
+import { ExecutorToolCallHandler } from './tool-call-handler.js';
 import type { ExecutorCollectedContext, ExecutorConfig } from './types.js';
 
 function makeStep(overrides: Partial<ExecutionStep> = {}): ExecutionStep {
@@ -119,6 +120,150 @@ describe('Executor', () => {
       executor.registerActionSkill(skill);
       const snapshot = executor.getActionSkillSnapshot();
       expect(snapshot.actionSkills.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('callTool', () => {
+    it('passes approved security args to the MCP client and emits ask then allow decisions', async () => {
+      const approvalHandler = vi.fn().mockResolvedValue(true);
+      const decisions: Array<{ decision: string; reasonCode: string; approvalId?: string }> = [];
+      const callTool = vi.fn().mockResolvedValue({ success: true });
+      const executor = new Executor(
+        makeConfig({
+          security: { mode: 'strict', interactive: true, auditEnabled: true },
+          approvalHandler,
+          onSecurityDecision: (decision) => decisions.push(decision),
+        }),
+      );
+      executor.registerMCPClient('files', {
+        callTool,
+        listTools: vi.fn().mockResolvedValue([]),
+      });
+      executor.registerToolMapping('create_file', 'files');
+
+      const result = await executor.callTool('create_file', {
+        path: 'src/new.ts',
+        content: 'export {}',
+      });
+
+      expect(result).toEqual(expect.objectContaining({ success: true }));
+      expect(approvalHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          decision: 'ask',
+          reasonCode: 'strict_file_write_requires_approval',
+          toolName: 'create_file',
+        }),
+      );
+      expect(callTool).toHaveBeenCalledWith(
+        'create_file',
+        expect.objectContaining({
+          path: 'src/new.ts',
+          content: 'export {}',
+          __frontagentSecurityApproved: true,
+        }),
+      );
+      expect(decisions.map((decision) => decision.decision)).toEqual(['ask', 'allow']);
+      expect(decisions[1]).toEqual(
+        expect.objectContaining({
+          reasonCode: 'approved_by_user',
+          approvalId: expect.any(String),
+        }),
+      );
+    });
+
+    it('fails closed without invoking the MCP client when approval is unavailable', async () => {
+      const decisions: Array<{ decision: string; reasonCode: string }> = [];
+      const callTool = vi.fn().mockResolvedValue({ success: true });
+      const executor = new Executor(
+        makeConfig({
+          security: { mode: 'strict', interactive: false, auditEnabled: true },
+          onSecurityDecision: (decision) => decisions.push(decision),
+        }),
+      );
+      executor.registerMCPClient('files', {
+        callTool,
+        listTools: vi.fn().mockResolvedValue([]),
+      });
+      executor.registerToolMapping('create_file', 'files');
+
+      const result = await executor.callTool('create_file', {
+        path: 'src/new.ts',
+        content: 'export {}',
+      });
+
+      expect(result).toEqual({
+        success: false,
+        error: 'Approval is required but no interactive approval channel is available.',
+      });
+      expect(callTool).not.toHaveBeenCalled();
+      expect(decisions).toEqual([
+        expect.objectContaining({
+          decision: 'ask',
+          reasonCode: 'strict_file_write_requires_approval',
+        }),
+        expect.objectContaining({
+          decision: 'deny',
+          reasonCode: 'security_approval_unavailable',
+        }),
+      ]);
+    });
+
+    it('updates browser context only after successful navigation results', async () => {
+      const callTool = vi
+        .fn()
+        .mockResolvedValueOnce({ success: false, error: 'navigation failed' })
+        .mockResolvedValueOnce({ success: true })
+        .mockResolvedValueOnce({ success: true })
+        .mockResolvedValueOnce({ success: true });
+      const executor = new Executor(
+        makeConfig({
+          security: { mode: 'balanced', interactive: false, auditEnabled: true },
+        }),
+      );
+      executor.registerMCPClient('browser', {
+        callTool,
+        listTools: vi.fn().mockResolvedValue([]),
+      });
+      executor.registerToolMapping('browser_navigate', 'browser');
+      executor.registerToolMapping('browser_click', 'browser');
+
+      const failedNavigate = await executor.callTool('browser_navigate', {
+        url: 'http://localhost:5173',
+      });
+      const clickAfterFailure = await executor.callTool('browser_click', { selector: '#submit' });
+      const successfulNavigate = await executor.callTool('browser_navigate', {
+        url: 'http://localhost:5173',
+      });
+      const clickAfterSuccess = await executor.callTool('browser_click', { selector: '#submit' });
+
+      expect(failedNavigate).toEqual(expect.objectContaining({ success: false }));
+      expect(clickAfterFailure).toEqual(
+        expect.objectContaining({
+          success: false,
+          error: 'Approval is required but no interactive approval channel is available.',
+        }),
+      );
+      expect(successfulNavigate).toEqual(expect.objectContaining({ success: true }));
+      expect(clickAfterSuccess).toEqual(expect.objectContaining({ success: true }));
+      expect(callTool).toHaveBeenCalledTimes(3);
+      expect(callTool).toHaveBeenNthCalledWith(3, 'browser_click', { selector: '#submit' });
+    });
+  });
+
+  describe('ExecutorToolCallHandler', () => {
+    it('classifies object results with success false as unsuccessful', () => {
+      const handler = new ExecutorToolCallHandler({
+        config: makeConfig(),
+        mcpClients: new Map(),
+        toolToClient: new Map(),
+        nowMs: () => 0,
+        getCurrentBrowserUrl: () => undefined,
+      });
+
+      expect(handler.isSuccessfulToolResult({ success: false })).toBe(false);
+      expect(handler.isSuccessfulToolResult({ success: true })).toBe(true);
+      expect(handler.isSuccessfulToolResult({})).toBe(true);
+      expect(handler.isSuccessfulToolResult('ok')).toBe(true);
     });
   });
 

--- a/packages/core/src/executor/executor.ts
+++ b/packages/core/src/executor/executor.ts
@@ -1,14 +1,7 @@
 import { existsSync, statSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
-import type {
-  AgentTask,
-  ExecutionStep,
-  SecurityDecision,
-  StepResult,
-  ValidationResult,
-} from '@frontagent/shared';
+import type { AgentTask, ExecutionStep, StepResult, ValidationResult } from '@frontagent/shared';
 import { logger } from '@frontagent/shared';
-import { SecurityManager, toApprovalRequest } from '../security.js';
 import {
   createDefaultExecutorSkillRegistry,
   type ExecutorActionSkill,
@@ -20,6 +13,7 @@ import { PhaseRunner } from './phase-runner.js';
 import { executeStepsWithProgressEnforcement } from './progress-enforcement.js';
 import { executeStepsWithErrorFeedbackViaLangGraph } from './step-feedback-runner.js';
 import { createStepTraceRecorder } from './step-trace-recorder.js';
+import { ExecutorToolCallHandler } from './tool-call-handler.js';
 import type {
   ExecutorCollectedContext,
   ExecutorConfig,
@@ -32,13 +26,19 @@ export class Executor {
   private mcpClients: Map<string, MCPClient> = new Map();
   private toolToClient: Map<string, string> = new Map();
   private actionSkills: ReturnType<typeof createDefaultExecutorSkillRegistry>;
-  private securityManager: SecurityManager;
   private currentBrowserUrl?: string;
   private phaseRunner: PhaseRunner;
+  private toolCallHandler: ExecutorToolCallHandler;
 
   constructor(config: ExecutorConfig) {
     this.config = config;
-    this.securityManager = new SecurityManager();
+    this.toolCallHandler = new ExecutorToolCallHandler({
+      config: this.config,
+      mcpClients: this.mcpClients,
+      toolToClient: this.toolToClient,
+      nowMs: () => this.nowMs(),
+      getCurrentBrowserUrl: () => this.currentBrowserUrl,
+    });
     this.actionSkills = createDefaultExecutorSkillRegistry({
       llmService: this.config.llmService,
       debug: this.config.debug,
@@ -564,131 +564,15 @@ export class Executor {
   }
 
   async callTool(toolName: string, args: Record<string, unknown>): Promise<unknown> {
-    const clientName = this.toolToClient.get(toolName);
-    if (!clientName) {
-      throw new Error(`No MCP client registered for tool: ${toolName}`);
-    }
-
-    const client = this.mcpClients.get(clientName);
-    if (!client) {
-      throw new Error(`MCP client not found: ${clientName}`);
-    }
-
-    if (this.config.debug) {
-      console.log(`[Executor] Calling tool: ${toolName}`, args);
-    }
-
-    const security = await this.enforceSecurity(toolName, args);
-    if (!security.allowed) {
-      return {
-        success: false,
-        error: security.error,
-      };
-    }
-
-    const mcpStart = this.nowMs();
-    const result = await client.callTool(toolName, security.args);
-    const mcpDurationMs = this.nowMs() - mcpStart;
-    if (typeof result === 'object' && result !== null) {
-      (result as Record<string, unknown>).__toolDurationMs = mcpDurationMs;
-    }
+    const toolCall = await this.toolCallHandler.callTool(toolName, args);
 
     if (toolName === 'browser_navigate' || toolName === 'navigate') {
-      if (typeof args.url === 'string' && this.isSuccessfulToolResult(result)) {
+      if (typeof args.url === 'string' && toolCall.successful) {
         this.currentBrowserUrl = args.url;
       }
     }
 
-    if (this.config.debug) {
-      console.log('[Executor] Tool result:', result);
-    }
-
-    return result;
-  }
-
-  private async enforceSecurity(
-    toolName: string,
-    args: Record<string, unknown>,
-  ): Promise<{ allowed: true; args: Record<string, unknown> } | { allowed: false; error: string }> {
-    const decision = this.securityManager.evaluate({
-      toolName,
-      args,
-      projectRoot: this.config.projectRoot,
-      sddConfig: this.config.sddConfig,
-      security: this.config.security,
-      currentBrowserUrl: this.currentBrowserUrl,
-    });
-
-    this.emitSecurityDecision(decision);
-
-    if (decision.decision === 'deny') {
-      return { allowed: false, error: `Security policy denied ${toolName}: ${decision.message}` };
-    }
-
-    if (decision.decision === 'allow') {
-      return { allowed: true, args };
-    }
-
-    const approvalRequest = toApprovalRequest(decision);
-    const interactive = this.config.security?.interactive ?? false;
-    if (!interactive || !this.config.approvalHandler) {
-      const deniedDecision: SecurityDecision = {
-        ...decision,
-        decision: 'deny',
-        reasonCode: 'security_approval_unavailable',
-        message: 'Approval is required but no interactive approval channel is available.',
-      };
-      this.emitSecurityDecision(deniedDecision);
-      return { allowed: false, error: deniedDecision.message };
-    }
-
-    const approved = await this.config.approvalHandler(approvalRequest);
-    const finalDecision: SecurityDecision = approved
-      ? {
-          ...decision,
-          decision: 'allow',
-          reasonCode: 'approved_by_user',
-          message: `User approved: ${decision.message}`,
-          approvalId: approvalRequest.approvalId,
-        }
-      : {
-          ...decision,
-          decision: 'deny',
-          reasonCode: 'rejected_by_user',
-          message: `User rejected: ${decision.message}`,
-          approvalId: approvalRequest.approvalId,
-        };
-    this.emitSecurityDecision(finalDecision);
-
-    if (!approved) {
-      return {
-        allowed: false,
-        error: `Security approval rejected for ${toolName}: ${decision.message}`,
-      };
-    }
-
-    return {
-      allowed: true,
-      args: {
-        ...args,
-        __frontagentSecurityApproved: true,
-      },
-    };
-  }
-
-  private emitSecurityDecision(decision: SecurityDecision): void {
-    if (this.config.security?.auditEnabled === false) {
-      return;
-    }
-    this.config.onSecurityDecision?.(decision);
-  }
-
-  private isSuccessfulToolResult(result: unknown): boolean {
-    if (typeof result !== 'object' || result === null) {
-      return true;
-    }
-    const resultObj = result as { success?: boolean };
-    return resultObj.success !== false;
+    return toolCall.result;
   }
 
   async executeSteps(

--- a/packages/core/src/executor/tool-call-handler.ts
+++ b/packages/core/src/executor/tool-call-handler.ts
@@ -1,0 +1,164 @@
+import type { SecurityDecision } from '@frontagent/shared';
+import { SecurityManager, toApprovalRequest } from '../security.js';
+import type { ExecutorConfig, MCPClient } from './types.js';
+
+type SecurityCheckResult =
+  | { allowed: true; args: Record<string, unknown> }
+  | { allowed: false; error: string };
+
+export interface ExecutorToolCallHandlerOptions {
+  config: ExecutorConfig;
+  mcpClients: Map<string, MCPClient>;
+  toolToClient: Map<string, string>;
+  nowMs: () => number;
+  getCurrentBrowserUrl: () => string | undefined;
+}
+
+export interface ExecutorToolCallResult {
+  result: unknown;
+  successful: boolean;
+}
+
+export class ExecutorToolCallHandler {
+  private readonly config: ExecutorConfig;
+  private readonly mcpClients: Map<string, MCPClient>;
+  private readonly toolToClient: Map<string, string>;
+  private readonly nowMs: () => number;
+  private readonly getCurrentBrowserUrl: () => string | undefined;
+  private readonly securityManager: SecurityManager;
+
+  constructor(options: ExecutorToolCallHandlerOptions) {
+    this.config = options.config;
+    this.mcpClients = options.mcpClients;
+    this.toolToClient = options.toolToClient;
+    this.nowMs = options.nowMs;
+    this.getCurrentBrowserUrl = options.getCurrentBrowserUrl;
+    this.securityManager = new SecurityManager();
+  }
+
+  async callTool(toolName: string, args: Record<string, unknown>): Promise<ExecutorToolCallResult> {
+    const clientName = this.toolToClient.get(toolName);
+    if (!clientName) {
+      throw new Error(`No MCP client registered for tool: ${toolName}`);
+    }
+
+    const client = this.mcpClients.get(clientName);
+    if (!client) {
+      throw new Error(`MCP client not found: ${clientName}`);
+    }
+
+    if (this.config.debug) {
+      console.log(`[Executor] Calling tool: ${toolName}`, args);
+    }
+
+    const security = await this.enforceSecurity(toolName, args);
+    if (!security.allowed) {
+      const result = {
+        success: false,
+        error: security.error,
+      };
+      return { result, successful: false };
+    }
+
+    const mcpStart = this.nowMs();
+    const result = await client.callTool(toolName, security.args);
+    const mcpDurationMs = this.nowMs() - mcpStart;
+    if (typeof result === 'object' && result !== null) {
+      (result as Record<string, unknown>).__toolDurationMs = mcpDurationMs;
+    }
+
+    if (this.config.debug) {
+      console.log('[Executor] Tool result:', result);
+    }
+
+    return {
+      result,
+      successful: this.isSuccessfulToolResult(result),
+    };
+  }
+
+  isSuccessfulToolResult(result: unknown): boolean {
+    if (typeof result !== 'object' || result === null) {
+      return true;
+    }
+    const resultObj = result as { success?: boolean };
+    return resultObj.success !== false;
+  }
+
+  private async enforceSecurity(
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<SecurityCheckResult> {
+    const decision = this.securityManager.evaluate({
+      toolName,
+      args,
+      projectRoot: this.config.projectRoot,
+      sddConfig: this.config.sddConfig,
+      security: this.config.security,
+      currentBrowserUrl: this.getCurrentBrowserUrl(),
+    });
+
+    this.emitSecurityDecision(decision);
+
+    if (decision.decision === 'deny') {
+      return { allowed: false, error: `Security policy denied ${toolName}: ${decision.message}` };
+    }
+
+    if (decision.decision === 'allow') {
+      return { allowed: true, args };
+    }
+
+    const approvalRequest = toApprovalRequest(decision);
+    const interactive = this.config.security?.interactive ?? false;
+    if (!interactive || !this.config.approvalHandler) {
+      const deniedDecision: SecurityDecision = {
+        ...decision,
+        decision: 'deny',
+        reasonCode: 'security_approval_unavailable',
+        message: 'Approval is required but no interactive approval channel is available.',
+      };
+      this.emitSecurityDecision(deniedDecision);
+      return { allowed: false, error: deniedDecision.message };
+    }
+
+    const approved = await this.config.approvalHandler(approvalRequest);
+    const finalDecision: SecurityDecision = approved
+      ? {
+          ...decision,
+          decision: 'allow',
+          reasonCode: 'approved_by_user',
+          message: `User approved: ${decision.message}`,
+          approvalId: approvalRequest.approvalId,
+        }
+      : {
+          ...decision,
+          decision: 'deny',
+          reasonCode: 'rejected_by_user',
+          message: `User rejected: ${decision.message}`,
+          approvalId: approvalRequest.approvalId,
+        };
+    this.emitSecurityDecision(finalDecision);
+
+    if (!approved) {
+      return {
+        allowed: false,
+        error: `Security approval rejected for ${toolName}: ${decision.message}`,
+      };
+    }
+
+    return {
+      allowed: true,
+      args: {
+        ...args,
+        __frontagentSecurityApproved: true,
+      },
+    };
+  }
+
+  private emitSecurityDecision(decision: SecurityDecision): void {
+    if (this.config.security?.auditEnabled === false) {
+      return;
+    }
+    this.config.onSecurityDecision?.(decision);
+  }
+}


### PR DESCRIPTION
## Linked Issue Or Context

Closes #242

## Summary

- Added `ExecutorToolCallHandler` as an internal executor collaborator for tool lookup, security evaluation/emission, approval handling, MCP client invocation, duration annotation, and result success classification.
- Kept public `Executor.callTool` API and tool mapping behavior intact; `Executor` now coordinates helper results and browser URL state updates.
- Added focused executor tests for approved security decisions, fail-closed approval-unavailable behavior, browser navigation success classification, and helper result classification.

## Impact Scope

- Internal executor refactor only.
- No public `Executor` API changes.
- No MCP client result schema changes.
- No security decision semantic changes.
- No tool mapping behavior changes.

## GitNexus Impact Summary

- Risk level: HIGH
- Critical skeleton changes: `packages/core/src/executor/executor.ts`, `packages/core/src/executor/tool-call-handler.ts`, and matching `packages/core/src/executor/executor.test.ts`; executor/tool-call security path only.
- GitNexus impact: `impact callTool` reported LOW risk with 3 direct callers (`executeStep`, `validateBeforeExecution`, `rollback`) and 2 affected process groups. `impact` for `enforceSecurity`, `emitSecurityDecision`, `isSuccessfulToolResult`, and `Executor` reported HIGH because they sit on the security/tool-call path. `query "Executor tool call security decision approval MCP client invocation result classification"` returned CallTool/Rollback flows including `CallTool -> CheckForbiddenPackages`, `CallTool -> CheckCodeQuality`, and `Rollback -> CheckFileProtection`. `detect-changes --scope compare --base-ref origin/develop` reported 5 files, 6 indexed symbols, 12 affected execution flows, HIGH risk.
- Verification: `pnpm agent:bootstrap` passed; `pnpm quality:predev` passed; focused `pnpm --filter @frontagent/core test -- src/executor/executor.test.ts` passed with 26 tests; `pnpm typecheck` passed; `pnpm quality:precommit` passed; pre-push `pnpm quality:local` passed including contract, quality:ci, build, and VSIX package.

## Verification

- `pnpm agent:bootstrap`
- `pnpm quality:predev`
- `pnpm --filter @frontagent/core test -- src/executor/executor.test.ts`
- `pnpm typecheck`
- `pnpm quality:precommit`
- `pnpm quality:local` via pre-push hook
- `npx gitnexus detect-changes --scope compare --base-ref origin/develop --repo /Users/ceilf6/.config/superpowers/worktrees/FrontAgent-app/improve-executor-tool-call-security`

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.