### PR TITLE
refactor(mcp-memory): dedupe tokenize/countTerms by reusing bm25 implementations

### DIFF
--- a/packages/mcp-memory/src/rag/bm25.ts
+++ b/packages/mcp-memory/src/rag/bm25.ts
@@ -168,7 +168,7 @@ export function tokenize(input: string): string[] {
   return tokens;
 }
 
-function countTerms(tokens: string[]): Record<string, number> {
+export function countTerms(tokens: string[]): Record<string, number> {
   const counts: Record<string, number> = {};
   for (const token of tokens) {
     counts[token] = (counts[token] ?? 0) + 1;

--- a/packages/mcp-memory/src/rag/repository.test.ts
+++ b/packages/mcp-memory/src/rag/repository.test.ts
@@ -1,5 +1,9 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { canReuseIndex } from './repository.js';
+import { countTerms, tokenize } from './bm25.js';
+import { buildRepositoryIndex, canReuseIndex } from './repository.js';
 import type { RepositoryIndex } from './types.js';
 import { INDEX_VERSION } from './types.js';
 
@@ -46,6 +50,37 @@ const baseExpected = {
   chunkOverlap: 200,
   maxFileSizeBytes: 256 * 1024,
 };
+
+describe('buildRepositoryIndex tokenization contract', () => {
+  it('indexes chunk term frequencies with the shared bm25 tokenizer', async () => {
+    const repoDir = mkdtempSync(join(tmpdir(), 'rag-repo-'));
+    try {
+      writeFileSync(join(repoDir, 'app.ts'), 'const getUserName = 1; // 中文检索', 'utf-8');
+
+      const index = await buildRepositoryIndex({
+        repoDir,
+        repoUrl: 'https://github.com/user/repo.git',
+        branch: 'main',
+        revision: 'abc123',
+        excludedPathPrefixes: [],
+        excludedSubmodulePaths: [],
+        chunkSize: 2048,
+        chunkOverlap: 0,
+        maxFileSizeBytes: 1024 * 1024,
+      });
+
+      const chunk = index.chunks.find((candidate) => candidate.path === 'app.ts');
+      expect(chunk).toBeDefined();
+      // repository 索引侧与 BM25 检索侧必须使用同一份分词实现，
+      // 否则查询 token 与索引 token 漂移会导致检索质量回退
+      expect(chunk?.termFrequency).toEqual(countTerms(tokenize(chunk?.keywordText ?? '')));
+      expect(Object.keys(chunk?.termFrequency ?? {})).toContain('user');
+      expect(Object.keys(chunk?.termFrequency ?? {})).toContain('中文');
+    } finally {
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('canReuseIndex', () => {
   it('returns true when all fields match', () => {

--- a/packages/mcp-memory/src/rag/repository.ts
+++ b/packages/mcp-memory/src/rag/repository.ts
@@ -5,6 +5,7 @@ import { readdir, readFile, stat } from 'node:fs/promises';
 import { basename, extname, join, resolve } from 'node:path';
 import { promisify } from 'node:util';
 
+import { countTerms, tokenize } from './bm25.js';
 import { chunkText } from './chunking.js';
 import {
   BINARY_EXTENSIONS,
@@ -332,61 +333,6 @@ function looksBinary(buffer: Buffer, path: string): boolean {
 function getTopLevelDir(path: string): string {
   const firstSegment = normalizeRepoPath(path).split('/')[0];
   return firstSegment || 'root';
-}
-
-function tokenize(input: string): string[] {
-  const tokens: string[] = [];
-  const seen = new Set<string>();
-
-  const emit = (token: string) => {
-    if (token.length >= 2 && !seen.has(token)) {
-      seen.add(token);
-      tokens.push(token);
-    }
-  };
-
-  const normalized = input.toLowerCase();
-  for (const match of normalized.match(/[a-z0-9_@./:-]+/g) ?? []) {
-    emit(match);
-    if (match.includes('_')) {
-      for (const part of match.split('_')) {
-        emit(part);
-      }
-    }
-  }
-
-  for (const identifier of input.match(/[A-Za-z][a-zA-Z0-9]*/g) ?? []) {
-    if (!/[a-z]/.test(identifier) || !/[A-Z]/.test(identifier)) {
-      continue;
-    }
-    const parts = identifier
-      .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-      .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
-      .split(/\s+/);
-    for (const part of parts) {
-      emit(part.toLowerCase());
-    }
-  }
-
-  for (const match of normalized.match(/[一-鿿]+/g) ?? []) {
-    if (match.length === 1) {
-      emit(match);
-      continue;
-    }
-    for (let i = 0; i < match.length - 1; i++) {
-      emit(match.slice(i, i + 2));
-    }
-  }
-
-  return tokens;
-}
-
-function countTerms(tokens: string[]): Record<string, number> {
-  const counts: Record<string, number> = {};
-  for (const token of tokens) {
-    counts[token] = (counts[token] ?? 0) + 1;
-  }
-  return counts;
 }
 
 function buildChunkSignature(chunks: RepositoryChunk[]): string {


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #262

## Summary

- `packages/mcp-memory/src/rag/repository.ts` 中存在与 `bm25.ts` 逐字相同的 `tokenize`（约 45 行）与 `countTerms` 私有副本。两侧分词逻辑一旦只改一处，BM25 检索 token 与索引 token 会漂移，造成难排查的检索质量回退。
- 修复：`bm25.ts` 导出 `countTerms`，`repository.ts` 改为 `import { countTerms, tokenize } from './bm25.js'` 并删除本地副本（净删 54 行），行为完全不变。
- 新增契约测试：`buildRepositoryIndex` 产出的 chunk `termFrequency` 必须等于共享 `tokenize`/`countTerms` 对 `keywordText` 的计算结果（含 camelCase 拆分与中文 bigram 断言）。

## Impact Scope

- `packages/mcp-memory/src/rag/bm25.ts`（`countTerms` 由私有改为导出，实现不变）
- `packages/mcp-memory/src/rag/repository.ts`（删除重复实现，改为 import）
- `packages/mcp-memory/src/rag/repository.test.ts`（新增契约测试）

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: memory boundary（`packages/mcp-memory/src/rag/`），已附带同包契约测试
- GitNexus impact: `gitnexus impact tokenize` 此前返回 2 个同名符号（bm25.ts / repository.ts），正是重复实现的佐证；两者调用方均在 mcp-memory 包内
- Verification: `gitnexus detect-changes` → 3 files, 1 symbol（`countTerms` → bm25.ts），affected processes 0，risk low

## Verification

- `pnpm vitest run src/rag/repository.test.ts src/rag/bm25.test.ts src/rag/knowledge-base.test.ts`（mcp-memory 包内）：通过
- pre-commit 钩子完整执行 `pnpm quality:precommit`：通过
- pre-push 钩子完整执行 `pnpm quality:local`（contract:local + quality:ci 含 build，memory-boundary 契约测试检查通过）：通过

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

Made with [Cursor](https://cursor.com)