### PR TITLE
fix(mcp-web): harden URL safety against IP encodings and redirect bypass

### DIFF
--- a/packages/mcp-web/src/browser.test.ts
+++ b/packages/mcp-web/src/browser.test.ts
@@ -7,7 +7,10 @@ function internals(m: BrowserManager): Internals {
 }
 
 function createMockPage() {
+  const mainFrame = { name: 'main' };
   return {
+    route: vi.fn().mockResolvedValue(undefined),
+    mainFrame: vi.fn().mockReturnValue(mainFrame),
     goto: vi.fn().mockResolvedValue(undefined),
     title: vi.fn().mockResolvedValue('Test Page'),
     url: vi.fn().mockReturnValue('http://localhost:3000'),
@@ -284,6 +287,153 @@ describe('BrowserManager', () => {
         expect(result.viewport).toEqual({ width: 1920, height: 1080 });
         expect(result.domTree).toEqual([{ tag: 'body', children: [] }]);
       });
+    });
+  });
+
+  describe('navigation guard', () => {
+    afterEach(() => {
+      vi.doUnmock('playwright');
+      vi.resetModules();
+    });
+
+    type RouteHandler = (route: ReturnType<typeof createMockRoute>) => Promise<void>;
+
+    async function launchWithGuard() {
+      const mockPage = createMockPage();
+      const mockBrowser = createMockBrowser(mockPage);
+      vi.doMock('playwright', () => ({
+        chromium: { launch: vi.fn().mockResolvedValue(mockBrowser) },
+      }));
+      const { BrowserManager: FreshManager } = await import('./browser.js');
+      const manager = new FreshManager();
+      await manager.launch();
+      const handler = mockPage.route.mock.calls[0][1] as RouteHandler;
+      return { manager, mockPage, handler };
+    }
+
+    function createMockRoute(options: {
+      url: string;
+      isNavigation?: boolean;
+      frame?: unknown;
+      mainFrame: unknown;
+    }) {
+      return {
+        request: () => ({
+          url: () => options.url,
+          isNavigationRequest: () => options.isNavigation ?? true,
+          frame: () => options.frame ?? options.mainFrame,
+        }),
+        continue: vi.fn().mockResolvedValue(undefined),
+        abort: vi.fn().mockResolvedValue(undefined),
+        fetch: vi.fn().mockResolvedValue({ status: () => 200, headers: () => ({}) }),
+        fulfill: vi.fn().mockResolvedValue(undefined),
+      };
+    }
+
+    it('registers a route guard for all requests on launch', async () => {
+      const { mockPage } = await launchWithGuard();
+      expect(mockPage.route).toHaveBeenCalledWith('**/*', expect.any(Function));
+    });
+
+    it('continues non-navigation requests untouched', async () => {
+      const { mockPage, handler } = await launchWithGuard();
+      const route = createMockRoute({
+        url: 'http://169.254.169.254/asset.js',
+        isNavigation: false,
+        mainFrame: mockPage.mainFrame(),
+      });
+      await handler(route);
+      expect(route.continue).toHaveBeenCalled();
+      expect(route.abort).not.toHaveBeenCalled();
+      expect(route.fetch).not.toHaveBeenCalled();
+    });
+
+    it('continues subframe navigations untouched', async () => {
+      const { mockPage, handler } = await launchWithGuard();
+      const route = createMockRoute({
+        url: 'http://example.com/frame',
+        frame: { name: 'iframe' },
+        mainFrame: mockPage.mainFrame(),
+      });
+      await handler(route);
+      expect(route.continue).toHaveBeenCalled();
+      expect(route.abort).not.toHaveBeenCalled();
+    });
+
+    it('aborts top-level navigations to blocked targets (redirect hops)', async () => {
+      const { mockPage, handler } = await launchWithGuard();
+      const route = createMockRoute({
+        url: 'http://169.254.169.254/latest/meta-data/',
+        mainFrame: mockPage.mainFrame(),
+      });
+      await handler(route);
+      expect(route.abort).toHaveBeenCalledWith('blockedbyclient');
+      expect(route.fetch).not.toHaveBeenCalled();
+      expect(route.fulfill).not.toHaveBeenCalled();
+    });
+
+    it('aborts top-level navigations to encoded metadata IPs', async () => {
+      const { mockPage, handler } = await launchWithGuard();
+      for (const url of ['http://2852039166/', 'http://0xA9FEA9FE/']) {
+        const route = createMockRoute({ url, mainFrame: mockPage.mainFrame() });
+        await handler(route);
+        expect(route.abort).toHaveBeenCalledWith('blockedbyclient');
+      }
+    });
+
+    it('fetches allowed navigations with redirects disabled and fulfills', async () => {
+      const { mockPage, handler } = await launchWithGuard();
+      const route = createMockRoute({
+        url: 'https://example.com/',
+        mainFrame: mockPage.mainFrame(),
+      });
+      await handler(route);
+      expect(route.fetch).toHaveBeenCalledWith({ maxRedirects: 0 });
+      expect(route.fulfill).toHaveBeenCalledWith({
+        response: expect.objectContaining({ status: expect.any(Function) }),
+      });
+      expect(route.abort).not.toHaveBeenCalled();
+    });
+
+    it('aborts redirects whose Location target is blocked', async () => {
+      const { mockPage, handler } = await launchWithGuard();
+      const route = createMockRoute({
+        url: 'https://example.com/start',
+        mainFrame: mockPage.mainFrame(),
+      });
+      route.fetch.mockResolvedValueOnce({
+        status: () => 302,
+        headers: () => ({ location: 'http://169.254.169.254/latest/meta-data/' }),
+      });
+      await handler(route);
+      expect(route.abort).toHaveBeenCalledWith('blockedbyclient');
+      expect(route.fulfill).not.toHaveBeenCalled();
+    });
+
+    it('fulfills redirects whose Location target is allowed', async () => {
+      const { mockPage, handler } = await launchWithGuard();
+      const route = createMockRoute({
+        url: 'https://example.com/start',
+        mainFrame: mockPage.mainFrame(),
+      });
+      route.fetch.mockResolvedValueOnce({
+        status: () => 302,
+        headers: () => ({ location: '/landing' }),
+      });
+      await handler(route);
+      expect(route.fulfill).toHaveBeenCalled();
+      expect(route.abort).not.toHaveBeenCalled();
+    });
+
+    it('aborts when the guarded fetch fails', async () => {
+      const { mockPage, handler } = await launchWithGuard();
+      const route = createMockRoute({
+        url: 'https://example.com/',
+        mainFrame: mockPage.mainFrame(),
+      });
+      route.fetch.mockRejectedValueOnce(new Error('net::ERR_FAILED'));
+      await handler(route);
+      expect(route.abort).toHaveBeenCalledWith('failed');
     });
   });
 

