### PR TITLE
fix(mcp-file): guard search_code against zero-width regex infinite loop

### DIFF
--- a/packages/mcp-file/src/tools/search-code.test.ts
+++ b/packages/mcp-file/src/tools/search-code.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { searchCode } from './search-code.js';
+
+let roots: string[] = [];
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'mcp-file-search-'));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots) {
+    rmSync(root, { recursive: true, force: true });
+  }
+  roots = [];
+});
+
+describe('searchCode', () => {
+  it('finds plain query matches', async () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'app.ts'), 'const foo = 1;\nconst bar = foo + 1;\n', 'utf-8');
+
+    const result = await searchCode({ query: 'foo' }, root);
+    expect(result.success).toBe(true);
+    expect(result.totalMatches).toBe(2);
+  });
+
+  it('terminates on zero-width regex patterns instead of looping forever', {
+    timeout: 5000,
+  }, async () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'app.ts'), 'const foo = 1;\nconst bar = 2;\n', 'utf-8');
+
+    // `x*` 在不含 x 的位置产生零宽匹配，旧实现会死循环
+    const result = await searchCode({ pattern: 'x*' }, root);
+    expect(result.success).toBe(true);
+  });
+
+  it('still reports non-empty matches for patterns that can match empty strings', {
+    timeout: 5000,
+  }, async () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'app.ts'), 'xx yy xxx\n', 'utf-8');
+
+    const result = await searchCode({ pattern: 'x*' }, root);
+    expect(result.success).toBe(true);
+    expect(result.matches?.map((m) => m.column)).toEqual([1, 7]);
+  });
+
+  it('terminates on lookahead-only patterns', { timeout: 5000 }, async () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'app.ts'), 'const foo = 1;\n', 'utf-8');
+
+    const result = await searchCode({ pattern: '(?=foo)' }, root);
+    expect(result.success).toBe(true);
+    expect(result.totalMatches).toBe(0);
+  });
+});

--- a/packages/mcp-file/src/tools/search-code.ts
+++ b/packages/mcp-file/src/tools/search-code.ts
@@ -124,6 +124,13 @@ export async function searchCode(
           searchRegex.lastIndex = 0;
 
           while ((match = searchRegex.exec(line)) !== null) {
+            // 零宽匹配（如 pattern 为 `a*`、`(?=x)`）不会推进 lastIndex，
+            // 手动前移避免死循环；空匹配本身没有可展示的内容，直接跳过
+            if (match[0].length === 0) {
+              searchRegex.lastIndex++;
+              continue;
+            }
+
             const searchMatch: SearchMatch = {
               file: relative(realProjectRoot, fullPath),
               line: lineIdx + 1,


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #261

## Summary

- `search_code` 对调用方提供的 `pattern` 构造带 `g` 标志的正则后循环 `exec`。当 pattern 产生零宽匹配（如 `x*`、`(?=foo)`、`\b`）时，`lastIndex` 不会推进，`while` 死循环导致 MCP server 进程被打满（面向 Agent 输入的 DoS 缺陷）。
- 修复：循环内检测 `match[0].length === 0` 时手动推进 `lastIndex` 并跳过该空匹配（空匹配本身没有可展示内容）。
- 新增 `search-code.test.ts`：零宽 pattern 终止性（带超时保护）、lookahead-only pattern、以及可匹配空串的 pattern 仍正确报告非空匹配位置。

## Impact Scope

- `packages/mcp-file/src/tools/search-code.ts`（`searchCode` 匹配循环，公开 API 与正常匹配行为不变）
- `packages/mcp-file/src/tools/search-code.test.ts`（新增）

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: mcp boundary（`packages/mcp-file/src/`），已附带同包契约测试
- GitNexus impact: `gitnexus impact searchCode --direction upstream` → impactedCount 1（仅 `mcp-file/src/server.ts`），processes_affected 0
- Verification: `gitnexus detect-changes` → 2 files, 1 symbol（`searchCode`），affected processes 0，risk low

## Verification

- `pnpm vitest run src/tools/search-code.test.ts`（mcp-file 包内）：4/4 通过（修复前零宽 pattern 用例会超时）
- pre-commit 钩子完整执行 `pnpm quality:precommit`：通过
- pre-push 钩子完整执行 `pnpm quality:local`（contract:local + quality:ci 含 build）：通过

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

Made with [Cursor](https://cursor.com)