### PR TITLE
fix(mcp-file): validate read_file line-range bounds

### DIFF
--- a/packages/mcp-file/src/tools/read-file.test.ts
+++ b/packages/mcp-file/src/tools/read-file.test.ts
@@ -1,0 +1,101 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { readFile } from './read-file.js';
+
+let roots: string[] = [];
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'mcp-file-read-'));
+  roots.push(root);
+  return root;
+}
+
+function makeFixture(root: string): void {
+  writeFileSync(join(root, 'sample.txt'), 'line1\nline2\nline3\nline4\nline5', 'utf-8');
+}
+
+afterEach(() => {
+  for (const root of roots) {
+    rmSync(root, { recursive: true, force: true });
+  }
+  roots = [];
+});
+
+describe('readFile', () => {
+  it('reads the whole file by default', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = readFile({ path: 'sample.txt' }, root);
+    expect(result.success).toBe(true);
+    expect(result.content).toBe('line1\nline2\nline3\nline4\nline5');
+    expect(result.lines).toBe(5);
+  });
+
+  it('returns the requested line range with accurate line count', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = readFile({ path: 'sample.txt', startLine: 2, endLine: 4 }, root);
+    expect(result.success).toBe(true);
+    expect(result.content).toBe('line2\nline3\nline4');
+    expect(result.lines).toBe(3);
+  });
+
+  it('clamps endLine beyond file length and reports actual lines', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = readFile({ path: 'sample.txt', startLine: 4, endLine: 100 }, root);
+    expect(result.success).toBe(true);
+    expect(result.content).toBe('line4\nline5');
+    expect(result.lines).toBe(2);
+  });
+
+  it('rejects startLine of 0 instead of returning the last line', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = readFile({ path: 'sample.txt', startLine: 0, endLine: 2 }, root);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/invalid startline/i);
+  });
+
+  it('rejects negative startLine', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = readFile({ path: 'sample.txt', startLine: -2 }, root);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/invalid startline/i);
+  });
+
+  it('rejects endLine smaller than startLine instead of negative line count', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = readFile({ path: 'sample.txt', startLine: 4, endLine: 2 }, root);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/invalid endline/i);
+  });
+
+  it('rejects startLine beyond file length instead of silent empty content', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = readFile({ path: 'sample.txt', startLine: 10 }, root);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/exceeds file length/i);
+  });
+
+  it('rejects non-integer line numbers', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = readFile({ path: 'sample.txt', startLine: 1.5 }, root);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/invalid startline/i);
+  });
+});

--- a/packages/mcp-file/src/tools/read-file.ts
+++ b/packages/mcp-file/src/tools/read-file.ts
@@ -92,10 +92,31 @@ export function readFile(params: ReadFileParams, projectRoot: string): ReadFileR
 
     // 如果指定了行范围，截取内容
     if (startLine !== undefined || endLine !== undefined) {
-      const start = (startLine ?? 1) - 1; // 转为 0-based
+      const start = startLine ?? 1;
       const end = endLine ?? allLines.length;
-      content = allLines.slice(start, end).join('\n');
-      lines = end - start;
+
+      if (!Number.isInteger(start) || start < 1) {
+        return {
+          success: false,
+          error: `Invalid startLine: ${start} (must be an integer >= 1)`,
+        };
+      }
+      if (start > allLines.length) {
+        return {
+          success: false,
+          error: `startLine ${start} exceeds file length (${allLines.length} lines)`,
+        };
+      }
+      if (!Number.isInteger(end) || end < start) {
+        return {
+          success: false,
+          error: `Invalid endLine: ${end} (must be an integer >= startLine)`,
+        };
+      }
+
+      const selected = allLines.slice(start - 1, end);
+      content = selected.join('\n');
+      lines = selected.length;
     }
 
     return {


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #260

## Summary

- `read_file` 的 `startLine`/`endLine` 此前没有任何校验：`startLine=0` 时 `slice(-1, end)` 会错误返回最后一行；`startLine > endLine` 时 `lines` 为负数；超出文件行数时静默返回空内容。
- 现在在截取前校验：`startLine` 为 >=1 的整数、不超过文件总行数；`endLine` 为 >= `startLine` 的整数；非法输入返回明确的 `{ success: false, error }`。
- `lines` 改为 slice 结果的实际行数（`endLine` 超出文件长度时自动截断并如实计数）。
- 新增 `read-file.test.ts`，覆盖正常范围、超界截断与 5 类非法输入。

## Impact Scope

- `packages/mcp-file/src/tools/read-file.ts`（`readFile` 行范围分支，公开 API 不变）
- `packages/mcp-file/src/tools/read-file.test.ts`（新增）

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: mcp boundary（`packages/mcp-file/src/`），已附带同包契约测试
- GitNexus impact: `gitnexus impact readFile --direction upstream` → impactedCount 1（仅 `mcp-file/src/server.ts`），processes_affected 0
- Verification: `gitnexus detect-changes` → 2 files, 2 symbols（`readFile`、`readFileSchema`），affected processes 0，risk low

## Verification

- `pnpm vitest run src/tools/read-file.test.ts`（mcp-file 包内）：8/8 通过
- pre-commit 钩子完整执行 `pnpm quality:precommit`：通过
- pre-push 钩子完整执行 `pnpm quality:local`（contract:local + quality:ci 含 build）：通过

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

Made with [Cursor](https://cursor.com)