--- a/packages/mcp-web/src/browser.ts
+++ b/packages/mcp-web/src/browser.ts
@@ -53,6 +53,54 @@ export class BrowserManager {
 
     this.page = await this.context.newPage();
     this.page.setDefaultTimeout(this.config.timeout);
+    await this.installNavigationGuard(this.page);
+  }
+
+  /**
+   * Re-check URL safety on every top-level navigation, including HTTP
+   * redirects. `navigate()` only validates the initial URL; without this an
+   * allowed public URL could 302 to a blocked target (e.g. the cloud
+   * metadata endpoint) and Playwright would follow it unchecked.
+   */
+  private async installNavigationGuard(page: Page): Promise<void> {
+    await page.route('**/*', async (route) => {
+      const request = route.request();
+      const isTopLevelNavigation =
+        request.isNavigationRequest() && request.frame() === page.mainFrame();
+      if (!isTopLevelNavigation) {
+        await route.continue();
+        return;
+      }
+
+      const safety = checkUrlSafety(request.url(), defaultUrlSafetyOptions());
+      if (!safety.ok) {
+        await route.abort('blockedbyclient');
+        return;
+      }
+
+      // Playwright does not re-invoke route handlers for server-side
+      // redirect hops, so fetch with redirects disabled. Fulfilling a 3xx
+      // response makes the browser issue a new top-level request for the
+      // redirect target, which goes through this handler (and the safety
+      // check) again. The Location pre-check below only makes blocked
+      // redirects fail fast instead of hanging until the goto timeout.
+      try {
+        const response = await route.fetch({ maxRedirects: 0 });
+        const status = response.status();
+        const location = response.headers().location;
+        if (status >= 300 && status < 400 && location) {
+          const target = new URL(location, request.url()).toString();
+          const redirectSafety = checkUrlSafety(target, defaultUrlSafetyOptions());
+          if (!redirectSafety.ok) {
+            await route.abort('blockedbyclient');
+            return;
+          }
+        }
+        await route.fulfill({ response });
+      } catch {
+        await route.abort('failed').catch(() => {});
+      }
+    });
   }
 
   /**

--- a/packages/mcp-web/src/url-safety.test.ts
+++ b/packages/mcp-web/src/url-safety.test.ts
@@ -27,6 +27,24 @@ describe('checkUrlSafety', () => {
     expect(checkUrlSafety('http://[fe80::1]/').ok).toBe(false);
   });
 
+  it('blocks alternate encodings of the metadata IP', () => {
+    // decimal, hex, octal, partial and trailing-dot forms of 169.254.169.254
+    expect(checkUrlSafety('http://2852039166/').ok).toBe(false);
+    expect(checkUrlSafety('http://0xA9FEA9FE/').ok).toBe(false);
+    expect(checkUrlSafety('http://0251.0376.0251.0376/').ok).toBe(false);
+    expect(checkUrlSafety('http://169.254.43518/').ok).toBe(false);
+    expect(checkUrlSafety('http://0xa9.254.169.254/').ok).toBe(false);
+    expect(checkUrlSafety('http://169.254.169.254./').ok).toBe(false);
+  });
+
+  it('blocks alternate encodings of private addresses in strict mode', () => {
+    const strict = { blockPrivate: true };
+    expect(checkUrlSafety('http://2130706433/', strict).ok).toBe(false); // 127.0.0.1
+    expect(checkUrlSafety('http://0x7f000001/', strict).ok).toBe(false); // 127.0.0.1
+    expect(checkUrlSafety('http://017700000001/', strict).ok).toBe(false); // 127.0.0.1
+    expect(checkUrlSafety('http://0xC0A80101/', strict).ok).toBe(false); // 192.168.1.1
+  });
+
   it('rejects malformed URLs', () => {
     expect(checkUrlSafety('not a url').ok).toBe(false);
     expect(checkUrlSafety('').ok).toBe(false);

--- a/packages/mcp-web/src/url-safety.ts
+++ b/packages/mcp-web/src/url-safety.ts
@@ -29,15 +29,56 @@ function stripBrackets(hostname: string): string {
   return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
 }
 
+/**
+ * Parse one IPv4 part the way browsers do (`inet_aton` semantics):
+ * decimal, hex (`0x…`), or octal (leading `0`).
+ */
+function parseIpv4Part(part: string): number | undefined {
+  let digits = part;
+  let radix = 10;
+  if (/^0x/i.test(part)) {
+    digits = part.slice(2);
+    radix = 16;
+    if (digits === '') return 0; // WHATWG: bare "0x" is 0
+    if (!/^[0-9a-f]+$/i.test(digits)) return undefined;
+  } else if (part.length > 1 && part.startsWith('0')) {
+    digits = part.slice(1);
+    radix = 8;
+    if (!/^[0-7]+$/.test(digits)) return undefined;
+  } else if (!/^\d+$/.test(part)) {
+    return undefined;
+  }
+  return Number.parseInt(digits, radix);
+}
+
+/**
+ * Parse an IPv4 host into four octets. `new URL()` already normalizes
+ * numeric hosts to dotted-quad, but this also accepts the decimal / hex /
+ * octal and partial (1–3 part) encodings directly so the guard does not
+ * depend on URL-parser normalization.
+ */
 function parseIpv4(host: string): number[] | undefined {
   const parts = host.split('.');
-  if (parts.length !== 4) return undefined;
-  const octets: number[] = [];
+  // Tolerate a single trailing dot ("169.254.169.254.").
+  if (parts.length > 1 && parts[parts.length - 1] === '') parts.pop();
+  if (parts.length < 1 || parts.length > 4) return undefined;
+  // A plain hostname must not be mistaken for an IP: only treat the host
+  // as IPv4 when every part parses as a number (matches WHATWG host parsing).
+  const values: number[] = [];
   for (const part of parts) {
-    if (!/^\d{1,3}$/.test(part)) return undefined;
-    const value = Number(part);
-    if (value > 255) return undefined;
-    octets.push(value);
+    const value = parseIpv4Part(part);
+    if (value === undefined) return undefined;
+    values.push(value);
+  }
+  // inet_aton: the last value fills all remaining bytes.
+  const prefix = values.slice(0, -1);
+  if (prefix.some((value) => value > 255)) return undefined;
+  const last = values[values.length - 1];
+  const lastByteCount = 4 - prefix.length;
+  if (last >= 256 ** lastByteCount) return undefined;
+  const octets = [...prefix];
+  for (let i = lastByteCount - 1; i >= 0; i--) {
+    octets.push((last >>> (8 * i)) & 0xff);
   }
   return octets;
 }


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #271 (follow-up to the SSRF hardening in #254)

