### PR TITLE
fix(vscode): failed runtime load or cancel no longer leaves activeRun set, blocking new runs

### DIFF
--- a/apps/vscode/src/test/view-provider.test.ts
+++ b/apps/vscode/src/test/view-provider.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type * as vscode from 'vscode';
+import type { ChatMode, ViewState } from '../state.js';
+import { FrontAgentViewProvider } from '../view-provider.js';
+import { __test } from './vscode-stub.js';
+
+type SendMessage = {
+  type: 'send';
+  task: string;
+  mode: ChatMode;
+  files: string[];
+  url?: string;
+};
+
+interface ProviderInternals {
+  state: ViewState;
+  activeRun?: AbortController;
+  runtimeModulePromise?: Promise<unknown>;
+  startRun(message: SendMessage): Promise<void>;
+  cancelRun(): void;
+}
+
+interface CapturedRunOptions {
+  signal: AbortSignal;
+  onEvent: (event: { type: string; label?: string; operation?: string }) => void;
+}
+
+interface RunCall {
+  options: CapturedRunOptions;
+  resolve: (result: unknown) => void;
+  reject: (error: unknown) => void;
+}
+
+const context = {
+  secrets: {
+    get: async () => 'test-api-key',
+    store: async () => {},
+  },
+} as unknown as vscode.ExtensionContext;
+
+function makeProvider(): ProviderInternals {
+  const provider = new FrontAgentViewProvider(
+    context,
+    () => {},
+    () => {},
+  );
+  return provider as unknown as ProviderInternals;
+}
+
+function fakeRuntime(): { module: unknown; calls: RunCall[] } {
+  const calls: RunCall[] = [];
+  const module = {
+    runFrontAgentTask: (options: CapturedRunOptions) =>
+      new Promise((resolve, reject) => {
+        calls.push({ options, resolve, reject });
+      }),
+  };
+  return { module, calls };
+}
+
+function send(task: string): SendMessage {
+  return { type: 'send', task, mode: 'query', files: [] };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('FrontAgentViewProvider run lifecycle', () => {
+  beforeEach(() => {
+    __test.reset();
+    __test.workspaceFolders = [{ uri: { fsPath: '/tmp/test-ws' }, name: 'ws', index: 0 }];
+    __test.settings.set('provider', 'openai');
+    __test.settings.set('model', 'test-model');
+    __test.settings.set('baseUrl', 'https://example.com/v1');
+  });
+
+  it('clears activeRun when the runtime module fails to load, allowing a retry', async () => {
+    const provider = makeProvider();
+    const rejected = Promise.reject(new Error('missing bundle'));
+    rejected.catch(() => {});
+    provider.runtimeModulePromise = rejected;
+
+    await provider.startRun(send('first task'));
+
+    expect(provider.activeRun).toBeUndefined();
+    expect(provider.state.isRunning).toBe(false);
+    expect(provider.state.error).toContain('missing bundle');
+
+    const { module, calls } = fakeRuntime();
+    provider.runtimeModulePromise = Promise.resolve(module);
+    await provider.startRun(send('retry task'));
+
+    expect(__test.warnings).toHaveLength(0);
+    expect(provider.state.isRunning).toBe(true);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('still blocks a second send while a run is active', async () => {
+    const provider = makeProvider();
+    const { module, calls } = fakeRuntime();
+    provider.runtimeModulePromise = Promise.resolve(module);
+
+    await provider.startRun(send('first task'));
+    await provider.startRun(send('second task'));
+
+    expect(__test.warnings).toEqual(['FrontAgent is already running in this workspace.']);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('cancelRun clears activeRun immediately and ignores callbacks from the cancelled run', async () => {
+    const provider = makeProvider();
+    const { module, calls } = fakeRuntime();
+    provider.runtimeModulePromise = Promise.resolve(module);
+
+    await provider.startRun(send('first task'));
+    expect(provider.state.isRunning).toBe(true);
+
+    provider.cancelRun();
+    expect(provider.activeRun).toBeUndefined();
+    expect(provider.state.isRunning).toBe(false);
+    expect(provider.state.error).toContain('cancelled');
+    expect(calls[0]?.options.signal.aborted).toBe(true);
+
+    await provider.startRun(send('second task'));
+    expect(__test.warnings).toHaveLength(0);
+    expect(provider.state.isRunning).toBe(true);
+    expect(calls).toHaveLength(2);
+
+    calls[0]?.reject(new Error('FrontAgent run cancelled by user'));
+    await flushMicrotasks();
+    expect(provider.state.isRunning).toBe(true);
+    expect(provider.activeRun).toBeDefined();
+
+    const labelBefore = provider.state.lastActivityLabel;
+    calls[0]?.options.onEvent({ type: 'status_update', label: 'stale', operation: 'stale' });
+    expect(provider.state.lastActivityLabel).toBe(labelBefore);
+  });
+});

--- a/apps/vscode/src/test/vscode-stub.ts
+++ b/apps/vscode/src/test/vscode-stub.ts
@@ -1,0 +1,58 @@
+// Minimal stand-in for the `vscode` module so vitest can load modules that
+// import it. Tests mutate `__test` to control workspace state and inspect
+// user-facing notifications.
+
+interface StubWorkspaceFolder {
+  uri: { fsPath: string };
+  name: string;
+  index: number;
+}
+
+export const __test = {
+  workspaceFolders: undefined as StubWorkspaceFolder[] | undefined,
+  settings: new Map<string, unknown>(),
+  warnings: [] as string[],
+  infos: [] as string[],
+  reset(): void {
+    this.workspaceFolders = undefined;
+    this.settings.clear();
+    this.warnings = [];
+    this.infos = [];
+  },
+};
+
+export const workspace = {
+  get workspaceFolders(): StubWorkspaceFolder[] | undefined {
+    return __test.workspaceFolders;
+  },
+  getConfiguration: () => ({
+    get: <T>(key: string, defaultValue?: T): T | undefined =>
+      __test.settings.has(key) ? (__test.settings.get(key) as T) : defaultValue,
+    update: async (): Promise<void> => {},
+  }),
+  openTextDocument: async (): Promise<unknown> => ({}),
+};
+
+export const window = {
+  showWarningMessage: (message: string): void => {
+    __test.warnings.push(message);
+  },
+  showInformationMessage: (message: string): void => {
+    __test.infos.push(message);
+  },
+  showTextDocument: async (): Promise<void> => {},
+};
+
+export const commands = {
+  executeCommand: async (): Promise<void> => {},
+};
+
+export const Uri = {
+  file: (fsPath: string): { fsPath: string } => ({ fsPath }),
+};
+
+export const ConfigurationTarget = {
+  Global: 1,
+  Workspace: 2,
+  WorkspaceFolder: 3,
+};

--- a/apps/vscode/src/view-provider.ts
+++ b/apps/vscode/src/view-provider.ts
@@ -66,6 +66,7 @@ export class FrontAgentViewProvider implements vscode.WebviewViewProvider {
   private state: ViewState = createInitialViewState();
   private pendingPrefill?: PrefillRequest;
   private activeRun?: AbortController;
+  private runGeneration = 0;
   private pendingApproval?: PendingApproval;
   private runtimeModulePromise?: Promise<RuntimeModule>;
 
@@ -216,22 +217,29 @@ export class FrontAgentViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
+    // Each run gets a generation; callbacks from superseded runs check it and bail
+    // so a cancelled or failed run can never clobber the run that replaced it.
+    const generation = ++this.runGeneration;
     const controller = new AbortController();
     this.activeRun = controller;
     this.pendingApproval = undefined;
-    const runtimeOptions = await resolveRuntimeOptions(this.context, folder, configStatus);
     const runtimeTask = this.state.selectionPreview
       ? `${task}\n\nSelected text context:\n${this.state.selectionPreview}`
       : task;
+    let runtimeOptions: Awaited<ReturnType<typeof resolveRuntimeOptions>>;
     let runtime: RuntimeModule;
     try {
+      runtimeOptions = await resolveRuntimeOptions(this.context, folder, configStatus);
       runtime = await this.loadRuntimeModule();
     } catch (error) {
-      this.state = failChatRun(
-        this.state,
-        `FrontAgent runtime failed to load: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      this.postState();
+      if (this.runGeneration === generation) {
+        this.activeRun = undefined;
+        this.state = failChatRun(
+          this.state,
+          `FrontAgent runtime failed to load: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        this.postState();
+      }
       return;
     }
 
@@ -251,10 +259,12 @@ export class FrontAgentViewProvider implements vscode.WebviewViewProvider {
         filterConsole: true,
         signal: controller.signal,
         onRunLogPath: (runLogPath) => {
+          if (this.runGeneration !== generation) return;
           this.state = { ...this.state, runLogPath };
           this.postState();
         },
         onEvent: (event) => {
+          if (this.runGeneration !== generation) return;
           if (event.type === 'status_update') {
             this.log(
               `Runtime status: ${event.label}${event.operation ? ` (${event.operation})` : ''}`,
@@ -263,12 +273,16 @@ export class FrontAgentViewProvider implements vscode.WebviewViewProvider {
           this.state = reduceAgentEvent(this.state, event);
           this.postState();
         },
-        onApprovalRequest: (request) => this.requestApproval(request),
+        onApprovalRequest: (request) =>
+          this.runGeneration === generation
+            ? this.requestApproval(request)
+            : Promise.resolve(false),
       })
       .then((result) => {
         this.log(
           `Run finished. success=${String(result.success)}, steps=${result.executedSteps.length}`,
         );
+        if (this.runGeneration !== generation) return;
         this.state = reduceAgentEvent(this.state, {
           type: 'task_completed',
           result,
@@ -277,6 +291,7 @@ export class FrontAgentViewProvider implements vscode.WebviewViewProvider {
       })
       .catch((error) => {
         this.logError('Run failed.', error);
+        if (this.runGeneration !== generation) return;
         this.state = failChatRun(
           this.state,
           error instanceof Error ? error.message : String(error),
@@ -284,6 +299,7 @@ export class FrontAgentViewProvider implements vscode.WebviewViewProvider {
         this.postState();
       })
       .finally(() => {
+        if (this.runGeneration !== generation) return;
         this.activeRun = undefined;
         this.pendingApproval = undefined;
         this.state = { ...this.state, isRunning: false, approval: null };
@@ -292,16 +308,16 @@ export class FrontAgentViewProvider implements vscode.WebviewViewProvider {
   }
 
   private cancelRun(): void {
-    if (!this.activeRun) return;
+    const run = this.activeRun;
+    if (!run) return;
+    // Supersede the cancelled run immediately so a new run can start without
+    // waiting for the aborted promise to settle; its late callbacks become no-ops.
+    this.runGeneration += 1;
+    this.activeRun = undefined;
     this.pendingApproval?.resolve(false);
     this.pendingApproval = undefined;
-    this.activeRun.abort(new Error('FrontAgent run cancelled by user'));
-    this.state = {
-      ...this.state,
-      lastActivityLabel: '正在取消',
-      currentOperation: '等待当前步骤结束',
-      approval: null,
-    };
+    run.abort(new Error('FrontAgent run cancelled by user'));
+    this.state = failChatRun(this.state, 'FrontAgent run cancelled by user');
     this.postState();
   }
 

--- a/apps/vscode/vitest.config.ts
+++ b/apps/vscode/vitest.config.ts
@@ -1,0 +1,10 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      vscode: fileURLToPath(new URL('./src/test/vscode-stub.ts', import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
## Linked Issue Or Context

- Fixes #273

## Summary

- `startRun()` set `this.activeRun` before awaiting `loadRuntimeModule()`; the load-failure path returned without clearing it, so one failed import (e.g. missing bundle after an upgrade) permanently triggered the "FrontAgent is already running in this workspace." guard until the extension host reloaded.
- Introduce a `runGeneration` counter. The load-failure catch now clears `activeRun` and fails the chat run only when the run has not been superseded. `resolveRuntimeOptions` is moved into the same try/catch since a throw there had the identical stuck-guard effect.
- `cancelRun()` now bumps the generation and clears `activeRun` immediately, so users can start a new run without waiting for the aborted promise to settle. It fails the chat run with the same "FrontAgent run cancelled by user" message the abort rejection previously produced.
- `onEvent` / `onRunLogPath` / `onApprovalRequest` and the run promise `then`/`catch`/`finally` handlers check the generation and ignore callbacks from superseded runs, so a late-settling cancelled run cannot clobber the run that replaced it.

## Impact Scope

- `apps/vscode/src/view-provider.ts` only (`startRun`, `cancelRun`, run callbacks).
- New test infrastructure: `apps/vscode/vitest.config.ts` aliases `vscode` to a minimal stub (`src/test/vscode-stub.ts`) so the view provider can be unit-tested; existing tests unaffected.

## GitNexus Impact Summary

- Risk level: `gitnexus impact` upstream on `startRun` and `cancelRun`: LOW (1 direct caller each — `handleMessage`, confidence 0.85). `gitnexus detect-changes`: HIGH label from 6 changed symbols / 6 affected flows.
- Critical skeleton changes: none — all changes confined to the VS Code webview run lifecycle.
- GitNexus impact: affected flows are `OnEvent → AppendChatMessage/Post/BuildPhasesFromPlan/UpsertStep/EventStepToViewStep` and `OnApprovalRequest → Post`, i.e. exactly the callback paths this fix guards; no flows outside `view-provider.ts` are touched.
- Verification: new lifecycle tests cover load-failure retry, concurrent-send guard, and cancel-then-restart with stale-callback suppression.

## Verification

- `pnpm --dir apps/vscode test` — 5 files, 21 tests passed (3 new lifecycle tests).
- `pnpm quality:precommit` (lint, typecheck, test, test:workflows) — all green, also re-run by the pre-commit hook.
- `pnpm agent:bootstrap` and `pnpm quality:predev` ran clean before changes.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [ ] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run. (Not a critical skeleton change.)
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)