### PR TITLE
fix(hallucination-guard): contain local import resolution within project root

### DIFF
--- a/packages/hallucination-guard/src/checks/file-existence.ts
+++ b/packages/hallucination-guard/src/checks/file-existence.ts
@@ -4,17 +4,9 @@
  */
 
 import { existsSync, statSync } from 'node:fs';
-import { isAbsolute, relative, resolve } from 'node:path';
+import { resolve } from 'node:path';
 import type { HallucinationCheckResult } from '@frontagent/shared';
-
-/**
- * 判断 child 是否位于 parent 目录内（含 parent 本身）。
- * 使用 path.relative 而非字符串前缀，避免同级目录（如 /tmp/project-secret）误判。
- */
-function isInsidePath(child: string, parent: string): boolean {
-  const rel = relative(parent, child);
-  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
-}
+import { isInsidePath } from './path-containment.js';
 
 export interface FileExistenceCheckInput {
   path: string;

--- a/packages/hallucination-guard/src/checks/import-validity.test.ts
+++ b/packages/hallucination-guard/src/checks/import-validity.test.ts
@@ -1,5 +1,136 @@
-import { describe, expect, it } from 'vitest';
-import { extractImports } from './import-validity.js';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { checkImportValidity, extractImports } from './import-validity.js';
+
+let roots: string[] = [];
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'hallucination-guard-'));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots) {
+    rmSync(root, { recursive: true, force: true });
+  }
+  roots = [];
+});
+
+describe('checkImportValidity', () => {
+  it('passes for resolvable relative import', async () => {
+    const root = makeRoot();
+    mkdirSync(join(root, 'src'));
+    writeFileSync(join(root, 'src', 'app.ts'), '', 'utf-8');
+    writeFileSync(join(root, 'src', 'utils.ts'), '', 'utf-8');
+
+    const result = await checkImportValidity({
+      importPath: './utils',
+      sourceFilePath: 'src/app.ts',
+      projectRoot: root,
+    });
+    expect(result.pass).toBe(true);
+    expect(result.type).toBe('import_validity');
+  });
+
+  it('resolves relative import to index file', async () => {
+    const root = makeRoot();
+    mkdirSync(join(root, 'src', 'lib'), { recursive: true });
+    writeFileSync(join(root, 'src', 'lib', 'index.ts'), '', 'utf-8');
+
+    const result = await checkImportValidity({
+      importPath: './lib',
+      sourceFilePath: 'src/app.ts',
+      projectRoot: root,
+    });
+    expect(result.pass).toBe(true);
+  });
+
+  it('fails for unresolvable relative import', async () => {
+    const root = makeRoot();
+    mkdirSync(join(root, 'src'));
+
+    const result = await checkImportValidity({
+      importPath: './missing',
+      sourceFilePath: 'src/app.ts',
+      projectRoot: root,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.severity).toBe('block');
+    expect(result.message).toMatch(/cannot resolve/i);
+  });
+
+  it('blocks relative import escaping the project root even if the target exists', async () => {
+    const root = makeRoot();
+    mkdirSync(join(root, 'src'));
+
+    const result = await checkImportValidity({
+      importPath: '../'.repeat(20) + 'etc/hosts',
+      sourceFilePath: 'src/app.ts',
+      projectRoot: root,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.severity).toBe('block');
+    expect(result.message).toMatch(/outside project root/i);
+  });
+
+  it('blocks absolute import outside the project root even if the target exists', async () => {
+    const root = makeRoot();
+
+    const result = await checkImportValidity({
+      importPath: '/etc/hosts',
+      sourceFilePath: 'src/app.ts',
+      projectRoot: root,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.severity).toBe('block');
+    expect(result.message).toMatch(/outside project root/i);
+  });
+
+  it('blocks import into a sibling directory sharing the project root prefix', async () => {
+    const root = makeRoot();
+    const sibling = `${root}-secret`;
+    mkdirSync(sibling);
+    roots.push(sibling);
+    writeFileSync(join(sibling, 'leak.ts'), '', 'utf-8');
+    mkdirSync(join(root, 'src'));
+
+    const result = await checkImportValidity({
+      importPath: relative(join(root, 'src'), join(sibling, 'leak.ts')),
+      sourceFilePath: 'src/app.ts',
+      projectRoot: root,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.severity).toBe('block');
+    expect(result.message).toMatch(/outside project root/i);
+  });
+
+  it('passes for node builtin modules', async () => {
+    const root = makeRoot();
+
+    const result = await checkImportValidity({
+      importPath: 'node:path',
+      sourceFilePath: 'src/app.ts',
+      projectRoot: root,
+    });
+    expect(result.pass).toBe(true);
+  });
+
+  it('blocks uninstalled external packages', async () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ dependencies: {} }), 'utf-8');
+
+    const result = await checkImportValidity({
+      importPath: 'totally-hallucinated-pkg',
+      sourceFilePath: 'src/app.ts',
+      projectRoot: root,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.severity).toBe('block');
+  });
+});
 
 describe('extractImports', () => {
   it('extracts ES6 named imports', () => {

--- a/packages/hallucination-guard/src/checks/import-validity.ts
+++ b/packages/hallucination-guard/src/checks/import-validity.ts
@@ -6,6 +6,7 @@
 import { existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import type { HallucinationCheckResult } from '@frontagent/shared';
+import { isInsidePath } from './path-containment.js';
 
 export interface ImportValidityCheckInput {
   importPath: string;
@@ -52,10 +53,24 @@ export async function checkImportValidity(
   }
 
   // 相对导入
-  const sourceDir = dirname(resolve(projectRoot, sourceFilePath));
+  const resolvedRoot = resolve(projectRoot);
+  const sourceDir = dirname(resolve(resolvedRoot, sourceFilePath));
   const possiblePaths = generatePossiblePaths(importPath, sourceDir);
 
-  for (const possiblePath of possiblePaths) {
+  // 安全检查：只允许解析到项目根目录内的候选路径
+  const containedPaths = possiblePaths.filter((path) => isInsidePath(path, resolvedRoot));
+
+  if (containedPaths.length === 0) {
+    return {
+      pass: false,
+      type: 'import_validity',
+      severity: 'block',
+      message: `Security violation: Import "${importPath}" resolves outside project root`,
+      details: { importPath, sourceFilePath, projectRoot },
+    };
+  }
+
+  for (const possiblePath of containedPaths) {
     if (existsSync(possiblePath)) {
       return {
         pass: true,
@@ -71,7 +86,7 @@ export async function checkImportValidity(
     type: 'import_validity',
     severity: 'block',
     message: `Hallucination detected: Cannot resolve import "${importPath}" from "${sourceFilePath}"`,
-    details: { importPath, sourceFilePath, triedPaths: possiblePaths },
+    details: { importPath, sourceFilePath, triedPaths: containedPaths },
   };
 }
 

--- a/packages/hallucination-guard/src/checks/path-containment.ts
+++ b/packages/hallucination-guard/src/checks/path-containment.ts
@@ -1,0 +1,15 @@
+/**
+ * 路径包含关系判断
+ * 供各检查共用的项目根目录约束 helper
+ */
+
+import { isAbsolute, relative } from 'node:path';
+
+/**
+ * 判断 child 是否位于 parent 目录内（含 parent 本身）。
+ * 使用 path.relative 而非字符串前缀，避免同级目录（如 /tmp/project-secret）误判。
+ */
+export function isInsidePath(child: string, parent: string): boolean {
+  const rel = relative(parent, child);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #270

## Summary

- `checkImportValidity` resolved relative and absolute import paths with `resolve(sourceDir, importPath)` and probed `existsSync` with no project-root containment, so imports like `../../../../etc/hosts` or `/etc/hosts` that exist on the host were approved as valid local imports.
- Extracted the `relative()`-based `isInsidePath` helper from `file-existence.ts` (#259) into a shared `path-containment.ts` and reused it in both checks.
- Resolved import candidates are now filtered for containment within `resolve(projectRoot)` before any `existsSync` probe; when every candidate escapes the root, the check fails with `block` severity (`Security violation: Import "..." resolves outside project root`).

## Impact Scope

- `packages/hallucination-guard/src/checks/import-validity.ts` — containment filter in `checkImportValidity`
- `packages/hallucination-guard/src/checks/file-existence.ts` — helper moved to shared module, behavior unchanged
- `packages/hallucination-guard/src/checks/path-containment.ts` — new shared helper
- `packages/hallucination-guard/src/checks/import-validity.test.ts` — new `checkImportValidity` tests

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: none
- GitNexus impact: `impact checkImportValidity --direction upstream` → 3 impacted (`checkAllImports` → `HallucinationGuard.validate`/`validateCode`), 0 processes; `impact checkFileExistence` → 2 impacted (`validate`, `validateFilePath`), LOW
- Verification: `detect-changes` → 4 files, 3 symbols (`ImportValidityCheckInput`, `checkImportValidity`, `checkPackageExists`), 0 affected processes, risk low

## Verification

- `pnpm --filter @frontagent/hallucination-guard test` — 56 tests pass, including new cases for `../` traversal escapes, absolute imports, and sibling directories sharing the root prefix
- `pnpm quality:precommit` — pass (29 pass / 0 fail); pre-push `quality:local` ran via hook

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)