### PR TITLE
fix(mcp-web): validate navigate URL to prevent SSRF (HIGH)

### DIFF
--- a/packages/mcp-web/src/browser.test.ts
+++ b/packages/mcp-web/src/browser.test.ts
@@ -103,6 +103,20 @@ describe('BrowserManager', () => {
         expect(result.success).toBe(false);
         expect(result.error).toContain('ERR_CONNECTION_REFUSED');
       });
+
+      it('blocks SSRF to cloud metadata without calling goto', async () => {
+        const result = await manager.navigate('http://169.254.169.254/latest/meta-data/');
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/Access denied/i);
+        expect(mockPage.goto).not.toHaveBeenCalled();
+      });
+
+      it('blocks file: scheme without calling goto', async () => {
+        const result = await manager.navigate('file:///etc/passwd');
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/Access denied/i);
+        expect(mockPage.goto).not.toHaveBeenCalled();
+      });
     });
 
     describe('click', () => {

--- a/packages/mcp-web/src/browser.ts
+++ b/packages/mcp-web/src/browser.ts
@@ -5,6 +5,7 @@
 
 import type { AXNode, DOMNode, InteractiveElement } from '@frontagent/shared';
 import type { Browser, BrowserContext, Page } from 'playwright';
+import { checkUrlSafety, defaultUrlSafetyOptions } from './url-safety.js';
 
 type PlaywrightModule = typeof import('playwright');
 
@@ -70,6 +71,11 @@ export class BrowserManager {
    * 导航到指定 URL
    */
   async navigate(url: string): Promise<{ success: boolean; title?: string; error?: string }> {
+    const safety = checkUrlSafety(url, defaultUrlSafetyOptions());
+    if (!safety.ok) {
+      return { success: false, error: `Access denied: ${safety.error}` };
+    }
+
     await this.ensurePage();
 
     try {

--- a/packages/mcp-web/src/index.ts
+++ b/packages/mcp-web/src/index.ts
@@ -3,3 +3,9 @@
  */
 
 export { type BrowserConfig, BrowserManager, createBrowserManager } from './browser.js';
+export {
+  checkUrlSafety,
+  defaultUrlSafetyOptions,
+  type UrlSafetyOptions,
+  type UrlSafetyResult,
+} from './url-safety.js';

--- a/packages/mcp-web/src/url-safety.test.ts
+++ b/packages/mcp-web/src/url-safety.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { checkUrlSafety } from './url-safety.js';
+
+describe('checkUrlSafety', () => {
+  it('allows http and https', () => {
+    expect(checkUrlSafety('http://example.com').ok).toBe(true);
+    expect(checkUrlSafety('https://example.com/page').ok).toBe(true);
+  });
+
+  it('allows localhost dev servers by default', () => {
+    expect(checkUrlSafety('http://localhost:3000').ok).toBe(true);
+    expect(checkUrlSafety('http://127.0.0.1:5173').ok).toBe(true);
+    expect(checkUrlSafety('http://192.168.1.10:8080').ok).toBe(true);
+  });
+
+  it('blocks non-http(s) schemes', () => {
+    expect(checkUrlSafety('file:///etc/passwd').ok).toBe(false);
+    expect(checkUrlSafety('javascript:alert(1)').ok).toBe(false);
+    expect(checkUrlSafety('data:text/html,<h1>x</h1>').ok).toBe(false);
+    expect(checkUrlSafety('ftp://example.com').ok).toBe(false);
+  });
+
+  it('always blocks the cloud metadata / link-local range', () => {
+    expect(checkUrlSafety('http://169.254.169.254/latest/meta-data/').ok).toBe(false);
+    expect(checkUrlSafety('http://169.254.1.1/').ok).toBe(false);
+    expect(checkUrlSafety('http://metadata.google.internal/').ok).toBe(false);
+    expect(checkUrlSafety('http://[fe80::1]/').ok).toBe(false);
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(checkUrlSafety('not a url').ok).toBe(false);
+    expect(checkUrlSafety('').ok).toBe(false);
+  });
+
+  it('blocks loopback and private ranges in strict mode', () => {
+    const strict = { blockPrivate: true };
+    expect(checkUrlSafety('http://localhost:3000', strict).ok).toBe(false);
+    expect(checkUrlSafety('http://127.0.0.1', strict).ok).toBe(false);
+    expect(checkUrlSafety('http://10.0.0.5', strict).ok).toBe(false);
+    expect(checkUrlSafety('http://172.16.0.1', strict).ok).toBe(false);
+    expect(checkUrlSafety('http://192.168.0.1', strict).ok).toBe(false);
+    expect(checkUrlSafety('http://[::1]/', strict).ok).toBe(false);
+    expect(checkUrlSafety('https://example.com', strict).ok).toBe(true);
+  });
+});

--- a/packages/mcp-web/src/url-safety.ts
+++ b/packages/mcp-web/src/url-safety.ts
@@ -1,0 +1,121 @@
+/**
+ * URL safety checks for the web MCP tools.
+ *
+ * Guards against SSRF and local-file access through the browser:
+ *  - only `http:` / `https:` schemes are allowed (blocks `file:`,
+ *    `javascript:`, `data:`, etc.)
+ *  - link-local addresses (incl. the cloud metadata IP 169.254.169.254)
+ *    are always blocked
+ *  - loopback / private-network targets are allowed by default because
+ *    FrontAgent is a frontend dev agent that legitimately drives local dev
+ *    servers; set FRONTAGENT_BLOCK_PRIVATE_URLS=1 to block them too
+ */
+
+export interface UrlSafetyOptions {
+  /** Block loopback and private network ranges (default false). */
+  blockPrivate?: boolean;
+}
+
+export interface UrlSafetyResult {
+  ok: boolean;
+  error?: string;
+}
+
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+
+const LOCAL_HOSTNAMES = new Set(['localhost', 'ip6-localhost', 'ip6-loopback']);
+
+function stripBrackets(hostname: string): string {
+  return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+}
+
+function parseIpv4(host: string): number[] | undefined {
+  const parts = host.split('.');
+  if (parts.length !== 4) return undefined;
+  const octets: number[] = [];
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return undefined;
+    const value = Number(part);
+    if (value > 255) return undefined;
+    octets.push(value);
+  }
+  return octets;
+}
+
+function isLinkLocalIpv4(octets: number[]): boolean {
+  // 169.254.0.0/16 — includes the cloud metadata IP 169.254.169.254
+  return octets[0] === 169 && octets[1] === 254;
+}
+
+function isPrivateIpv4(octets: number[]): boolean {
+  const [a, b] = octets;
+  if (a === 127) return true; // loopback
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  if (a === 0) return true; // 0.0.0.0/8
+  return false;
+}
+
+function isLinkLocalIpv6(host: string): boolean {
+  const h = host.toLowerCase();
+  // fe80::/10 link-local
+  if (h.startsWith('fe8') || h.startsWith('fe9') || h.startsWith('fea') || h.startsWith('feb')) {
+    return true;
+  }
+  return false;
+}
+
+function isLoopbackIpv6(host: string): boolean {
+  const h = host.toLowerCase();
+  return h === '::1' || h === '0:0:0:0:0:0:0:1';
+}
+
+export function checkUrlSafety(rawUrl: string, options: UrlSafetyOptions = {}): UrlSafetyResult {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return { ok: false, error: `Invalid URL: ${rawUrl}` };
+  }
+
+  if (!ALLOWED_PROTOCOLS.has(url.protocol)) {
+    return {
+      ok: false,
+      error: `Blocked URL scheme "${url.protocol}": only http and https are allowed`,
+    };
+  }
+
+  const host = stripBrackets(url.hostname).toLowerCase();
+  const ipv4 = parseIpv4(host);
+
+  // Always block link-local (cloud metadata endpoint lives here).
+  if (ipv4 && isLinkLocalIpv4(ipv4)) {
+    return { ok: false, error: `Blocked link-local address: ${url.hostname}` };
+  }
+  if (!ipv4 && isLinkLocalIpv6(host)) {
+    return { ok: false, error: `Blocked link-local address: ${url.hostname}` };
+  }
+  if (host === 'metadata.google.internal') {
+    return { ok: false, error: 'Blocked cloud metadata host' };
+  }
+
+  if (options.blockPrivate) {
+    if (LOCAL_HOSTNAMES.has(host)) {
+      return { ok: false, error: `Blocked loopback host: ${url.hostname}` };
+    }
+    if (ipv4 && isPrivateIpv4(ipv4)) {
+      return { ok: false, error: `Blocked private/loopback address: ${url.hostname}` };
+    }
+    if (!ipv4 && isLoopbackIpv6(host)) {
+      return { ok: false, error: `Blocked loopback address: ${url.hostname}` };
+    }
+  }
+
+  return { ok: true };
+}
+
+/** Read the default safety policy from the environment. */
+export function defaultUrlSafetyOptions(): UrlSafetyOptions {
+  return { blockPrivate: process.env.FRONTAGENT_BLOCK_PRIVATE_URLS === '1' };
+}


### PR DESCRIPTION
## Summary

- Closes #254
- `mcp-web`'s `navigate()` passed the user-supplied URL straight to Playwright `page.goto()` with no validation, enabling SSRF: cloud metadata (`169.254.169.254`), `file:///etc/passwd`, `javascript:` and other dangerous schemes, with page contents readable via the other web tools.
- Adds a `checkUrlSafety()` guard enforced in `navigate()` before the browser is touched.

## Policy

- **Allow** only `http:` / `https:` (blocks `file:`, `javascript:`, `data:`, `ftp:`, ...).
- **Always block** the link-local range `169.254.0.0/16` (incl. the cloud metadata IP `169.254.169.254`), IPv6 link-local `fe80::/10`, and `metadata.google.internal`.
- **Loopback / private ranges stay allowed by default** because FrontAgent is a frontend dev agent that legitimately drives local dev servers (e.g. `http://localhost:3000`). Set `FRONTAGENT_BLOCK_PRIVATE_URLS=1` to block loopback/private targets in hardened deployments.

## Changes

- `packages/mcp-web/src/url-safety.ts` (new) — `checkUrlSafety()` + `defaultUrlSafetyOptions()`.
- `packages/mcp-web/src/browser.ts` — validate URL at the top of `navigate()`; return `Access denied: ...` without launching/navigating.
- `packages/mcp-web/src/index.ts` — export the new helpers.
- `packages/mcp-web/src/url-safety.test.ts` (new) and `browser.test.ts` — cover scheme blocking, metadata/link-local blocking, strict-mode private blocking, and that `goto()` is not called on a blocked URL.

## Test plan

- [x] `vitest run` in `packages/mcp-web` — 35 passed (incl. new SSRF tests)
- [x] `tsc --noEmit` clean
- [x] `biome check .` clean
- [x] `pnpm quality:precommit` passed (pre-commit hook)

## GitNexus impact summary

New module `url-safety.ts` is imported only by `browser.ts::navigate` (single chokepoint; `server.ts` routes `navigate` through it). `navigate`'s signature is unchanged; the only behavioral change is early rejection of unsafe URLs. Existing callers/tests for legitimate `http://localhost` navigation continue to pass. Risk: LOW.

Made with [Cursor](https://cursor.com)