### PR TITLE
fix(mcp-file): validate apply_patch line-range bounds before mutating

### DIFF
--- a/packages/mcp-file/src/tools/apply-patch.test.ts
+++ b/packages/mcp-file/src/tools/apply-patch.test.ts
@@ -1,0 +1,217 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SnapshotManager } from '../snapshot.js';
+import { applyPatch } from './apply-patch.js';
+
+const FIXTURE = 'line1\nline2\nline3\nline4\nline5';
+
+let roots: string[] = [];
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'mcp-file-patch-'));
+  roots.push(root);
+  return root;
+}
+
+function makeFixture(root: string): void {
+  mkdirSync(join(root, 'src'));
+  writeFileSync(join(root, 'src/sample.ts'), FIXTURE, 'utf-8');
+}
+
+function readFixture(root: string): string {
+  return readFileSync(join(root, 'src/sample.ts'), 'utf-8');
+}
+
+afterEach(() => {
+  for (const root of roots) {
+    rmSync(root, { recursive: true, force: true });
+  }
+  roots = [];
+});
+
+describe('applyPatch line-range validation', () => {
+  it('applies a valid replace patch', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = applyPatch(
+      {
+        path: 'src/sample.ts',
+        patches: [{ operation: 'replace', startLine: 2, endLine: 3, content: 'patched' }],
+      },
+      root,
+      new SnapshotManager(root),
+    );
+
+    expect(result.success).toBe(true);
+    expect(readFixture(root)).toBe('line1\npatched\nline4\nline5');
+  });
+
+  it('allows insert at lineCount + 1 to append at end of file', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = applyPatch(
+      {
+        path: 'src/sample.ts',
+        patches: [{ operation: 'insert', startLine: 6, content: 'line6' }],
+      },
+      root,
+      new SnapshotManager(root),
+    );
+
+    expect(result.success).toBe(true);
+    expect(readFixture(root)).toBe(`${FIXTURE}\nline6`);
+  });
+
+  it('rejects startLine of 0 instead of splicing from the end', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = applyPatch(
+      {
+        path: 'src/sample.ts',
+        patches: [{ operation: 'replace', startLine: 0, content: 'corrupted' }],
+      },
+      root,
+      new SnapshotManager(root),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/startLine 0 must be an integer >= 1/);
+    expect(readFixture(root)).toBe(FIXTURE);
+  });
+
+  it('rejects negative startLine', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = applyPatch(
+      {
+        path: 'src/sample.ts',
+        patches: [{ operation: 'delete', startLine: -2 }],
+      },
+      root,
+      new SnapshotManager(root),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/startLine -2 must be an integer >= 1/);
+    expect(readFixture(root)).toBe(FIXTURE);
+  });
+
+  it('rejects non-integer startLine', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = applyPatch(
+      {
+        path: 'src/sample.ts',
+        patches: [{ operation: 'replace', startLine: 1.5, content: 'x' }],
+      },
+      root,
+      new SnapshotManager(root),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/startLine 1.5 must be an integer/);
+    expect(readFixture(root)).toBe(FIXTURE);
+  });
+
+  it('rejects replace/delete startLine beyond file length', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = applyPatch(
+      {
+        path: 'src/sample.ts',
+        patches: [{ operation: 'delete', startLine: 6 }],
+      },
+      root,
+      new SnapshotManager(root),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/startLine 6 exceeds file length \(5 lines\)/);
+    expect(readFixture(root)).toBe(FIXTURE);
+  });
+
+  it('rejects insert startLine beyond lineCount + 1', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = applyPatch(
+      {
+        path: 'src/sample.ts',
+        patches: [{ operation: 'insert', startLine: 7, content: 'late' }],
+      },
+      root,
+      new SnapshotManager(root),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/startLine 7 exceeds file length \+ 1/);
+    expect(readFixture(root)).toBe(FIXTURE);
+  });
+
+  it('rejects endLine lower than startLine', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = applyPatch(
+      {
+        path: 'src/sample.ts',
+        patches: [{ operation: 'replace', startLine: 3, endLine: 2, content: 'x' }],
+      },
+      root,
+      new SnapshotManager(root),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/endLine 2 must be an integer >= startLine \(3\)/);
+    expect(readFixture(root)).toBe(FIXTURE);
+  });
+
+  it('rejects endLine beyond file length', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = applyPatch(
+      {
+        path: 'src/sample.ts',
+        patches: [{ operation: 'delete', startLine: 4, endLine: 100 }],
+      },
+      root,
+      new SnapshotManager(root),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/endLine 100 exceeds file length \(5 lines\)/);
+    expect(readFixture(root)).toBe(FIXTURE);
+  });
+
+  it('rejects the whole patch set before creating a snapshot when any patch is invalid', () => {
+    const root = makeRoot();
+    makeFixture(root);
+    const snapshotManager = new SnapshotManager(root);
+
+    const result = applyPatch(
+      {
+        path: 'src/sample.ts',
+        patches: [
+          { operation: 'replace', startLine: 1, content: 'valid' },
+          { operation: 'delete', startLine: 99 },
+        ],
+      },
+      root,
+      snapshotManager,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.snapshotId).toBe('');
+    expect(snapshotManager.getFileSnapshots(join(root, 'src/sample.ts'))).toHaveLength(0);
+    expect(readFixture(root)).toBe(FIXTURE);
+  });
+});

