### PR TITLE
fix(sdd): match protected directories on path-segment boundaries

### DIFF
--- a/packages/sdd/src/validator.test.ts
+++ b/packages/sdd/src/validator.test.ts
@@ -19,6 +19,34 @@ describe('SDDValidator', () => {
       expect(result.violations[0].rule).toBe('protected_directory');
     });
 
+    it('blocks the protected directory itself as an exact match', () => {
+      const validator = new SDDValidator(makeConfig());
+      const result = validator.validate({
+        type: 'write_file',
+        targetPath: 'node_modules',
+      });
+      expect(result.valid).toBe(false);
+      expect(result.violations[0].rule).toBe('protected_directory');
+    });
+
+    it('allows sibling directories that share a protected-directory name prefix', () => {
+      const validator = new SDDValidator(makeConfig());
+      const result = validator.validate({
+        type: 'write_file',
+        targetPath: 'node_modules-shim/pkg/index.ts',
+      });
+      expect(result.violations.some((v) => v.rule === 'protected_directory')).toBe(false);
+    });
+
+    it('allows .gitnexus paths when .git is protected', () => {
+      const validator = new SDDValidator(makeConfig());
+      const result = validator.validate({
+        type: 'write_file',
+        targetPath: '.gitnexus/meta.json',
+      });
+      expect(result.violations.some((v) => v.rule === 'protected_directory')).toBe(false);
+    });
+
     it('blocks modification of .git directory', () => {
       const validator = new SDDValidator(makeConfig());
       const result = validator.validate({

--- a/packages/sdd/src/validator.ts
+++ b/packages/sdd/src/validator.ts
@@ -109,9 +109,10 @@ export class SDDValidator {
     const approvalReasons: string[] = [];
     const normalizedPath = normalizePath(targetPath);
 
-    // 检查是否在保护目录中
+    // 检查是否在保护目录中(按路径段匹配,避免误判同前缀的兄弟目录,如 node_modules-shim)
     for (const dir of this.config.modificationRules.protectedDirectories) {
-      if (normalizedPath.startsWith(normalizePath(dir))) {
+      const dirPrefix = normalizePath(dir).replace(/\/+$/, '');
+      if (normalizedPath === dirPrefix || normalizedPath.startsWith(`${dirPrefix}/`)) {
         violations.push({
           type: 'error',
           rule: 'protected_directory',


### PR DESCRIPTION
## Linked Issue Or Context

- Fixes #269

## Summary

- `SDDValidator.checkFileProtection` matched protected directories with a raw string prefix (`normalizedPath.startsWith(normalizePath(dir))`), so sibling directories sharing a name prefix were falsely flagged as `protected_directory` violations (e.g. `node_modules-shim/...`, `.gitnexus/...` with the default `['node_modules', '.git']`).
- Now matches on path segments: exact match or `prefix + '/'`, with trailing slashes stripped from the configured directory first (since `normalizePath` does not strip them). Mirrors the hallucination-guard path-containment fix from #259/#263.
- Added tests: exact-match protected dir is blocked, `node_modules-shim/...` and `.gitnexus/...` are allowed.

## Impact Scope

- `packages/sdd/src/validator.ts` — `checkFileProtection` protected-directory loop only.
- `packages/sdd/src/validator.test.ts` — 3 new tests.

## GitNexus Impact Summary

- Risk level: `gitnexus impact checkFileProtection --direction upstream` → HIGH (1 direct caller `validate`, 4 affected flows: rollback, callTool, evaluateFileWrite, enforceSecurity); `detect_changes` on the final diff → MEDIUM (2 symbols, 1 flow: Rollback → CheckFileProtection).
- Critical skeleton changes: behavior change is one-directional — paths previously misclassified as protected are now allowed; genuinely protected paths are still blocked (covered by existing + new tests).
- GitNexus impact: changed symbols `SDDValidator`, `checkFileProtection` in `packages/sdd/src/validator.ts`; no other symbols touched.
- Verification: `pnpm quality:local` passed (all package tests green, GitNexus contract passed).

## Verification

- `pnpm vitest run packages/sdd/src/validator.test.ts` → 25 passed.
- `pnpm quality:local` → passed (pre-push hook re-ran it on push).

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)