### PR TITLE
fix(mcp-filesense): prevent path traversal (CRITICAL)

### DIFF
--- a/packages/mcp-filesense/src/tools.security.test.ts
+++ b/packages/mcp-filesense/src/tools.security.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { handleFilesenseTool } from './tools.js';
+
+let roots: string[] = [];
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'frontagent-filesense-'));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots) {
+    rmSync(root, { recursive: true, force: true });
+  }
+  roots = [];
+});
+
+describe('mcp-filesense path containment', () => {
+  it('rejects absolute paths outside the project root', async () => {
+    const root = makeRoot();
+    const result = await handleFilesenseTool('filesense_check', { path: '/etc' }, root);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/outside project root/i);
+  });
+
+  it('rejects parent-directory traversal', async () => {
+    const root = makeRoot();
+    const result = await handleFilesenseTool('filesense_check', { path: '../../../etc' }, root);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/outside project root/i);
+  });
+
+  it('rejects sibling-prefix traversal', async () => {
+    const root = makeRoot();
+    const sibling = `${root}-sibling`;
+    roots.push(sibling);
+    const result = await handleFilesenseTool(
+      'filesense_check',
+      { path: '../frontagent-filesense-sibling' },
+      root,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/outside project root/i);
+  });
+
+  it('rejects out-of-root entries in navigate paths', async () => {
+    const root = makeRoot();
+    const result = await handleFilesenseTool(
+      'filesense_navigate',
+      { paths: ['.', '../../../etc'] },
+      root,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/outside project root/i);
+  });
+
+  it('allows in-root relative paths', async () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'index.ts'), 'export const x = 1;\n', 'utf-8');
+
+    const result = await handleFilesenseTool('filesense_check', { path: '.' }, root);
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/mcp-filesense/src/tools.ts
+++ b/packages/mcp-filesense/src/tools.ts
@@ -3,7 +3,8 @@
  * Exposes filesense operations as MCP-compatible tools for FrontAgent
  */
 
-import { resolve } from 'node:path';
+import { realpathSync } from 'node:fs';
+import { isAbsolute, relative, resolve } from 'node:path';
 import * as engine from './engine.js';
 import type {
   CheckSummary,
@@ -207,9 +208,34 @@ export interface FilesenseToolResult {
   error?: string;
 }
 
+function realProjectRoot(projectRoot: string): string {
+  try {
+    return realpathSync(resolve(projectRoot));
+  } catch {
+    return resolve(projectRoot);
+  }
+}
+
+function isInsidePath(child: string, parent: string): boolean {
+  const rel = relative(parent, child);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+/**
+ * Resolve a user-supplied path against the project root while enforcing
+ * containment. Absolute paths and `..` escapes that resolve outside the
+ * project root are rejected to prevent arbitrary filesystem read/write.
+ */
 function resolvePath(inputPath: string | undefined, projectRoot: string): string {
-  if (!inputPath || inputPath === '.' || inputPath === '') return projectRoot;
-  return resolve(projectRoot, inputPath);
+  const root = realProjectRoot(projectRoot);
+  if (!inputPath || inputPath === '.' || inputPath === '') return root;
+
+  const fullPath = resolve(root, inputPath);
+  if (!isInsidePath(fullPath, root)) {
+    throw new Error(`Access denied: Path resolves outside project root: ${inputPath}`);
+  }
+
+  return fullPath;
 }
 
 export async function handleFilesenseTool(
@@ -250,14 +276,19 @@ export async function handleFilesenseTool(
         return { success: true, data: result };
       }
       case 'filesense_navigate': {
+        const requestedPaths = Array.isArray(args.paths)
+          ? args.paths.filter((item): item is string => typeof item === 'string')
+          : undefined;
+        // Validate every requested path stays inside the project root.
+        for (const requested of requestedPaths ?? []) {
+          resolvePath(requested, projectRoot);
+        }
         const firstPath =
-          Array.isArray(args.paths) && typeof args.paths[0] === 'string'
-            ? resolvePath(args.paths[0], projectRoot)
+          requestedPaths && requestedPaths.length > 0
+            ? resolvePath(requestedPaths[0], projectRoot)
             : targetPath;
         const result = await engine.navigate(firstPath, {
-          paths: Array.isArray(args.paths)
-            ? args.paths.filter((item): item is string => typeof item === 'string')
-            : undefined,
+          paths: requestedPaths,
           intent: args.intent as never,
           depth: args.depth as number | undefined,
           maxEntries: args.maxEntries as number | undefined,


### PR DESCRIPTION
## Summary

- Closes #253
- `mcp-filesense`'s `resolvePath()` passed user-supplied paths straight to `resolve(projectRoot, inputPath)`, so **absolute paths** and **`..` segments** escaped the project root. Because Filesense tools are exposed via the `mcp-file` MCP server, this allowed arbitrary filesystem **read and write** outside the project sandbox (CRITICAL).
- Now `resolvePath()` resolves against the real project root and rejects any path that lands outside it. `filesense_navigate` additionally validates every entry of its `paths` array.

## Changes

- `packages/mcp-filesense/src/tools.ts`
  - `resolvePath()` enforces containment via `realpathSync(projectRoot)` + `isInsidePath()`; throws `Access denied: Path resolves outside project root` for escapes (caught by the handler → `{ success: false, error }`).
  - `filesense_navigate` validates all requested paths.
- `packages/mcp-filesense/src/tools.security.test.ts` (new)
  - Rejects absolute paths, parent traversal, sibling-prefix traversal, out-of-root navigate entries; allows in-root relative paths.

## Test plan

- [x] `vitest run` in `packages/mcp-filesense` — 47 passed (incl. 5 new security tests)
- [x] `tsc --noEmit` clean
- [x] `biome check .` clean
- [x] `pnpm quality:precommit` passed (pre-commit hook)

## GitNexus impact summary

`resolvePath` is a module-private helper in `mcp-filesense/src/tools.ts`; blast radius is limited to the `handleFilesenseTool` dispatch in the same file (and its caller `mcp-file/src/server.ts`). No public symbol signatures changed — the function keeps the same name/signature and only adds validation, so callers are unaffected. Behavior change is limited to now-rejecting out-of-root paths that previously (incorrectly) succeeded. Risk: LOW for legitimate in-root usage.

Made with [Cursor](https://cursor.com)