--- a/packages/mcp-file/src/tools/apply-patch.test.ts
+++ b/packages/mcp-file/src/tools/apply-patch.test.ts
@@ -210,6 +210,111 @@ describe('applyPatch line-range validation', () => {
     expect(readFixture(root)).toBe(FIXTURE);
   });
 
+  it('applies multi-patch sets in original-file coordinates when an earlier patch shrinks the file', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = applyPatch(
+      {
+        path: 'src/sample.ts',
+        patches: [
+          { operation: 'delete', startLine: 4, endLine: 5 },
+          { operation: 'replace', startLine: 2, content: 'patched2' },
+        ],
+      },
+      root,
+      new SnapshotManager(root),
+    );
+
+    expect(result.success).toBe(true);
+    expect(readFixture(root)).toBe('line1\npatched2\nline3');
+  });
+
+  it('applies multi-patch sets in original-file coordinates when an earlier patch grows the file', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = applyPatch(
+      {
+        path: 'src/sample.ts',
+        patches: [
+          { operation: 'insert', startLine: 2, content: 'inserted-a\ninserted-b' },
+          { operation: 'replace', startLine: 4, content: 'patched4' },
+        ],
+      },
+      root,
+      new SnapshotManager(root),
+    );
+
+    expect(result.success).toBe(true);
+    expect(readFixture(root)).toBe('line1\ninserted-a\ninserted-b\nline2\nline3\npatched4\nline5');
+  });
+
+  it('rejects overlapping range patches before creating a snapshot', () => {
+    const root = makeRoot();
+    makeFixture(root);
+    const snapshotManager = new SnapshotManager(root);
+
+    const result = applyPatch(
+      {
+        path: 'src/sample.ts',
+        patches: [
+          { operation: 'delete', startLine: 1, endLine: 5 },
+          { operation: 'replace', startLine: 5, content: 'ghost' },
+        ],
+      },
+      root,
+      snapshotManager,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/delete at lines 1-5 overlaps replace at lines 5-5/);
+    expect(result.snapshotId).toBe('');
+    expect(snapshotManager.getFileSnapshots(join(root, 'src/sample.ts'))).toHaveLength(0);
+    expect(readFixture(root)).toBe(FIXTURE);
+  });
+
+  it('rejects an insert whose insertion point falls inside another patch range', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = applyPatch(
+      {
+        path: 'src/sample.ts',
+        patches: [
+          { operation: 'insert', startLine: 3, content: 'x' },
+          { operation: 'delete', startLine: 2, endLine: 4 },
+        ],
+      },
+      root,
+      new SnapshotManager(root),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/insert at line 3 overlaps delete at lines 2-4/);
+    expect(readFixture(root)).toBe(FIXTURE);
+  });
+
+  it('allows an insert immediately after a deleted range', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = applyPatch(
+      {
+        path: 'src/sample.ts',
+        patches: [
+          { operation: 'delete', startLine: 2, endLine: 3 },
+          { operation: 'insert', startLine: 4, content: 'inserted' },
+        ],
+      },
+      root,
+      new SnapshotManager(root),
+    );
+
+    expect(result.success).toBe(true);
+    expect(readFixture(root)).toBe('line1\ninserted\nline4\nline5');
+  });
+
   it('rejects the whole patch set before creating a snapshot when any patch is invalid', () => {
     const root = makeRoot();
     makeFixture(root);

--- a/packages/mcp-file/src/tools/apply-patch.test.ts
+++ b/packages/mcp-file/src/tools/apply-patch.test.ts
@@ -156,6 +156,24 @@ describe('applyPatch line-range validation', () => {
     expect(readFixture(root)).toBe(FIXTURE);
   });
 
+  it('rejects insert with endLine because insert does not use a line range', () => {
+    const root = makeRoot();
+    makeFixture(root);
+
+    const result = applyPatch(
+      {
+        path: 'src/sample.ts',
+        patches: [{ operation: 'insert', startLine: 2, endLine: 3, content: 'x' }],
+      },
+      root,
+      new SnapshotManager(root),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/endLine is not supported for insert operations/);
+    expect(readFixture(root)).toBe(FIXTURE);
+  });
+
   it('rejects endLine lower than startLine', () => {
     const root = makeRoot();
     makeFixture(root);

--- a/packages/mcp-file/src/tools/apply-patch.ts
+++ b/packages/mcp-file/src/tools/apply-patch.ts
@@ -67,6 +67,17 @@ export function applyPatch(
 
   const lines = originalContent.split('\n');
 
+  const boundsError = validatePatchBounds(patches, lines.length);
+  if (boundsError) {
+    return {
+      success: false,
+      diff: '',
+      validation: { syntaxValid: false, lintErrors: [], typeErrors: [] },
+      snapshotId: '',
+      error: boundsError,
+    };
+  }
+
   // 创建快照
   const snapshotId = dryRun ? '' : snapshotManager.createSnapshot(safePath.fullPath, 'modify');
 
@@ -124,6 +135,43 @@ export function applyPatch(
     validation,
     snapshotId,
   };
+}
+
+/**
+ * 校验补丁行号边界。
+ * 行号越界时 splice 会相对文件末尾操作并静默损坏内容，因此必须在任何写入前整体拒绝。
+ */
+function validatePatchBounds(patches: FilePatch[], lineCount: number): string | null {
+  for (const patch of patches) {
+    const { operation, startLine, endLine } = patch;
+
+    if (!Number.isInteger(startLine) || startLine < 1) {
+      return `Invalid patch (${operation}): startLine ${startLine} must be an integer >= 1`;
+    }
+
+    if (operation === 'insert') {
+      // insert 在 startLine 之前插入，允许 lineCount + 1 表示追加到文件末尾
+      if (startLine > lineCount + 1) {
+        return `Invalid patch (insert): startLine ${startLine} exceeds file length + 1 (${lineCount} lines)`;
+      }
+      continue;
+    }
+
+    if (startLine > lineCount) {
+      return `Invalid patch (${operation}): startLine ${startLine} exceeds file length (${lineCount} lines)`;
+    }
+
+    if (endLine !== undefined) {
+      if (!Number.isInteger(endLine) || endLine < startLine) {
+        return `Invalid patch (${operation}): endLine ${endLine} must be an integer >= startLine (${startLine})`;
+      }
+      if (endLine > lineCount) {
+        return `Invalid patch (${operation}): endLine ${endLine} exceeds file length (${lineCount} lines)`;
+      }
+    }
+  }
+
+  return null;
 }
 
 /**

--- a/packages/mcp-file/src/tools/apply-patch.ts
+++ b/packages/mcp-file/src/tools/apply-patch.ts
@@ -139,7 +139,9 @@ export function applyPatch(
 
 /**
  * 校验补丁行号边界。
- * 行号越界时 splice 会相对文件末尾操作并静默损坏内容，因此必须在任何写入前整体拒绝。
+ * 契约：所有行号均基于原始文件内容（1-based）；补丁按 startLine 倒序自下而上应用，
+ * 因此各补丁的行范围不得重叠——重叠时先应用的补丁会改变后应用补丁的目标行，
+ * 导致 splice 静默损坏内容。越界或重叠都必须在创建 snapshot / 写入前整体拒绝。
  */
 function validatePatchBounds(patches: FilePatch[], lineCount: number): string | null {
   for (const patch of patches) {
@@ -170,6 +172,47 @@ function validatePatchBounds(patches: FilePatch[], lineCount: number): string | 
       }
       if (endLine > lineCount) {
         return `Invalid patch (${operation}): endLine ${endLine} exceeds file length (${lineCount} lines)`;
+      }
+    }
+  }
+
+  return validatePatchOverlap(patches);
+}
+
+/**
+ * 拒绝行范围重叠的补丁组合。
+ * replace/delete 占用 [startLine, endLine ?? startLine]；insert 占用 startLine 这一插入点
+ * （落在其他补丁范围内时，倒序应用会先改写目标区间，再让 insert/范围补丁作用到错误的行）。
+ * 两个 insert 指向同一行不冲突：插入点不消耗原始行。
+ */
+function validatePatchOverlap(patches: FilePatch[]): string | null {
+  const describe = (p: FilePatch): string =>
+    p.operation === 'insert'
+      ? `insert at line ${p.startLine}`
+      : `${p.operation} at lines ${p.startLine}-${p.endLine ?? p.startLine}`;
+
+  for (let i = 0; i < patches.length; i++) {
+    for (let j = i + 1; j < patches.length; j++) {
+      const a = patches[i];
+      const b = patches[j];
+      if (a.operation === 'insert' && b.operation === 'insert') {
+        continue;
+      }
+
+      let conflict: boolean;
+      if (a.operation === 'insert' || b.operation === 'insert') {
+        const point = a.operation === 'insert' ? a : b;
+        const range = a.operation === 'insert' ? b : a;
+        conflict =
+          point.startLine >= range.startLine &&
+          point.startLine <= (range.endLine ?? range.startLine);
+      } else {
+        conflict =
+          a.startLine <= (b.endLine ?? b.startLine) && b.startLine <= (a.endLine ?? a.startLine);
+      }
+
+      if (conflict) {
+        return `Invalid patch set: ${describe(a)} overlaps ${describe(b)}; line numbers refer to the original file content and patch ranges must not overlap`;
       }
     }
   }
@@ -303,7 +346,8 @@ export const applyPatchSchema = {
       },
       patches: {
         type: 'array',
-        description: '补丁列表',
+        description:
+          '补丁列表。所有行号均相对原始文件内容（应用任何补丁之前），各补丁的行范围不得重叠',
         items: {
           type: 'object',
           properties: {

--- a/packages/mcp-file/src/tools/apply-patch.ts
+++ b/packages/mcp-file/src/tools/apply-patch.ts
@@ -154,6 +154,9 @@ function validatePatchBounds(patches: FilePatch[], lineCount: number): string | 
       if (startLine > lineCount + 1) {
         return `Invalid patch (insert): startLine ${startLine} exceeds file length + 1 (${lineCount} lines)`;
       }
+      if (endLine !== undefined) {
+        return `Invalid patch (insert): endLine is not supported for insert operations`;
+      }
       continue;
     }
 


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #268

## Summary

- `apply_patch` previously converted `startLine`/`endLine` straight into `Array.splice` indices with no validation. `startLine: 0` produced `splice(-1, ...)` which operates relative to the **end** of the file, so invalid patches silently corrupted content while still reporting `success: true`.
- Added `validatePatchBounds`, which rejects the whole patch set with a structured `PatchResult.error` **before** any snapshot is created or content is mutated:
  - `startLine` must be an integer `>= 1`; for `replace`/`delete` it must be `<= lineCount`.
  - `insert` allows `startLine` up to `lineCount + 1` (append at end of file); `endLine` is rejected because insert does not use a line range.
  - For `replace`/`delete`, `endLine` when present must be an integer `>= startLine` and `<= lineCount`.
- Added `apply-patch.test.ts` with 11 focused tests covering valid replace/append plus rejection of `startLine: 0`, negative, non-integer, out-of-range start/end, reversed ranges, insert with `endLine`, and the no-snapshot/no-mutation guarantee on rejection.

## Impact Scope

- `packages/mcp-file/src/tools/apply-patch.ts` (mcp-boundary): new pre-mutation validation only; tool signature, schema, and success-path behavior unchanged.
- `packages/mcp-file/src/tools/apply-patch.test.ts`: new test file.

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: `applyPatch` in `packages/mcp-file/src/tools/apply-patch.ts` (mcp-boundary contract surface)
- GitNexus impact: `gitnexus impact applyPatch --direction upstream` → risk LOW, 1 direct caller at d=1 (`packages/mcp-file/src/server.ts`); `gitnexus detect_changes --repo FrontAgent` → 2 files, 4 symbols, 4 ApplyPatch flows affected, scope limited to intended mcp-boundary edits.
- Verification: `gitnexus context applyPatch` confirms callers propagate `PatchResult.error`; no caller changes required.

## Verification

- `pnpm --filter @frontagent/mcp-file test` — 7 files, 79 tests passed (11 new).
- `pnpm quality:precommit` (lint, typecheck, test, test:workflows) — passed via pre-commit hook.
- `pnpm quality:local` (contract:local + quality:ci incl. build) — passed via pre-push hook.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.