### PR TITLE
perf(vscode): throttle stream_token state posts and apply terminal state once

### DIFF
--- a/apps/vscode/src/test/view-provider.test.ts
+++ b/apps/vscode/src/test/view-provider.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as vscode from 'vscode';
 import type { ChatMode, ViewState } from '../state.js';
 import { FrontAgentViewProvider } from '../view-provider.js';
@@ -14,6 +14,7 @@ type SendMessage = {
 
 interface ProviderInternals {
   state: ViewState;
+  view?: { webview: { postMessage: (message: unknown) => void } };
   activeRun?: AbortController;
   runtimeModulePromise?: Promise<unknown>;
   startRun(message: SendMessage): Promise<void>;
@@ -22,7 +23,7 @@ interface ProviderInternals {
 
 interface CapturedRunOptions {
   signal: AbortSignal;
-  onEvent: (event: { type: string; label?: string; operation?: string }) => void;
+  onEvent: (event: Record<string, unknown> & { type: string }) => void;
 }
 
 interface RunCall {
@@ -135,5 +136,89 @@ describe('FrontAgentViewProvider run lifecycle', () => {
     const labelBefore = provider.state.lastActivityLabel;
     calls[0]?.options.onEvent({ type: 'status_update', label: 'stale', operation: 'stale' });
     expect(provider.state.lastActivityLabel).toBe(labelBefore);
+  });
+});
+
+describe('FrontAgentViewProvider state posting', () => {
+  beforeEach(() => {
+    __test.reset();
+    __test.workspaceFolders = [{ uri: { fsPath: '/tmp/test-ws' }, name: 'ws', index: 0 }];
+    __test.settings.set('provider', 'openai');
+    __test.settings.set('model', 'test-model');
+    __test.settings.set('baseUrl', 'https://example.com/v1');
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function startWithCapturedPosts(): Promise<{
+    provider: ProviderInternals;
+    onEvent: CapturedRunOptions['onEvent'];
+    resolveRun: (result: unknown) => void;
+    posts: unknown[];
+  }> {
+    const provider = makeProvider();
+    const posts: unknown[] = [];
+    provider.view = { webview: { postMessage: (message) => posts.push(message) } };
+    const { module, calls } = fakeRuntime();
+    provider.runtimeModulePromise = Promise.resolve(module);
+
+    await provider.startRun(send('stream task'));
+    const call = calls[0];
+    if (!call) throw new Error('runFrontAgentTask was not called');
+    posts.length = 0;
+    return { provider, onEvent: call.options.onEvent, resolveRun: call.resolve, posts };
+  }
+
+  it('throttles full-state posts for stream_token events to the trailing edge', async () => {
+    const { provider, onEvent, posts } = await startWithCapturedPosts();
+
+    for (let i = 0; i < 25; i += 1) {
+      onEvent({ type: 'stream_token', token: `t${i} ` });
+    }
+    // Inside the throttle window right after startRun's own post: nothing yet.
+    expect(posts).toHaveLength(0);
+
+    vi.advanceTimersByTime(50);
+    expect(posts).toHaveLength(1);
+    expect(provider.state.streamText).toContain('t24');
+    const posted = posts[0] as { type: string; state: ViewState };
+    expect(posted.type).toBe('state');
+    expect(posted.state.streamText).toContain('t24');
+  });
+
+  it('posts non-stream events immediately and supersedes a pending stream post', async () => {
+    const { onEvent, posts } = await startWithCapturedPosts();
+
+    onEvent({ type: 'stream_token', token: 'hello' });
+    expect(posts).toHaveLength(0);
+
+    onEvent({ type: 'status_update', label: 'working', operation: 'op' });
+    expect(posts).toHaveLength(1);
+
+    // The immediate post flushed the pending trailing-edge timer.
+    vi.advanceTimersByTime(200);
+    expect(posts).toHaveLength(1);
+  });
+
+  it('applies terminal state exactly once, via events rather than the resolved promise', async () => {
+    const { provider, onEvent, resolveRun, posts } = await startWithCapturedPosts();
+
+    onEvent({ type: 'task_failed', error: 'boom from events' });
+    expect(provider.state.status).toBe('error');
+    expect(provider.state.error).toBe('boom from events');
+    const errorMessages = provider.state.messages.filter((message) => message.role === 'error');
+    expect(errorMessages).toHaveLength(1);
+
+    resolveRun({ success: false, executedSteps: [], error: 'synthetic resolved error' });
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The resolved result must not be re-reduced into a second terminal state.
+    expect(provider.state.error).toBe('boom from events');
+    expect(provider.state.messages.filter((message) => message.role === 'error')).toHaveLength(1);
+    expect(provider.state.isRunning).toBe(false);
+    expect(posts.length).toBeGreaterThan(0);
   });
 });

--- a/apps/vscode/src/view-provider.ts
+++ b/apps/vscode/src/view-provider.ts
@@ -61,6 +61,13 @@ type WebviewMessage =
   | { type: 'details'; collapsed: boolean }
   | { type: 'webviewError'; message: string; stack?: string };
 
+/**
+ * Trailing-edge throttle window for stream_token-driven state posts. Each
+ * post serializes the full ViewState across the webview bridge and triggers
+ * a full re-render, so per-token posting causes visible jank on long streams.
+ */
+const STREAM_STATE_POST_INTERVAL_MS = 50;
+
 export class FrontAgentViewProvider implements vscode.WebviewViewProvider {
   private view?: vscode.WebviewView;
   private state: ViewState = createInitialViewState();
@@ -69,6 +76,8 @@ export class FrontAgentViewProvider implements vscode.WebviewViewProvider {
   private runGeneration = 0;
   private pendingApproval?: PendingApproval;
   private runtimeModulePromise?: Promise<RuntimeModule>;
+  private statePostTimer?: ReturnType<typeof setTimeout>;
+  private lastStatePostAt = 0;
 
   constructor(
     private readonly context: vscode.ExtensionContext,
@@ -271,7 +280,11 @@ export class FrontAgentViewProvider implements vscode.WebviewViewProvider {
             );
           }
           this.state = reduceAgentEvent(this.state, event);
-          this.postState();
+          if (event.type === 'stream_token') {
+            this.postStateThrottled();
+          } else {
+            this.postState();
+          }
         },
         onApprovalRequest: (request) =>
           this.runGeneration === generation
@@ -279,15 +292,13 @@ export class FrontAgentViewProvider implements vscode.WebviewViewProvider {
             : Promise.resolve(false),
       })
       .then((result) => {
+        // Terminal state is applied exactly once, via the task_completed /
+        // task_failed events in onEvent. Re-reducing the resolved result here
+        // would apply completion twice and turn an event-reported failure into
+        // a synthetic task_completed.
         this.log(
           `Run finished. success=${String(result.success)}, steps=${result.executedSteps.length}`,
         );
-        if (this.runGeneration !== generation) return;
-        this.state = reduceAgentEvent(this.state, {
-          type: 'task_completed',
-          result,
-        });
-        this.postState();
       })
       .catch((error) => {
         this.logError('Run failed.', error);
@@ -370,7 +381,31 @@ export class FrontAgentViewProvider implements vscode.WebviewViewProvider {
   }
 
   private postState(): void {
+    if (this.statePostTimer) {
+      clearTimeout(this.statePostTimer);
+      this.statePostTimer = undefined;
+    }
+    this.lastStatePostAt = Date.now();
     this.post({ type: 'state', state: this.state });
+  }
+
+  /**
+   * Posts the current state at most once per STREAM_STATE_POST_INTERVAL_MS,
+   * with a trailing-edge timer so the final tokens always reach the webview.
+   * Any immediate postState() (non-stream events) flushes and supersedes a
+   * pending trailing post, since every post carries the full latest state.
+   */
+  private postStateThrottled(): void {
+    if (this.statePostTimer) return;
+    const elapsed = Date.now() - this.lastStatePostAt;
+    if (elapsed >= STREAM_STATE_POST_INTERVAL_MS) {
+      this.postState();
+      return;
+    }
+    this.statePostTimer = setTimeout(() => {
+      this.statePostTimer = undefined;
+      this.postState();
+    }, STREAM_STATE_POST_INTERVAL_MS - elapsed);
   }
 
   private post(message: Record<string, unknown>): void {


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #280

## Summary

- `stream_token` events now post the full `ViewState` at most once per 50ms via a trailing-edge timer (`postStateThrottled`), instead of one full-state post + full webview re-render per token. Non-stream events still post immediately, and an immediate post flushes/supersedes any pending trailing post (every post carries the complete latest state, so nothing is lost).
- Terminal state is now applied exactly once: `task_completed`/`task_failed` arrive via `onEvent`; the resolved promise's `.then()` only logs. This removes the double reduction on completion and the synthetic `task_completed { success: false }` that previously followed an event-reported `task_failed`.

## Impact Scope

- `apps/vscode/src/view-provider.ts` (`FrontAgentViewProvider`: new throttle fields/method, `onEvent` dispatch, `.then()` handler)
- New tests in `apps/vscode/src/test/view-provider.test.ts` (fake timers; throttling, flush-on-immediate-post, single terminal application)

## GitNexus Impact Summary

- Risk level: HIGH per `detect_changes` — with a caveat: the class gained two private fields, so GitNexus marks the whole `FrontAgentViewProvider` class (and its untouched properties/`resolveWebviewView`) as touched, fanning out to 12 `ResolveWebviewView → *` render flows. The semantic change is confined to `startRun`'s `onEvent`/`.then()` and `postState`/`postStateThrottled`.
- Critical skeleton changes: none (extension UI layer; `gitnexus_impact` on `FrontAgentViewProvider` upstream: LOW, 2 direct callers via `extension.ts` activate)
- GitNexus impact: `detect_changes` (scope: all) — 3 changed files, affected processes are all webview render flows reached through the shared class symbol
- Verification: full vscode app test suite incl. webview render tests

## Verification

- `pnpm --dir apps/vscode test` — 5 files, 24 tests passed (3 new: trailing-edge throttle, immediate-post supersedes pending stream post, terminal state applied once)
- `pnpm quality:precommit` — all gates green (29/29 workflow checks)

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [ ] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run. (not a critical skeleton change)
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)