### PR TITLE
fix(mcp-file): strip internal approval flag at MCP boundary (HIGH)

### DIFF
--- a/packages/mcp-file/src/internal-args.test.ts
+++ b/packages/mcp-file/src/internal-args.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { stripInternalArgs } from './internal-args.js';
+
+describe('stripInternalArgs', () => {
+  it('removes the security-approval marker injected by a client', () => {
+    const result = stripInternalArgs({
+      path: 'package.json',
+      __frontagentSecurityApproved: true,
+    });
+
+    expect(result).toEqual({ path: 'package.json' });
+    expect('__frontagentSecurityApproved' in result).toBe(false);
+  });
+
+  it('removes any __frontagent-prefixed key', () => {
+    const result = stripInternalArgs({
+      path: 'x.ts',
+      __frontagentInternal: 'secret',
+      __frontagentSecurityApproved: true,
+    });
+
+    expect(result).toEqual({ path: 'x.ts' });
+  });
+
+  it('preserves legitimate arguments', () => {
+    const args = { path: 'a.ts', patches: [{ start: 1 }], dryRun: true };
+    expect(stripInternalArgs(args)).toEqual(args);
+  });
+
+  it('handles undefined and empty input', () => {
+    expect(stripInternalArgs(undefined)).toEqual({});
+    expect(stripInternalArgs({})).toEqual({});
+  });
+});

--- a/packages/mcp-file/src/internal-args.ts
+++ b/packages/mcp-file/src/internal-args.ts
@@ -1,0 +1,25 @@
+/**
+ * Internal-only tool argument keys that must never be accepted from external
+ * MCP clients. These markers (e.g. `__frontagentSecurityApproved`) are set
+ * exclusively by the trusted executor after a real security decision; honoring
+ * them from raw client arguments would let any caller bypass write-approval
+ * gates. They are stripped at the MCP server boundary before dispatch.
+ */
+const INTERNAL_KEY_PREFIX = '__frontagent';
+
+/**
+ * Return a shallow copy of the tool arguments with any internal-only keys
+ * removed. Accepts the raw `arguments` object from a CallTool request.
+ */
+export function stripInternalArgs(
+  args: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!args || typeof args !== 'object') return {};
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (key.startsWith(INTERNAL_KEY_PREFIX)) continue;
+    sanitized[key] = value;
+  }
+  return sanitized;
+}

--- a/packages/mcp-file/src/server.ts
+++ b/packages/mcp-file/src/server.ts
@@ -9,6 +9,7 @@ import { allFilesenseSchemas, handleFilesenseTool } from '@frontagent/mcp-filese
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { stripInternalArgs } from './internal-args.js';
 import { SnapshotManager } from './snapshot.js';
 import { applyPatch, applyPatchSchema } from './tools/apply-patch.js';
 import { createFile, createFileSchema } from './tools/create-file.js';
@@ -82,7 +83,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 
 // 处理工具调用
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
+  const { name } = request.params;
+  // Strip internal-only markers (e.g. __frontagentSecurityApproved) so external
+  // clients cannot bypass write-approval gates. The trusted executor sets these
+  // in-process, never over the wire.
+  const args = stripInternalArgs(request.params.arguments as Record<string, unknown> | undefined);
 
   try {
     switch (name) {


### PR DESCRIPTION
## Summary

- Closes #255
- `__frontagentSecurityApproved` is an **internal trust marker** set only by the trusted executor (`core/.../tool-call-handler.ts`) after a real security decision. The standalone `mcp-file` MCP server forwarded raw client `arguments` to the tool handlers, which honor the flag — so any MCP client could inject `"__frontagentSecurityApproved": true` to bypass write-approval gates (e.g. unapproved overwrite of `package.json` / lockfiles).
- The server now strips any `__frontagent`-prefixed key from incoming tool arguments before dispatch.

## Changes

- `packages/mcp-file/src/internal-args.ts` (new) — `stripInternalArgs()` removes internal-only (`__frontagent*`) keys.
- `packages/mcp-file/src/server.ts` — sanitize `request.params.arguments` once at the top of the CallTool handler; all tool cases use the sanitized object.
- `packages/mcp-file/src/internal-args.test.ts` (new) — verifies the marker is stripped, all `__frontagent*` keys removed, legitimate args preserved, and undefined/empty handled.

## Notes

- Truly sensitive paths (`.env`, `*.pem`, `.git/`, snapshots) remain blocked by `isSensitiveWritePath` regardless of approval; this PR closes the dependency-file / overwrite bypass.
- The legitimate in-process executor path is unaffected: it sets the flag after `stripInternalArgs` no longer runs (the flag is injected within the executor, not over the MCP wire).

## Test plan

- [x] `vitest run` in `packages/mcp-file` — 56 passed (incl. new tests)
- [x] `tsc --noEmit` clean
- [x] `biome check .` clean
- [x] `pnpm quality:precommit` passed (pre-commit hook)

## GitNexus impact summary

New helper `stripInternalArgs` is called once in `server.ts`'s CallTool handler; it narrows the `args` object passed to every tool case. No tool handler signatures changed. The only behavioral change is that externally-supplied `__frontagent*` keys are dropped before reaching `applyPatch`/`createFile`, restoring the intended approval gate. Risk: LOW (in-process executor sets the flag through a separate path).

Made with [Cursor](https://cursor.com)