### PR TITLE
fix(hallucination-guard): use relative-path containment to block sibling-root paths

### DIFF
--- a/packages/hallucination-guard/src/checks/file-existence.test.ts
+++ b/packages/hallucination-guard/src/checks/file-existence.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { checkFileExistence, checkFilesExistence } from './file-existence.js';
 
@@ -44,6 +44,39 @@ describe('checkFileExistence', () => {
     expect(result.pass).toBe(false);
     expect(result.severity).toBe('block');
     expect(result.message).toMatch(/outside project root/i);
+  });
+
+  it('blocks sibling directory sharing the project root prefix', async () => {
+    const root = makeRoot();
+    const sibling = `${root}-secret`;
+    mkdirSync(sibling);
+    roots.push(sibling);
+    writeFileSync(join(sibling, 'leak.txt'), '', 'utf-8');
+
+    const result = await checkFileExistence({
+      path: relative(root, join(sibling, 'leak.txt')),
+      projectRoot: root,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.severity).toBe('block');
+    expect(result.message).toMatch(/outside project root/i);
+  });
+
+  it('blocks absolute path outside project root', async () => {
+    const root = makeRoot();
+
+    const result = await checkFileExistence({ path: '/etc/hosts', projectRoot: root });
+    expect(result.pass).toBe(false);
+    expect(result.severity).toBe('block');
+    expect(result.message).toMatch(/outside project root/i);
+  });
+
+  it('normalizes project root with trailing separator', async () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'app.ts'), '', 'utf-8');
+
+    const result = await checkFileExistence({ path: 'app.ts', projectRoot: `${root}/` });
+    expect(result.pass).toBe(true);
   });
 
   it('fails when path is a directory, not a file', async () => {

--- a/packages/hallucination-guard/src/checks/file-existence.ts
+++ b/packages/hallucination-guard/src/checks/file-existence.ts
@@ -4,8 +4,17 @@
  */
 
 import { existsSync, statSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { isAbsolute, relative, resolve } from 'node:path';
 import type { HallucinationCheckResult } from '@frontagent/shared';
+
+/**
+ * 判断 child 是否位于 parent 目录内（含 parent 本身）。
+ * 使用 path.relative 而非字符串前缀，避免同级目录（如 /tmp/project-secret）误判。
+ */
+function isInsidePath(child: string, parent: string): boolean {
+  const rel = relative(parent, child);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
 
 export interface FileExistenceCheckInput {
   path: string;
@@ -21,10 +30,11 @@ export async function checkFileExistence(
 ): Promise<HallucinationCheckResult> {
   const { path, projectRoot, shouldExist = true } = input;
 
-  const fullPath = resolve(projectRoot, path);
+  const resolvedRoot = resolve(projectRoot);
+  const fullPath = resolve(resolvedRoot, path);
 
   // 安全检查：确保路径在项目根目录内
-  if (!fullPath.startsWith(projectRoot)) {
+  if (!isInsidePath(fullPath, resolvedRoot)) {
     return {
       pass: false,
       type: 'file_existence',


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #259

## Summary

- `checkFileExistence` 原先用 `fullPath.startsWith(projectRoot)` 做项目根目录包含校验，存在经典 prefix 误判：`/tmp/project-secret` 会被当作 `/tmp/project` 的内部路径，导致 guard 对同级目录执行 `existsSync`/`statSync` 越界探测。
- 改为基于 `path.relative` 的容器检查（与 `packages/mcp-file/src/path-safety.ts` 的 `isInsidePath` 一致），并对 `projectRoot` 先做 `resolve()` 归一化。
- 新增 3 个回归测试：sibling 目录共享前缀、绝对路径越界、根路径带尾随分隔符。

## Impact Scope

- `packages/hallucination-guard/src/checks/file-existence.ts`（`checkFileExistence` 内部校验逻辑，公开 API 不变）
- `packages/hallucination-guard/src/checks/file-existence.test.ts`（新增测试）

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: 无（hallucination-guard 检查内部逻辑，不涉及关键骨架）
- GitNexus impact: `gitnexus impact checkFileExistence --direction upstream` → impactedCount 2（`HallucinationGuard.validate`、`HallucinationGuard.validateFilePath`），processes_affected 0，modules_affected 1（Checks）
- Verification: `gitnexus detect-changes` → 3 files, 2 symbols（`checkFileExistence`、`FileExistenceCheckInput`），affected processes 0，risk low

## Verification

- `pnpm vitest run src/checks/file-existence.test.ts`（hallucination-guard 包内）：10/10 通过
- pre-commit 钩子完整执行 `pnpm quality:precommit`（lint + typecheck + test + test:workflows）：通过
- pre-push 钩子完整执行 `pnpm quality:local`（contract:local + quality:ci 含 build）：通过

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

Made with [Cursor](https://cursor.com)