### PR TITLE
chore(deps): upgrade ts-morph ^21.0.1 -> ^28.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "homepage": "https://github.com/ceilf6/FrontAgent#readme",
   "dependencies": {
     "playwright": "^1.60.0",
-    "ts-morph": "^21.0.1"
+    "ts-morph": "^28.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",

--- a/packages/mcp-file/package.json
+++ b/packages/mcp-file/package.json
@@ -28,7 +28,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "diff": "^5.2.2",
     "glob": "^10.5.0",
-    "ts-morph": "^21.0.1"
+    "ts-morph": "^28.0.0"
   },
   "devDependencies": {
     "@types/diff": "^5.2.3",

--- a/packages/mcp-file/src/tools/get-ast.test.ts
+++ b/packages/mcp-file/src/tools/get-ast.test.ts
@@ -1,0 +1,128 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getAST } from './get-ast.js';
+
+let roots: string[] = [];
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'mcp-file-ast-'));
+  roots.push(root);
+  return root;
+}
+
+const TS_FIXTURE = `import { join } from 'node:path';
+import * as fs from 'node:fs';
+import os from 'node:os';
+
+export const PI = 3.14;
+
+export async function greet(name: string): Promise<string> {
+  return \`hi \${name}\`;
+}
+
+export class Greeter {}
+
+export interface GreetOptions {
+  loud?: boolean;
+}
+
+export type GreetResult = string;
+`;
+
+const TSX_FIXTURE = `import { Component } from 'react';
+
+export const Button = () => <button>ok</button>;
+
+export function Card(props: { title: string }) {
+  return <div>{props.title}</div>;
+}
+
+export class Panel extends Component {
+  render() {
+    return <div />;
+  }
+}
+`;
+
+afterEach(() => {
+  for (const root of roots) {
+    rmSync(root, { recursive: true, force: true });
+  }
+  roots = [];
+});
+
+describe('getAST (ts-morph smoke test)', () => {
+  it('extracts imports, exports, functions, classes, interfaces and type aliases from a .ts file', async () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'sample.ts'), TS_FIXTURE, 'utf-8');
+
+    const result = await getAST({ path: 'sample.ts' }, root);
+
+    expect(result.success).toBe(true);
+
+    // getImportDeclarations / getNamedImports / getNamespaceImport /
+    // getDefaultImport / getModuleSpecifierValue / getStartLineNumber
+    expect(result.imports).toHaveLength(3);
+    const [named, namespace, def] = result.imports ?? [];
+    expect(named.moduleSpecifier).toBe('node:path');
+    expect(named.namedImports).toEqual(['join']);
+    expect(named.line).toBe(1);
+    expect(namespace.namespaceImport).toBe('fs');
+    expect(def.defaultImport).toBe('os');
+
+    // getExportedDeclarations: ReadonlyMap iterated by key
+    expect(result.exports).toEqual(
+      expect.arrayContaining(['PI', 'greet', 'Greeter', 'GreetOptions', 'GreetResult']),
+    );
+
+    // getFunctions / isAsync / isExported / getParameters /
+    // getType().getText() / getReturnType().getText()
+    const greet = result.functions?.find((f) => f.name === 'greet');
+    expect(greet).toBeDefined();
+    expect(greet?.isAsync).toBe(true);
+    expect(greet?.isExported).toBe(true);
+    expect(greet?.parameters?.[0]).toContain('name: string');
+    // Loose match: type TEXT rendering may legitimately vary across TS engines
+    expect(greet?.returnType).toContain('Promise<string>');
+
+    // getClasses / getInterfaces / getTypeAliases
+    expect(result.classes).toEqual([
+      expect.objectContaining({ name: 'Greeter', isExported: true }),
+    ]);
+    expect(result.interfaces).toEqual([
+      expect.objectContaining({ name: 'GreetOptions', isExported: true }),
+    ]);
+    expect(result.types).toEqual([
+      expect.objectContaining({ name: 'GreetResult', isExported: true }),
+    ]);
+  });
+
+  it('detects arrow-function, function-declaration and class React components in a .tsx file', async () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'components.tsx'), TSX_FIXTURE, 'utf-8');
+
+    const result = await getAST({ path: 'components.tsx' }, root);
+
+    expect(result.success).toBe(true);
+    const componentNames = (result.components ?? []).map((c) => c.name);
+    // Button: getVariableDeclarations + getInitializer + SyntaxKind.ArrowFunction
+    expect(componentNames).toContain('Button');
+    // Card: getFunctions + getBody() JSX heuristic (exercises jsx: 2 parsing)
+    expect(componentNames).toContain('Card');
+    // Panel: getClasses + getExtends
+    expect(componentNames).toContain('Panel');
+    expect(result.components?.find((c) => c.name === 'Panel')?.type).toBe('class');
+  });
+
+  it('rejects unsupported file extensions', async () => {
+    const root = makeRoot();
+    writeFileSync(join(root, 'notes.md'), '# hi', 'utf-8');
+
+    const result = await getAST({ path: 'notes.md' }, root);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Unsupported file type');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,8 +26,8 @@ importers:
         specifier: ^1.60.0
         version: 1.60.0
       ts-morph:
-        specifier: ^21.0.1
-        version: 21.0.1
+        specifier: ^28.0.0
+        version: 28.0.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.16
@@ -204,8 +204,8 @@ importers:
         specifier: ^10.5.0
         version: 10.5.0
       ts-morph:
-        specifier: ^21.0.1
-        version: 21.0.1
+        specifier: ^28.0.0
+        version: 28.0.0
     devDependencies:
       '@types/diff':
         specifier: ^5.2.3
@@ -1010,18 +1010,6 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@nodelib/fs.scandir@2.1.5':
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.stat@2.0.5':
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.walk@1.2.8':
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
-
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
@@ -1197,8 +1185,8 @@ packages:
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
-  '@ts-morph/common@0.22.0':
-    resolution: {integrity: sha512-HqNBuV/oIlMKdkLshXd1zKBqNQCsuPEsgQOkfFQ/eUKjRlwndXW1AjN9LVkBEIukm00gGXSRmfkl0Wv5VXLnlw==}
+  '@ts-morph/common@0.29.0':
+    resolution: {integrity: sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==}
 
   '@turbo/darwin-64@2.9.16':
     resolution: {integrity: sha512-jLjApWTSNd7JZ5JaLYfelW1ytnGQOvB7ivl+2RD1xQvJTbi8I9gBjzcga7tDZVPyaxpl10YTfJt3BrYXR18KDw==}
@@ -1394,10 +1382,6 @@ packages:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
-  braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
-
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -1463,8 +1447,8 @@ packages:
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
-  code-block-writer@12.0.0:
-    resolution: {integrity: sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==}
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   code-excerpt@4.0.0:
     resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
@@ -1706,18 +1690,11 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
-    engines: {node: '>=8.6.0'}
-
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
-
-  fastq@1.20.1:
-    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1727,10 +1704,6 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
-
-  fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -1797,10 +1770,6 @@ packages:
     resolution: {integrity: sha512-50XwLbqWdqvwACRco1vm9Opa2aR+q7V6FVTck+bt3eZsR0Dcjr8W/JEpX5UPOy1NpU+V8r+VDIzQHL/USofxDQ==}
     engines: {node: '>=22.0.0'}
     hasBin: true
-
-  glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -1934,10 +1903,6 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
-  is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
-
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -1949,10 +1914,6 @@ packages:
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
-
-  is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
 
   is-in-ci@1.0.0:
     resolution: {integrity: sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==}
@@ -1966,10 +1927,6 @@ packages:
   is-network-error@1.3.2:
     resolution: {integrity: sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==}
     engines: {node: '>=16'}
-
-  is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
@@ -2109,14 +2066,6 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
-  merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
-
-  micromatch@4.0.8:
-    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
-    engines: {node: '>=8.6'}
-
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
@@ -2147,11 +2096,6 @@ packages:
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
-
-  mkdirp@3.0.1:
-    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   mnemonist@0.39.8:
     resolution: {integrity: sha512-vyWo2K3fjrUw8YeeZ1zF0fy6Mu59RHokURlld8ymdUPjMlD9EC9ov1/YPqTgqRvUN9nTr3Gqfz29LYAmu0PHPQ==}
@@ -2319,10 +2263,6 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -2383,9 +2323,6 @@ packages:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
-  queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
@@ -2437,10 +2374,6 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
-  reusify@1.1.0:
-    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
   roarr@2.15.4:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
@@ -2453,9 +2386,6 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
-
-  run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -2655,10 +2585,6 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
-  to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
-
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
@@ -2764,8 +2690,8 @@ packages:
   tree-sitter@0.21.1:
     resolution: {integrity: sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==}
 
-  ts-morph@21.0.1:
-    resolution: {integrity: sha512-dbDtVdEAncKctzrVZ+Nr7kHpHkv+0JDJb2MjjpBaj8bFeCkePU9rHfMklmhuLFnpeq/EJZk2IhStY6NzqgjOkg==}
+  ts-morph@28.0.0:
+    resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3501,18 +3427,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nodelib/fs.scandir@2.1.5':
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      run-parallel: 1.2.0
-
-  '@nodelib/fs.stat@2.0.5': {}
-
-  '@nodelib/fs.walk@1.2.8':
-    dependencies:
-      '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.20.1
-
   '@opentelemetry/api@1.9.0': {}
 
   '@pinojs/redact@0.4.0': {}
@@ -3625,12 +3539,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@ts-morph/common@0.22.0':
+  '@ts-morph/common@0.29.0':
     dependencies:
-      fast-glob: 3.3.3
       minimatch: 10.2.5
-      mkdirp: 3.0.1
       path-browserify: 1.0.1
+      tinyglobby: 0.2.17
 
   '@turbo/darwin-64@2.9.16':
     optional: true
@@ -3829,10 +3742,6 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  braces@3.0.3:
-    dependencies:
-      fill-range: 7.1.1
-
   bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -3901,7 +3810,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  code-block-writer@12.0.0: {}
+  code-block-writer@13.0.3: {}
 
   code-excerpt@4.0.0:
     dependencies:
@@ -4158,29 +4067,13 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-glob@3.3.3:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
-
   fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.2: {}
 
-  fastq@1.20.1:
-    dependencies:
-      reusify: 1.1.0
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
-
-  fill-range@7.1.1:
-    dependencies:
-      to-regex-range: 5.0.1
 
   finalhandler@2.1.1:
     dependencies:
@@ -4290,10 +4183,6 @@ snapshots:
       - supports-color
       - tree_sitter
       - zod
-
-  glob-parent@5.1.2:
-    dependencies:
-      is-glob: 4.0.3
 
   glob@10.5.0:
     dependencies:
@@ -4449,8 +4338,6 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
-  is-extglob@2.1.1: {}
-
   is-fullwidth-code-point@3.0.0: {}
 
   is-fullwidth-code-point@4.0.0: {}
@@ -4459,17 +4346,11 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.6.0
 
-  is-glob@4.0.3:
-    dependencies:
-      is-extglob: 2.1.1
-
   is-in-ci@1.0.0: {}
 
   is-interactive@2.0.0: {}
 
   is-network-error@1.3.2: {}
-
-  is-number@7.0.0: {}
 
   is-promise@4.0.0: {}
 
@@ -4578,13 +4459,6 @@ snapshots:
 
   merge-descriptors@2.0.0: {}
 
-  merge2@1.4.1: {}
-
-  micromatch@4.0.8:
-    dependencies:
-      braces: 3.0.3
-      picomatch: 2.3.2
-
   mime-db@1.54.0: {}
 
   mime-types@3.0.2:
@@ -4606,8 +4480,6 @@ snapshots:
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.3
-
-  mkdirp@3.0.1: {}
 
   mnemonist@0.39.8:
     dependencies:
@@ -4757,8 +4629,6 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.2: {}
-
   picomatch@4.0.4: {}
 
   pino-abstract-transport@3.0.0:
@@ -4848,8 +4718,6 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
-  queue-microtask@1.2.3: {}
-
   quick-format-unescaped@4.0.4: {}
 
   range-parser@1.2.1: {}
@@ -4906,8 +4774,6 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  reusify@1.1.0: {}
-
   roarr@2.15.4:
     dependencies:
       boolean: 3.2.0
@@ -4957,10 +4823,6 @@ snapshots:
       path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
-
-  run-parallel@1.2.0:
-    dependencies:
-      queue-microtask: 1.2.3
 
   safe-buffer@5.1.2: {}
 
@@ -5194,10 +5056,6 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  to-regex-range@5.0.1:
-    dependencies:
-      is-number: 7.0.0
-
   toidentifier@1.0.1: {}
 
   tree-sitter-c-sharp@0.23.1(tree-sitter@0.21.1):
@@ -5289,10 +5147,10 @@ snapshots:
       node-addon-api: 8.8.0
       node-gyp-build: 4.8.4
 
-  ts-morph@21.0.1:
+  ts-morph@28.0.0:
     dependencies:
-      '@ts-morph/common': 0.22.0
-      code-block-writer: 12.0.0
+      '@ts-morph/common': 0.29.0
+      code-block-writer: 13.0.3
 
   tslib@2.8.1: {}
 


### PR DESCRIPTION
Closes #311

## Summary

Upgrade `ts-morph` `^21.0.1` -> `^28.0.0` in the root manifest and `packages/mcp-file`, regenerating `pnpm-lock.yaml` via `pnpm install` (no hand edits). ts-morph 28 bundles TypeScript 6.0 via `@ts-morph/common ~0.29.0`, aligned with the repo's `typescript ^6.0.3`. The only consumer of the ts-morph API is `packages/mcp-file/src/tools/get-ast.ts` (read-only AST extraction via dynamic `import('ts-morph')`).

No source change to `get-ast.ts` was required: typecheck and the new characterization test both pass unmodified against ts-morph 28.

## Breaking changes checked (v22 -> v28)

| Version | Breaking change | Affects us? | Verified by |
|---|---|---|---|
| 22.0.0 | TS 5.4; `Node.forgetDescendants()` now returns `void` | No — API not used | grep + typecheck |
| 23.0.0 | TS 5.5 engine bump | No API change in our surface | typecheck + smoke test |
| 24.0.0 | TS 5.6 engine bump | No API change in our surface | typecheck + smoke test |
| 25.0.0 | TS 5.7; removing the last named import/export no longer removes the parent declaration | No — `get-ast.ts` is read-only, never mutates imports/exports | code review |
| 26.0.0 | TS 5.8 engine bump | No API change in our surface | typecheck + smoke test |
| 27.0.0 | TS 5.9 engine bump | No API change in our surface | typecheck + smoke test |
| 28.0.0 | TS 6.0 engine bump | Residual behavioral risk: type-text rendering and numeric `jsx: 2` (`JsxEmit.React`) | smoke test asserts `Promise<string>` / `name: string` text + `JsxEmit.React === 2` runtime check |

Every ts-morph call in `get-ast.ts` (dynamic import, `new Project`, `addSourceFileAtPath`, `getImportDeclarations`/`getNamedImports`/`getNamespaceImport`/`getDefaultImport`/`getModuleSpecifierValue`, `getExportedDeclarations` `ReadonlyMap`, `getFunctions`/`getParameters`/`getType().getText()`/`getReturnType().getText()`/`isAsync`/`isExported`/`getBody`, `getClasses`/`getExtends`, `getInterfaces`/`getTypeAliases`, `getVariableDeclarations`/`getInitializer`/`SyntaxKind.ArrowFunction`, `getTypeNode`) is exercised by either typecheck (signature-level) or the new `get-ast.test.ts` (runtime behavior).

> Note on lint: `pnpm lint` was run per-file (`biome check packages/mcp-file/src/tools/get-ast.test.ts` — clean). The workspace-wide `pnpm lint` could not run in the agent's `.git/modules/.../worktrees` location because biome's `!!**/.git` ignore glob excludes every path under it; CI runs in a normal checkout where this is unaffected.

## GitNexus Impact Summary

- **Risk level**: LOW
- **Critical skeleton changes**: None to source. `packages/mcp-file/src/tools/get-ast.ts` (mcp-boundary critical path) was NOT modified — the only ts-morph consumer typechecks and behaves identically under v28. The same diff adds the matching `packages/mcp-file/src/tools/get-ast.test.ts` to satisfy the mcp-boundary test-pairing contract and harden the regression net. Manifests (`package.json`, `packages/mcp-file/package.json`) and `pnpm-lock.yaml` are the only other changes (non-symbol).
- **GitNexus impact**: `gitnexus impact({ target: "getAST", direction: "upstream" })` returned LOW risk — 1 direct caller (`packages/mcp-file/src/server.ts` wiring), 0 processes affected, 0 modules affected. `gitnexus detect_changes` reported 1 changed file, 0 changed symbols, 0 affected processes, risk LOW — confirming no production symbol changed (bump touches manifests/lockfile plus the new test file only).
- **Verification**: `pnpm --filter @frontagent/mcp-file typecheck` PASS; `pnpm --filter @frontagent/mcp-file test` 9 files / 101 tests PASS (incl. new 3-test get-ast smoke test); workspace `pnpm typecheck` 22/22 PASS; workspace `pnpm test` 22/22 PASS; `pnpm test:workflows` 29 PASS; `pnpm build:verify` PASS; `pnpm contract:local` PASS; runtime checks `SyntaxKind.ArrowFunction = 220` and `JsxEmit.React = 2`; lockfile resolves a single `ts-morph@28.0.0` (+ `@ts-morph/common@0.29.0`), no remaining `ts-morph@21`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
