### PR TITLE
feat(core): load layered AGENTS.md project instructions into prompts

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -8,6 +8,7 @@ import { SDDParser, SDDPromptGenerator } from '@frontagent/sdd';
 import type { AgentTask, ExecutionPlan, SDDConfig, ValidationResult } from '@frontagent/shared';
 import { generateId, logger } from '@frontagent/shared';
 import { type A2AAgent, InMemoryA2ABus } from '../a2a.js';
+import { loadProjectInstructions } from '../context/project-instructions.js';
 import { ContextManager } from '../context.js';
 import { Executor, type MCPClient } from '../executor.js';
 import { LLMService } from '../llm.js';
@@ -419,6 +420,11 @@ export class FrontAgent {
       this.memoryStore.resetSession();
       preloadMemory(this.memoryDeps, task.id, context);
 
+      context.collectedContext.projectInstructions = loadProjectInstructions({
+        projectRoot: this.config.projectRoot,
+        cwd: process.cwd(),
+      });
+
       if (this.promptGenerator) {
         const constitutionPrompt = this.workflowIntegration?.getConstitutionPrompt();
         if (constitutionPrompt) {
@@ -466,6 +472,7 @@ export class FrontAgent {
           skillContext,
           matchedSkillNames,
           memoryContext: context.collectedContext.memoryContext,
+          projectInstructions: context.collectedContext.projectInstructions,
           filesense: this.config.filesense,
         },
         this.contextManager.getMessages(task.id),
@@ -486,6 +493,7 @@ export class FrontAgent {
             skillContext: context.collectedContext.skillContext,
             matchedSkillNames: context.collectedContext.matchedSkillNames,
             memoryContext: context.collectedContext.memoryContext,
+            projectInstructions: context.collectedContext.projectInstructions,
             filesense: this.config.filesense,
           },
           this.contextManager.getMessages(task.id),
@@ -611,6 +619,7 @@ export class FrontAgent {
           skillContext,
           matchedSkillNames,
           memoryContext: context.collectedContext.memoryContext,
+          projectInstructions: context.collectedContext.projectInstructions,
           filesense: this.config.filesense,
         },
         this.contextManager.getMessages(task.id),
@@ -631,6 +640,7 @@ export class FrontAgent {
             skillContext: context.collectedContext.skillContext,
             matchedSkillNames: context.collectedContext.matchedSkillNames,
             memoryContext: context.collectedContext.memoryContext,
+            projectInstructions: context.collectedContext.projectInstructions,
             filesense: this.config.filesense,
           },
           this.contextManager.getMessages(task.id),

--- a/packages/core/src/agent/task-execution-setup.test.ts
+++ b/packages/core/src/agent/task-execution-setup.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { AgentTask } from '@frontagent/shared';
 import { describe, expect, it, vi } from 'vitest';
 import type { AgentEvent } from '../types.js';
@@ -30,7 +33,13 @@ function makeContext() {
   };
 }
 
-function makeSetupDeps({ ragEnabled = true }: { ragEnabled?: boolean } = {}) {
+function makeSetupDeps({
+  ragEnabled = true,
+  projectRoot = '/repo',
+}: {
+  ragEnabled?: boolean;
+  projectRoot?: string;
+} = {}) {
   const events: AgentEvent[] = [];
   const statusUpdates: Array<{ label: string; operation?: string; detail?: string }> = [];
   const context = makeContext();
@@ -82,7 +91,7 @@ function makeSetupDeps({ ragEnabled = true }: { ragEnabled?: boolean } = {}) {
     workflowIntegration,
     deps: {
       config: {
-        projectRoot: '/repo',
+        projectRoot,
         llm: { provider: 'openai' as const, model: 'gpt-4', apiKey: 'test' },
         rag: ragEnabled
           ? { repoUrl: 'https://example.test/rag.git' }
@@ -169,6 +178,45 @@ describe('prepareTaskExecutionSetup', () => {
       ['检测开发服务器端口', '检测开发服务器端口'],
       ['检索知识库', 'RAG 检索'],
     ]);
+  });
+
+  it('loads layered AGENTS.md project instructions into the collected context', async () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'fa-setup-instructions-'));
+    writeFileSync(join(projectRoot, 'AGENTS.md'), 'Always use pnpm in this repo.');
+    const setup = makeSetupDeps({ projectRoot });
+
+    try {
+      await prepareTaskExecutionSetup({
+        task: makeTask(),
+        originalTaskDescription: 'Original task',
+        skillContext: undefined,
+        matchedSkillNames: [],
+        deps: setup.deps,
+      });
+
+      const instructions = (setup.context.collectedContext as { projectInstructions?: string })
+        .projectInstructions;
+      expect(instructions).toContain('## 项目指令 (Project Instructions)');
+      expect(instructions).toContain('Always use pnpm in this repo.');
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves project instructions unset when no instruction files exist', async () => {
+    const setup = makeSetupDeps();
+
+    await prepareTaskExecutionSetup({
+      task: makeTask(),
+      originalTaskDescription: 'Original task',
+      skillContext: undefined,
+      matchedSkillNames: [],
+      deps: setup.deps,
+    });
+
+    expect(
+      (setup.context.collectedContext as { projectInstructions?: string }).projectInstructions,
+    ).toBeUndefined();
   });
 
   it('keeps sanitized empty task descriptions from replacing the original and suppresses rag events when disabled', async () => {

--- a/packages/core/src/agent/task-execution-setup.ts
+++ b/packages/core/src/agent/task-execution-setup.ts
@@ -1,5 +1,6 @@
 import type { SDDPromptGenerator } from '@frontagent/sdd';
 import type { AgentTask, SDDConfig } from '@frontagent/shared';
+import { loadProjectInstructions } from '../context/project-instructions.js';
 import type { ContextManager } from '../context.js';
 import type { Executor } from '../executor.js';
 import type { MemoryStore } from '../memory/index.js';
@@ -71,6 +72,11 @@ export async function prepareTaskExecutionSetup({
   deps.memoryStore.resetSession();
   const preload = deps.preloadMemory ?? preloadMemoryDefault;
   preload(deps.memoryDeps, task.id, context);
+
+  context.collectedContext.projectInstructions = loadProjectInstructions({
+    projectRoot: deps.config.projectRoot,
+    cwd: process.cwd(),
+  });
 
   if (deps.promptGenerator) {
     const constitutionPrompt = deps.workflowIntegration?.getConstitutionPrompt();

--- a/packages/core/src/context/context-manager.test.ts
+++ b/packages/core/src/context/context-manager.test.ts
@@ -255,6 +255,18 @@ describe('ContextManager', () => {
       expect(prompt).toContain('Create file');
     });
 
+    it('includes project instructions zone after rules and before memory', () => {
+      const manager = new ContextManager();
+      manager.createContext(makeTask({ id: 't1' }));
+      const ctx = manager.getContext('t1')!;
+      ctx.collectedContext.projectInstructions = '## 项目指令 (Project Instructions)\nUse pnpm';
+      ctx.collectedContext.memoryContext = '## Memory\nKnown facts';
+      const prompt = manager.buildSystemPrompt('t1', 'SDD rules');
+      expect(prompt).toContain('Use pnpm');
+      expect(prompt.indexOf('SDD rules')).toBeLessThan(prompt.indexOf('Use pnpm'));
+      expect(prompt.indexOf('Use pnpm')).toBeLessThan(prompt.indexOf('Known facts'));
+    });
+
     it('includes memory context when set', () => {
       const manager = new ContextManager();
       manager.createContext(makeTask({ id: 't1' }));

--- a/packages/core/src/context/context-manager.ts
+++ b/packages/core/src/context/context-manager.ts
@@ -228,6 +228,11 @@ export class ContextManager {
     // --- Zone 1: Rules (SDD constraints) ---
     zones.push(sddPrompt);
 
+    // --- Zone 1.5: Project instructions (layered AGENTS.md/CLAUDE.md, soft guidance) ---
+    if (context.collectedContext.projectInstructions) {
+      zones.push(`\n${context.collectedContext.projectInstructions}`);
+    }
+
     // --- Zone 2: Memory (durable cross-session knowledge) ---
     if (context.collectedContext.memoryContext) {
       zones.push(`\n${context.collectedContext.memoryContext}`);

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -1,1 +1,8 @@
 export { ContextManager, createContextManager } from './context-manager.js';
+export {
+  DEFAULT_INSTRUCTION_FILE_MAX_BYTES,
+  discoverProjectInstructionSources,
+  type LoadProjectInstructionsOptions,
+  loadProjectInstructions,
+  type ProjectInstructionSource,
+} from './project-instructions.js';

--- a/packages/core/src/context/project-instructions.test.ts
+++ b/packages/core/src/context/project-instructions.test.ts
@@ -82,6 +82,38 @@ describe('project-instructions', () => {
     expect(loadProjectInstructions({ projectRoot, globalConfigDir: globalDir })).toBeUndefined();
   });
 
+  it('treats non-normalized cwd paths inside the project as the cwd level', () => {
+    const cwd = join(projectRoot, 'apps', 'web');
+    mkdirSync(cwd, { recursive: true });
+    writeFileSync(join(cwd, 'AGENTS.md'), 'app rules');
+
+    // 含 ..、重复分隔符、尾随分隔符的 cwd 输入都应归一化后判定为项目内
+    for (const messyCwd of [
+      join(projectRoot, 'apps', '..', 'apps', 'web'),
+      `${projectRoot}//apps//web`,
+      `${join(projectRoot, 'apps', 'web')}/`,
+    ]) {
+      const sources = discoverProjectInstructionSources({
+        projectRoot,
+        cwd: messyCwd,
+        globalConfigDir: globalDir,
+      });
+      expect(sources.map((s) => s.level)).toContain('cwd');
+    }
+
+    // 项目根的兄弟目录（共享前缀但不在项目内）必须被排除
+    const sibling = `${projectRoot}-sibling`;
+    mkdirSync(sibling, { recursive: true });
+    writeFileSync(join(sibling, 'AGENTS.md'), 'sibling rules');
+    const siblingSources = discoverProjectInstructionSources({
+      projectRoot,
+      cwd: sibling,
+      globalConfigDir: globalDir,
+    });
+    expect(siblingSources.map((s) => s.level)).not.toContain('cwd');
+    rmSync(sibling, { recursive: true, force: true });
+  });
+
   it('truncates oversized files with an explicit marker', () => {
     writeFileSync(join(projectRoot, 'AGENTS.md'), 'x'.repeat(200));
 

--- a/packages/core/src/context/project-instructions.test.ts
+++ b/packages/core/src/context/project-instructions.test.ts
@@ -129,6 +129,38 @@ describe('project-instructions', () => {
     expect(sources[0].content.startsWith('x'.repeat(100))).toBe(true);
   });
 
+  it('reads only the byte cap from very large files', () => {
+    // 4MB 文件、64 字节上限：截断结果只含上限范围内的内容
+    writeFileSync(join(projectRoot, 'AGENTS.md'), 'y'.repeat(4 * 1024 * 1024));
+
+    const sources = discoverProjectInstructionSources({
+      projectRoot,
+      globalConfigDir: globalDir,
+      maxBytesPerFile: 64,
+    });
+
+    expect(sources).toHaveLength(1);
+    expect(sources[0].truncated).toBe(true);
+    expect(sources[0].content.startsWith('y'.repeat(64))).toBe(true);
+    expect(sources[0].content).not.toContain('y'.repeat(65));
+  });
+
+  it('drops a multibyte character split by the byte cap instead of emitting garbage', () => {
+    // 每个 '指' 占 3 字节；上限 8 字节会把第三个字符切成半个
+    writeFileSync(join(projectRoot, 'AGENTS.md'), '指指指指');
+
+    const sources = discoverProjectInstructionSources({
+      projectRoot,
+      globalConfigDir: globalDir,
+      maxBytesPerFile: 8,
+    });
+
+    expect(sources).toHaveLength(1);
+    expect(sources[0].truncated).toBe(true);
+    expect(sources[0].content.startsWith('指指')).toBe(true);
+    expect(sources[0].content).not.toContain('�');
+  });
+
   it('formats a prompt zone with SDD-precedence note and source paths', () => {
     writeFileSync(join(globalDir, 'AGENTS.md'), 'global rules');
     writeFileSync(join(projectRoot, 'AGENTS.md'), 'repo rules');

--- a/packages/core/src/context/project-instructions.test.ts
+++ b/packages/core/src/context/project-instructions.test.ts
@@ -1,0 +1,113 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  discoverProjectInstructionSources,
+  loadProjectInstructions,
+} from './project-instructions.js';
+
+describe('project-instructions', () => {
+  let root: string;
+  let globalDir: string;
+  let projectRoot: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'fa-instructions-'));
+    globalDir = join(root, 'global');
+    projectRoot = join(root, 'repo');
+    mkdirSync(globalDir, { recursive: true });
+    mkdirSync(projectRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('discovers files in global → project → cwd order', () => {
+    const cwd = join(projectRoot, 'apps', 'web');
+    mkdirSync(cwd, { recursive: true });
+    writeFileSync(join(globalDir, 'AGENTS.md'), 'global rules');
+    writeFileSync(join(projectRoot, 'AGENTS.md'), 'repo rules');
+    writeFileSync(join(cwd, 'AGENTS.md'), 'app rules');
+
+    const sources = discoverProjectInstructionSources({
+      projectRoot,
+      cwd,
+      globalConfigDir: globalDir,
+    });
+
+    expect(sources.map((s) => s.level)).toEqual(['global', 'project', 'cwd']);
+    expect(sources.map((s) => s.content)).toEqual(['global rules', 'repo rules', 'app rules']);
+  });
+
+  it('falls back to CLAUDE.md when AGENTS.md is absent at a level', () => {
+    writeFileSync(join(projectRoot, 'CLAUDE.md'), 'claude rules');
+
+    const sources = discoverProjectInstructionSources({
+      projectRoot,
+      globalConfigDir: globalDir,
+    });
+
+    expect(sources).toHaveLength(1);
+    expect(sources[0].path).toBe(join(projectRoot, 'CLAUDE.md'));
+  });
+
+  it('prefers AGENTS.md over CLAUDE.md at the same level', () => {
+    writeFileSync(join(projectRoot, 'AGENTS.md'), 'agents rules');
+    writeFileSync(join(projectRoot, 'CLAUDE.md'), 'claude rules');
+
+    const sources = discoverProjectInstructionSources({
+      projectRoot,
+      globalConfigDir: globalDir,
+    });
+
+    expect(sources).toHaveLength(1);
+    expect(sources[0].content).toBe('agents rules');
+  });
+
+  it('skips missing files, empty files, and cwd outside the project root', () => {
+    const outsideCwd = join(root, 'elsewhere');
+    mkdirSync(outsideCwd, { recursive: true });
+    writeFileSync(join(outsideCwd, 'AGENTS.md'), 'outside rules');
+    writeFileSync(join(projectRoot, 'AGENTS.md'), '   \n  ');
+
+    const sources = discoverProjectInstructionSources({
+      projectRoot,
+      cwd: outsideCwd,
+      globalConfigDir: globalDir,
+    });
+
+    expect(sources).toHaveLength(0);
+    expect(loadProjectInstructions({ projectRoot, globalConfigDir: globalDir })).toBeUndefined();
+  });
+
+  it('truncates oversized files with an explicit marker', () => {
+    writeFileSync(join(projectRoot, 'AGENTS.md'), 'x'.repeat(200));
+
+    const sources = discoverProjectInstructionSources({
+      projectRoot,
+      globalConfigDir: globalDir,
+      maxBytesPerFile: 100,
+    });
+
+    expect(sources).toHaveLength(1);
+    expect(sources[0].truncated).toBe(true);
+    expect(sources[0].content).toContain('[已截断');
+    expect(sources[0].content.startsWith('x'.repeat(100))).toBe(true);
+  });
+
+  it('formats a prompt zone with SDD-precedence note and source paths', () => {
+    writeFileSync(join(globalDir, 'AGENTS.md'), 'global rules');
+    writeFileSync(join(projectRoot, 'AGENTS.md'), 'repo rules');
+
+    const zone = loadProjectInstructions({ projectRoot, globalConfigDir: globalDir });
+
+    expect(zone).toBeDefined();
+    expect(zone).toContain('## 项目指令 (Project Instructions)');
+    expect(zone).toContain('以 SDD 约束为准');
+    expect(zone).toContain(join(globalDir, 'AGENTS.md'));
+    expect(zone).toContain(join(projectRoot, 'AGENTS.md'));
+    expect(zone?.indexOf('global rules')).toBeLessThan(zone?.indexOf('repo rules') ?? -1);
+  });
+});

--- a/packages/core/src/context/project-instructions.ts
+++ b/packages/core/src/context/project-instructions.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 
 /**
  * 项目指令文件加载器
@@ -80,7 +80,9 @@ export function discoverProjectInstructionSources(
 
   if (options.cwd) {
     const cwd = resolve(options.cwd);
-    const withinProject = cwd !== projectRoot && cwd.startsWith(`${projectRoot}/`);
+    // 平台无关的祖先判断：相对路径非空、不向上越界、不落到别的盘符
+    const rel = relative(projectRoot, cwd);
+    const withinProject = rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
     if (withinProject) {
       const cwdSource = readInstructionFile(cwd, 'cwd', maxBytes);
       if (cwdSource) sources.push(cwdSource);

--- a/packages/core/src/context/project-instructions.ts
+++ b/packages/core/src/context/project-instructions.ts
@@ -1,0 +1,118 @@
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+/**
+ * 项目指令文件加载器
+ *
+ * 按 全局 → 仓库根 → 当前工作目录 的层级查找 AGENTS.md（缺失时回退 CLAUDE.md），
+ * 合并为系统提示词中的"项目指令"区。SDD 约束仍是硬约束，项目指令是软性指导。
+ */
+
+const INSTRUCTION_FILE_NAMES = ['AGENTS.md', 'CLAUDE.md'] as const;
+
+/** 单个指令文件的默认大小上限（字节），超出部分截断并附截断标记 */
+export const DEFAULT_INSTRUCTION_FILE_MAX_BYTES = 32 * 1024;
+
+export interface LoadProjectInstructionsOptions {
+  /** 项目根目录（仓库根层级） */
+  projectRoot: string;
+  /** 当前工作目录；与 projectRoot 相同或位于其外时跳过该层级 */
+  cwd?: string;
+  /** 全局配置目录，默认 ~/.frontagent；测试可覆盖 */
+  globalConfigDir?: string;
+  /** 单文件大小上限（字节） */
+  maxBytesPerFile?: number;
+}
+
+export interface ProjectInstructionSource {
+  /** 指令文件的绝对路径 */
+  path: string;
+  /** 层级标签 */
+  level: 'global' | 'project' | 'cwd';
+  /** 文件内容（可能被截断） */
+  content: string;
+  /** 是否因超出大小上限被截断 */
+  truncated: boolean;
+}
+
+function readInstructionFile(
+  dir: string,
+  level: ProjectInstructionSource['level'],
+  maxBytes: number,
+): ProjectInstructionSource | undefined {
+  for (const fileName of INSTRUCTION_FILE_NAMES) {
+    const filePath = join(dir, fileName);
+    try {
+      if (!existsSync(filePath) || !statSync(filePath).isFile()) continue;
+      const raw = readFileSync(filePath, 'utf-8');
+      const truncated = Buffer.byteLength(raw, 'utf-8') > maxBytes;
+      const content = truncated
+        ? `${Buffer.from(raw, 'utf-8').subarray(0, maxBytes).toString('utf-8')}\n\n[已截断：文件超过 ${maxBytes} 字节上限]`
+        : raw;
+      const trimmed = content.trim();
+      if (!trimmed) continue;
+      return { path: filePath, level, content: trimmed, truncated };
+    } catch {
+      // 不可读的指令文件按缺失处理，不阻塞任务
+    }
+  }
+  return undefined;
+}
+
+/**
+ * 发现各层级的项目指令文件（全局在前，最具体的层级在后）
+ */
+export function discoverProjectInstructionSources(
+  options: LoadProjectInstructionsOptions,
+): ProjectInstructionSource[] {
+  const maxBytes = options.maxBytesPerFile ?? DEFAULT_INSTRUCTION_FILE_MAX_BYTES;
+  const globalDir = options.globalConfigDir ?? join(homedir(), '.frontagent');
+  const projectRoot = resolve(options.projectRoot);
+
+  const sources: ProjectInstructionSource[] = [];
+
+  const globalSource = readInstructionFile(globalDir, 'global', maxBytes);
+  if (globalSource) sources.push(globalSource);
+
+  const projectSource = readInstructionFile(projectRoot, 'project', maxBytes);
+  if (projectSource) sources.push(projectSource);
+
+  if (options.cwd) {
+    const cwd = resolve(options.cwd);
+    const withinProject = cwd !== projectRoot && cwd.startsWith(`${projectRoot}/`);
+    if (withinProject) {
+      const cwdSource = readInstructionFile(cwd, 'cwd', maxBytes);
+      if (cwdSource) sources.push(cwdSource);
+    }
+  }
+
+  return sources;
+}
+
+const LEVEL_LABELS: Record<ProjectInstructionSource['level'], string> = {
+  global: '全局',
+  project: '仓库根',
+  cwd: '当前目录',
+};
+
+/**
+ * 加载并格式化项目指令区内容；没有任何指令文件时返回 undefined
+ */
+export function loadProjectInstructions(
+  options: LoadProjectInstructionsOptions,
+): string | undefined {
+  const sources = discoverProjectInstructionSources(options);
+  if (sources.length === 0) return undefined;
+
+  const parts: string[] = [
+    '## 项目指令 (Project Instructions)',
+    '以下指令来自项目的 AGENTS.md/CLAUDE.md，是软性指导；与 SDD 约束冲突时以 SDD 约束为准。',
+  ];
+
+  for (const source of sources) {
+    parts.push(`\n### 来源（${LEVEL_LABELS[source.level]}）: ${source.path}\n${source.content}`);
+  }
+
+  return parts.join('\n');
+}

--- a/packages/core/src/context/project-instructions.ts
+++ b/packages/core/src/context/project-instructions.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { closeSync, existsSync, openSync, readFileSync, readSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { isAbsolute, join, relative, resolve } from 'node:path';
 
@@ -36,6 +36,21 @@ export interface ProjectInstructionSource {
   truncated: boolean;
 }
 
+/**
+ * 读取文件的前 maxBytes 字节，不把超大文件整体载入内存。
+ * 多字节 UTF-8 字符被截断点切开时，去掉结尾产生的 replacement character。
+ */
+function readFileHead(filePath: string, maxBytes: number): string {
+  const fd = openSync(filePath, 'r');
+  try {
+    const buffer = Buffer.alloc(maxBytes);
+    const bytesRead = readSync(fd, buffer, 0, maxBytes, 0);
+    return buffer.subarray(0, bytesRead).toString('utf-8').replace(/�+$/, '');
+  } finally {
+    closeSync(fd);
+  }
+}
+
 function readInstructionFile(
   dir: string,
   level: ProjectInstructionSource['level'],
@@ -44,12 +59,15 @@ function readInstructionFile(
   for (const fileName of INSTRUCTION_FILE_NAMES) {
     const filePath = join(dir, fileName);
     try {
-      if (!existsSync(filePath) || !statSync(filePath).isFile()) continue;
-      const raw = readFileSync(filePath, 'utf-8');
-      const truncated = Buffer.byteLength(raw, 'utf-8') > maxBytes;
+      if (!existsSync(filePath)) continue;
+      const stats = statSync(filePath);
+      if (!stats.isFile()) continue;
+
+      // 超限时只读取上限范围，避免把超大文件整体载入 plan/execute 关键路径
+      const truncated = stats.size > maxBytes;
       const content = truncated
-        ? `${Buffer.from(raw, 'utf-8').subarray(0, maxBytes).toString('utf-8')}\n\n[已截断：文件超过 ${maxBytes} 字节上限]`
-        : raw;
+        ? `${readFileHead(filePath, maxBytes)}\n\n[已截断：文件超过 ${maxBytes} 字节上限]`
+        : readFileSync(filePath, 'utf-8');
       const trimmed = content.trim();
       if (!trimmed) continue;
       return { path: filePath, level, content: trimmed, truncated };

--- a/packages/core/src/planner.test.ts
+++ b/packages/core/src/planner.test.ts
@@ -176,6 +176,45 @@ describe('Planner LLM-based plan generation', () => {
     expect(createStep).toBeDefined();
   });
 
+  it('injects project instructions into the planning prompt context', async () => {
+    const planner = createPlanner({ useLLM: true });
+    const calls: Array<{ context: string }> = [];
+    mockLLMGeneratePlan(planner, async (input) => {
+      calls.push(input as { context: string });
+      return {
+        summary: '创建工具函数',
+        steps: [
+          {
+            description: '读取目标目录',
+            action: 'list_directory',
+            tool: 'list_directory',
+            phase: '阶段1-分析',
+            params: defaultParams({ path: 'src/utils' }),
+            reasoning: '了解目录结构',
+            needsCodeGeneration: false,
+          },
+        ],
+        risks: [],
+        alternatives: [],
+      };
+    });
+
+    await planner.plan(
+      createTask({ type: 'create' }),
+      emptyContext({
+        projectInstructions: '## 项目指令 (Project Instructions)\nAlways use pnpm.',
+        memoryContext: '## Memory\nKnown facts',
+      }),
+      [],
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].context).toContain('Always use pnpm.');
+    expect(calls[0].context.indexOf('Always use pnpm.')).toBeLessThan(
+      calls[0].context.indexOf('Known facts'),
+    );
+  });
+
   it('falls back to rule-based planning when LLM throws an error', async () => {
     const planner = createPlanner({ useLLM: true });
     mockLLMGeneratePlan(planner, async () => {

--- a/packages/core/src/planner.ts
+++ b/packages/core/src/planner.ts
@@ -275,6 +275,11 @@ export class Planner {
       );
     }
 
+    // Zone 1.5: 分层项目指令（AGENTS.md/CLAUDE.md），软性指导，SDD 约束优先
+    if (context.projectInstructions) {
+      contextParts.push(`\n${context.projectInstructions}`);
+    }
+
     // Zone 2: inject cross-session memory as a distinct block
     if (context.memoryContext) {
       contextParts.push(`\n${context.memoryContext}`);

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -11,6 +11,8 @@ export interface PlannerContextSnapshot {
   readonly matchedSkillNames?: readonly string[];
   /** Preloaded cross-session memory content (Phase 1) */
   readonly memoryContext?: string;
+  /** Layered AGENTS.md/CLAUDE.md project instructions */
+  readonly projectInstructions?: string;
   readonly filesense?: FilesenseConfig;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -585,6 +585,8 @@ export interface ContextInfo {
   matchedSkillNames?: string[];
   /** 跨会话记忆内容（Phase 1 preload） */
   memoryContext?: string;
+  /** 分层 AGENTS.md/CLAUDE.md 项目指令 */
+  projectInstructions?: string;
   /** 结构化 Filesense 目录导航上下文 */
   filesenseNavigation?: FilesenseNavigationContext;
   /** Filesense 目录索引上下文 */


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #294

## Summary

- Add `packages/core/src/context/project-instructions.ts`: layered discovery of `AGENTS.md` (with `CLAUDE.md` fallback) at global (`~/.frontagent/`), repo-root, and cwd levels, merged global-first with per-file size caps and explicit truncation markers.
- Inject the merged content as a dedicated "项目指令 (Project Instructions)" zone: after the SDD rules zone in `ContextManager.buildSystemPrompt`, and before the memory zone in the planner prompt (`Planner.generatePlanWithLLM`).
- Load instructions in both task entry points (`FrontAgent.planTask` via inline load, `prepareTaskExecutionSetup` for execute) and thread the new optional `projectInstructions` field through `ContextInfo` and `PlannerContextSnapshot`.
- SDD constraints remain authoritative; the zone header states instructions are soft guidance.

## Impact Scope

- `packages/core` only. Purely additive: new optional field and optional prompt zone; when no instruction file exists, prompts are byte-identical to before.

## GitNexus Impact Summary

- Risk level: CRITICAL
- Critical skeleton changes: `FrontAgent.execute`, `FrontAgent.planOnly`, `prepareTaskExecutionSetup`, `Planner.generatePlanWithLLM`, `ContextManager.buildSystemPrompt`, `ContextInfo`, `PlannerContextSnapshot`
- GitNexus impact: `detect_changes(scope: all)` reports 10 changed symbols / 20 affected across the GeneratePlan, Execute, and PlanOnly execution flows — exactly the planning/execution paths this feature targets; no unexpected symbols or flows. `impact(buildSystemPrompt, upstream)` returned LOW (no external callers).
- Verification: contract tests added in `packages/core/src/agent/task-execution-setup.test.ts` and `packages/core/src/planner.test.ts`; `pnpm quality:local` (contract:local + quality:ci) exits 0.

## Verification

- `pnpm --filter @frontagent/core test`: 38 files, 571+ tests pass (including 6 new project-instructions tests, 2 new setup tests, 1 new planner prompt test, 1 new buildSystemPrompt zone-order test).
- `pnpm quality:precommit` (lint, typecheck, test, test:workflows): pass.
- `pnpm quality:local` (contract:local + quality:ci incl. build verify): exit 0.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)