## Summary

- `url-safety.ts`: `parseIpv4` now parses IPv4 hosts with browser/`inet_aton` semantics — decimal (`2852039166`), hex (`0xA9FEA9FE`), octal (`0251.0376.0251.0376`), partial 1–3 part forms (`169.254.43518`), and a trailing dot — so the link-local/private checks no longer depend on `new URL()` normalization. Note: on current Node the WHATWG URL parser already normalizes these encodings to dotted-quad before `parseIpv4` runs, so this part is defense-in-depth; the new tests lock the behavior in either way.
- `browser.ts`: `launch()` now installs a `page.route('**/*')` navigation guard that re-runs `checkUrlSafety` on **every top-level navigation, including HTTP redirect hops**. Playwright does not re-invoke route handlers for server-side redirects, so the guard fetches with `maxRedirects: 0` and fulfills the response; a 3xx makes the browser issue the redirect target as a new top-level request that passes through the guard again. A `Location` pre-check aborts blocked redirects immediately (`net::ERR_BLOCKED_BY_CLIENT`) instead of hanging until the goto timeout. Non-navigation requests (subresources, iframes) are continued untouched.

## Impact Scope

- `packages/mcp-web` only: `url-safety.ts`, `browser.ts`, and their tests. The `navigate` MCP tool keeps its existing pre-check; redirect enforcement is additive.

## GitNexus Impact Summary

- Risk level: `impact` upstream on `checkUrlSafety` (0 direct callers) and `BrowserManager.navigate` (3 direct callers) both report **LOW**; `detect-changes` flags the touched mcp-web symbols across the two `CallTool` execution flows (CLI and runtime-node), which is the expected scope.
- Critical skeleton changes: none — changes are contained in the mcp-web safety layer.
- GitNexus impact: changed symbols `parseIpv4`, `parseIpv4Part`, `checkUrlSafety`, `BrowserManager.launch`, `BrowserManager.installNavigationGuard`, `BrowserManager.navigate`; affected flows `CallTool → ParseIpv4 / IsLinkLocalIpv4 / StripBrackets / LoadPlaywright`.
- Verification: `gitnexus detect-changes` re-run after the final diff confirms only the expected mcp-web symbols/flows.

## Verification

- `pnpm quality:precommit` and `pnpm quality:local` pass.
- Unit tests: 46/46 in `packages/mcp-web` (new cases: decimal/hex/octal/partial metadata-IP encodings, strict-mode encoded private IPs, route-guard abort/continue/fulfill paths, blocked-Location pre-check, fetch-failure abort).
- End-to-end probe against a real Chrome with a local redirect server: direct allowed navigation OK; benign same-host 302 still followed; 302 → `169.254.169.254` blocked; 302 → `http://2852039166/` blocked; direct `http://0xA9FEA9FE/` blocked. Blocked redirects fail fast with `net::ERR_BLOCKED_BY_CLIENT`.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)