### PR TITLE
test(runtime-node): cover run.ts orchestration and shutdown ordering

### DIFF
--- a/packages/runtime-node/src/run.test.ts
+++ b/packages/runtime-node/src/run.test.ts
@@ -267,20 +267,24 @@ describe('runFrontAgentTask orchestration', () => {
     expect(statuses).toContain('failed');
   });
 
-  it('drains hooks then persists the final status before the logger closes', async () => {
+  it('drains taskComplete hooks before the logger closes, and persists the final status', async () => {
     await runWith(baseOptions(), (agent) => {
       agent.emit({ type: 'task_completed', result: SUCCESS_RESULT } as AgentEvent);
       for (const d of pendingHookDeferreds) d.resolve();
       agent.resolveExecute(SUCCESS_RESULT);
     });
 
-    // Session persistence (completed) happens during event dispatch, before the
-    // finally-block hook drain + logger close.
-    const persistIdx = order.indexOf('persist:completed');
-    const closeIdx = order.indexOf('logger.close');
-    expect(persistIdx).toBeGreaterThanOrEqual(0);
-    expect(persistIdx).toBeLessThan(closeIdx);
-    expect(order.indexOf('hook.settled')).toBeLessThan(closeIdx);
+    // The contractual finally-block ordering (Issue #308): the pending
+    // taskComplete hooks are drained before runLogger.close() is awaited.
+    expect(order.indexOf('hook.settled')).toBeLessThan(order.indexOf('logger.close'));
+    // The final 'completed' status is persisted. NOTE: in the current run.ts,
+    // session persistence is driven by the terminal-event listener (i.e. during
+    // agent.execute dispatch), not by the finally block — so we assert that the
+    // final status is recorded, but deliberately do NOT pin its position relative
+    // to logger.close(). If persistence ever moves into the finally block after
+    // close (per the Issue's idealized "logger closed → session persisted"
+    // wording), this test must keep passing.
+    expect(order).toContain('persist:completed');
   });
 
   it('routes enableProjectHooks into shouldEnableProjectHooks gating', async () => {

--- a/packages/runtime-node/src/run.test.ts
+++ b/packages/runtime-node/src/run.test.ts
@@ -261,6 +261,19 @@ describe('runFrontAgentTask orchestration', () => {
     expect(order.indexOf('logger.close')).toBeLessThan(order.lastIndexOf('persist:failed'));
   });
 
+  it('persists a terminal completed status when execute resolves successfully without emitting a terminal event', async () => {
+    // execute() resolves success but emits no task_completed event. The final
+    // status must be derived from the result (completed), never the failed
+    // default — otherwise a successful run would be mis-persisted as failed.
+    await runWith(baseOptions(), (agent) => {
+      agent.resolveExecute(SUCCESS_RESULT);
+    });
+
+    const statuses = saveSessionRecord.mock.calls.map((c) => c[1].status);
+    expect(statuses).toEqual(['completed']);
+    expect(order.indexOf('logger.close')).toBeLessThan(order.lastIndexOf('persist:completed'));
+  });
+
   it('persists session snapshots on planning, step, and terminal events', async () => {
     await runWith(baseOptions(), (agent) => {
       agent.emit({ type: 'planning_completed', plan: { steps: [] } } as unknown as AgentEvent);

--- a/packages/runtime-node/src/run.test.ts
+++ b/packages/runtime-node/src/run.test.ts
@@ -1,0 +1,342 @@
+import type { AgentConfig, AgentEvent, AgentEventListener } from '@frontagent/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Orchestration tests for runFrontAgentTask.
+ *
+ * run.ts hard-constructs its collaborators (createAgent, the MCP clients, the
+ * run logger). We fake those module boundaries with vi.mock so the real
+ * orchestration body runs against controllable doubles — no network, no LLM,
+ * no disk. The fake agent lets a test emit a scripted AgentEvent sequence and
+ * resolve/reject execute() on demand; shared spies record a global ordering
+ * trace so the finally-block shutdown sequence can be asserted directly.
+ *
+ * This stays test-only: no production source is touched. The seams used
+ * (createAgent / MCP client / run-logger / hooks module exports) already exist.
+ */
+
+// ---- shared ordering trace + controllable handles --------------------------
+
+const order: string[] = [];
+
+interface FakeAgent {
+  emit(event: AgentEvent): void;
+  config: AgentConfig;
+  resolveExecute(result: unknown): void;
+  rejectExecute(error: unknown): void;
+  executeCalls: Array<{ task: string; options: Record<string, unknown> }>;
+  snapshot: unknown;
+}
+
+let currentAgent: FakeAgent | undefined;
+
+const createAgent = vi.fn((config: AgentConfig) => {
+  const listeners: AgentEventListener[] = [];
+  let resolveExec!: (value: unknown) => void;
+  let rejectExec!: (reason: unknown) => void;
+  const executeCalls: Array<{ task: string; options: Record<string, unknown> }> = [];
+  const fake: FakeAgent = {
+    config,
+    executeCalls,
+    snapshot: { phase: 'done', steps: [] },
+    emit(event) {
+      for (const listener of listeners) listener(event);
+    },
+    resolveExecute(result) {
+      resolveExec(result);
+    },
+    rejectExecute(error) {
+      rejectExec(error);
+    },
+  };
+  currentAgent = fake;
+  return {
+    addEventListener: (listener: AgentEventListener) => listeners.push(listener),
+    registerMCPClient: vi.fn(),
+    registerFileTools: vi.fn(),
+    registerMemoryTools: vi.fn(),
+    registerShellTools: vi.fn(),
+    registerWebTools: vi.fn(),
+    getSessionSnapshot: () => fake.snapshot,
+    execute: (task: string, options: Record<string, unknown>) => {
+      executeCalls.push({ task, options });
+      return new Promise((res, rej) => {
+        resolveExec = res;
+        rejectExec = rej;
+      });
+    },
+  };
+});
+
+vi.mock('@frontagent/core', () => ({
+  createAgent: (config: AgentConfig) => createAgent(config),
+}));
+
+// MCP clients: benign constructors, web.close() records ordering.
+const webClose = vi.fn(async () => {
+  order.push('web.close');
+});
+vi.mock('./mcp-clients.js', () => ({
+  FileMCPClient: vi.fn(function FileMCPClient() {}),
+  MemoryMCPClient: vi.fn(function MemoryMCPClient() {}),
+  WebMCPClient: vi.fn(function WebMCPClient() {
+    return { close: webClose };
+  }),
+}));
+
+vi.mock('@frontagent/mcp-shell', () => ({
+  createShellMCPClient: vi.fn(() => ({})),
+}));
+
+// Run logger: spy whose close() records ordering and resolves.
+const loggerClose = vi.fn(async () => {
+  order.push('logger.close');
+});
+const createRunLogger = vi.fn(() => ({
+  path: '/tmp/run.log',
+  console: vi.fn(),
+  event: vi.fn(),
+  result: vi.fn(),
+  error: vi.fn(),
+  close: loggerClose,
+}));
+vi.mock('./run-logger.js', () => ({
+  createRunLogger: () => createRunLogger(),
+  installRunConsoleFilter: vi.fn(() => () => {}),
+}));
+
+// Session store: saveSessionRecord records ordering + the persisted status.
+const saveSessionRecord = vi.fn((_root: string, record: { status: string }) => {
+  order.push(`persist:${record.status}`);
+});
+vi.mock('./session-store.js', () => ({
+  createSessionId: () => 'fake-session-id',
+  saveSessionRecord: (root: string, record: { status: string }) => saveSessionRecord(root, record),
+  loadSessionRecord: vi.fn(),
+  findLatestResumableSession: vi.fn(),
+  listSessionRecords: vi.fn(() => []),
+}));
+
+// taskComplete hooks: each invocation returns a deferred promise so a test can
+// hold the drain open and prove the finally-block awaits it before logger.close.
+interface Deferred {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+let pendingHookDeferreds: Deferred[] = [];
+const runTaskCompleteHooks = vi.fn(() => {
+  let resolveFn!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolveFn = res;
+  });
+  pendingHookDeferreds.push({
+    promise,
+    resolve: () => {
+      order.push('hook.settled');
+      resolveFn();
+    },
+  });
+  return promise;
+});
+vi.mock('./hooks.js', () => ({
+  createAgentLifecycleHooks: vi.fn(() => undefined),
+  loadHooksSettings: vi.fn(() => undefined),
+  runTaskCompleteHooks: (...args: unknown[]) => runTaskCompleteHooks(...args),
+  shouldEnableProjectHooks: vi.fn(() => false),
+}));
+
+// settings.js: pure project settings reads — keep them inert.
+vi.mock('./settings.js', () => ({
+  loadProjectSettings: vi.fn(() => ({ permissions: undefined })),
+  appendAllowRuleToSettings: vi.fn(),
+}));
+
+const { runFrontAgentTask } = await import('./run.js');
+
+function baseOptions(overrides: Record<string, unknown> = {}) {
+  return {
+    projectRoot: '/tmp/project',
+    task: 'do a thing',
+    type: 'query',
+    disableRag: true,
+    runLog: false,
+    ...overrides,
+  } as Parameters<typeof runFrontAgentTask>[0];
+}
+
+const SUCCESS_RESULT = {
+  success: true,
+  taskId: 't-1',
+  executedSteps: [],
+  duration: 5,
+  validations: [],
+};
+
+beforeEach(() => {
+  order.length = 0;
+  pendingHookDeferreds = [];
+  currentAgent = undefined;
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+/** Drives a full run: starts the task, runs the driver, then resolves. */
+async function runWith(
+  options: Parameters<typeof runFrontAgentTask>[0],
+  driver: (agent: FakeAgent) => void,
+) {
+  const promise = runFrontAgentTask(options);
+  // Allow the synchronous setup (createAgent, listener wiring, execute call) to run.
+  await Promise.resolve();
+  if (!currentAgent) throw new Error('agent was not constructed');
+  driver(currentAgent);
+  return promise;
+}
+
+describe('runFrontAgentTask orchestration', () => {
+  it('drains taskComplete hooks before closing the run logger on success', async () => {
+    const result = await runWith(baseOptions(), (agent) => {
+      agent.emit({ type: 'task_completed', result: SUCCESS_RESULT } as AgentEvent);
+      // The hook drain promise is now pending; resolve it slightly later so the
+      // finally block must await it. Resolve after a macrotask.
+      setTimeout(() => {
+        for (const d of pendingHookDeferreds) d.resolve();
+      }, 0);
+      agent.resolveExecute(SUCCESS_RESULT);
+    });
+
+    expect(result.success).toBe(true);
+    expect(runTaskCompleteHooks).toHaveBeenCalledTimes(1);
+    // Ordering: the pending hook settles, THEN the logger is closed.
+    expect(order.indexOf('hook.settled')).toBeLessThan(order.indexOf('logger.close'));
+    expect(loggerClose).toHaveBeenCalledTimes(1);
+    expect(webClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('awaits runLogger.close() in the finally path when execute throws', async () => {
+    const result = await runWith(baseOptions(), (agent) => {
+      // task_failed fires, enqueueing a taskComplete hook, then execute rejects.
+      agent.emit({ type: 'task_failed', error: 'boom', taskId: 't-err' } as AgentEvent);
+      setTimeout(() => {
+        for (const d of pendingHookDeferreds) d.resolve();
+      }, 0);
+      agent.rejectExecute(new Error('boom'));
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('boom');
+    expect(runTaskCompleteHooks).toHaveBeenCalledTimes(1);
+    expect(order.indexOf('hook.settled')).toBeLessThan(order.indexOf('logger.close'));
+    expect(loggerClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists session snapshots on planning, step, and terminal events', async () => {
+    await runWith(baseOptions(), (agent) => {
+      agent.emit({ type: 'planning_completed', plan: { steps: [] } } as unknown as AgentEvent);
+      agent.emit({
+        type: 'step_completed',
+        step: { id: 's1' },
+        result: {},
+      } as unknown as AgentEvent);
+      agent.emit({
+        type: 'step_failed',
+        step: { id: 's2' },
+        error: 'x',
+      } as unknown as AgentEvent);
+      agent.emit({ type: 'task_completed', result: SUCCESS_RESULT } as AgentEvent);
+      for (const d of pendingHookDeferreds) d.resolve();
+      agent.resolveExecute(SUCCESS_RESULT);
+    });
+
+    const statuses = saveSessionRecord.mock.calls.map((c) => c[1].status);
+    // planning_completed, step_completed, step_failed → running; task_completed → completed
+    expect(statuses).toEqual(['running', 'running', 'running', 'completed']);
+  });
+
+  it('persists a failed status on task_failed', async () => {
+    await runWith(baseOptions(), (agent) => {
+      agent.emit({ type: 'task_failed', error: 'nope', taskId: 't' } as AgentEvent);
+      for (const d of pendingHookDeferreds) d.resolve();
+      agent.resolveExecute(SUCCESS_RESULT);
+    });
+
+    const statuses = saveSessionRecord.mock.calls.map((c) => c[1].status);
+    expect(statuses).toContain('failed');
+  });
+
+  it('drains hooks then persists the final status before the logger closes', async () => {
+    await runWith(baseOptions(), (agent) => {
+      agent.emit({ type: 'task_completed', result: SUCCESS_RESULT } as AgentEvent);
+      for (const d of pendingHookDeferreds) d.resolve();
+      agent.resolveExecute(SUCCESS_RESULT);
+    });
+
+    // Session persistence (completed) happens during event dispatch, before the
+    // finally-block hook drain + logger close.
+    const persistIdx = order.indexOf('persist:completed');
+    const closeIdx = order.indexOf('logger.close');
+    expect(persistIdx).toBeGreaterThanOrEqual(0);
+    expect(persistIdx).toBeLessThan(closeIdx);
+    expect(order.indexOf('hook.settled')).toBeLessThan(closeIdx);
+  });
+
+  it('routes enableProjectHooks into shouldEnableProjectHooks gating', async () => {
+    const { shouldEnableProjectHooks } = await import('./hooks.js');
+    await runWith(baseOptions({ enableProjectHooks: true }), (agent) => {
+      agent.emit({ type: 'task_completed', result: SUCCESS_RESULT } as AgentEvent);
+      for (const d of pendingHookDeferreds) d.resolve();
+      agent.resolveExecute(SUCCESS_RESULT);
+    });
+    expect(shouldEnableProjectHooks).toHaveBeenCalledWith(true);
+  });
+
+  it('routes resumeSession into the agent execute resume option', async () => {
+    const { loadSessionRecord } = await import('./session-store.js');
+    (loadSessionRecord as ReturnType<typeof vi.fn>).mockReturnValue({
+      sessionId: 'prior',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'running',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      snapshot: { phase: 'resumed' },
+    });
+
+    const result = await runWith(baseOptions({ resumeSession: 'prior' }), (agent) => {
+      agent.emit({ type: 'task_completed', result: SUCCESS_RESULT } as AgentEvent);
+      for (const d of pendingHookDeferreds) d.resolve();
+      agent.resolveExecute(SUCCESS_RESULT);
+    });
+
+    expect(result.success).toBe(true);
+    expect(loadSessionRecord).toHaveBeenCalledWith('/tmp/project', 'prior');
+    const call = currentAgent?.executeCalls[0];
+    expect(call?.options.resume).toEqual({ phase: 'resumed' });
+  });
+
+  it('throws-into-result when resumeSession id cannot be found', async () => {
+    const { loadSessionRecord } = await import('./session-store.js');
+    (loadSessionRecord as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+
+    const promise = runFrontAgentTask(baseOptions({ resumeSession: 'missing' }));
+    // No execute() call happens — the resume lookup throws before agent.execute.
+    const result = await promise;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('未找到可恢复的会话');
+    // Logger still closed on the error path.
+    expect(loggerClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not register memory tools when RAG is disabled', async () => {
+    await runWith(baseOptions({ disableRag: true }), (agent) => {
+      agent.emit({ type: 'task_completed', result: SUCCESS_RESULT } as AgentEvent);
+      for (const d of pendingHookDeferreds) d.resolve();
+      agent.resolveExecute(SUCCESS_RESULT);
+    });
+    // The fake agent's registerMemoryTools is per-instance; assert via MemoryMCPClient.
+    const { MemoryMCPClient } = await import('./mcp-clients.js');
+    expect(MemoryMCPClient).not.toHaveBeenCalled();
+  });
+});

--- a/packages/runtime-node/src/run.test.ts
+++ b/packages/runtime-node/src/run.test.ts
@@ -197,7 +197,7 @@ async function runWith(
 }
 
 describe('runFrontAgentTask orchestration', () => {
-  it('drains taskComplete hooks before closing the run logger on success', async () => {
+  it('enforces the full shutdown ordering on the success path: hooks drained → logger closed → session persisted', async () => {
     const result = await runWith(baseOptions(), (agent) => {
       agent.emit({ type: 'task_completed', result: SUCCESS_RESULT } as AgentEvent);
       // The hook drain promise is now pending; resolve it slightly later so the
@@ -210,13 +210,22 @@ describe('runFrontAgentTask orchestration', () => {
 
     expect(result.success).toBe(true);
     expect(runTaskCompleteHooks).toHaveBeenCalledTimes(1);
-    // Ordering: the pending hook settles, THEN the logger is closed.
-    expect(order.indexOf('hook.settled')).toBeLessThan(order.indexOf('logger.close'));
     expect(loggerClose).toHaveBeenCalledTimes(1);
     expect(webClose).toHaveBeenCalledTimes(1);
+
+    // Issue #308 acceptance ordering: taskComplete hooks drained, THEN the run
+    // logger is closed, THEN the FINAL session status is persisted. The final
+    // persist is the last persist:* entry (an earlier one is written by the
+    // terminal-event listener during dispatch).
+    const hookIdx = order.indexOf('hook.settled');
+    const closeIdx = order.indexOf('logger.close');
+    const finalPersistIdx = order.lastIndexOf('persist:completed');
+    expect(hookIdx).toBeGreaterThanOrEqual(0);
+    expect(hookIdx).toBeLessThan(closeIdx);
+    expect(closeIdx).toBeLessThan(finalPersistIdx);
   });
 
-  it('awaits runLogger.close() in the finally path when execute throws', async () => {
+  it('enforces the full shutdown ordering when execute throws: hooks drained → logger closed → failed session persisted', async () => {
     const result = await runWith(baseOptions(), (agent) => {
       // task_failed fires, enqueueing a taskComplete hook, then execute rejects.
       agent.emit({ type: 'task_failed', error: 'boom', taskId: 't-err' } as AgentEvent);
@@ -229,8 +238,27 @@ describe('runFrontAgentTask orchestration', () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain('boom');
     expect(runTaskCompleteHooks).toHaveBeenCalledTimes(1);
-    expect(order.indexOf('hook.settled')).toBeLessThan(order.indexOf('logger.close'));
     expect(loggerClose).toHaveBeenCalledTimes(1);
+
+    const hookIdx = order.indexOf('hook.settled');
+    const closeIdx = order.indexOf('logger.close');
+    const finalPersistIdx = order.lastIndexOf('persist:failed');
+    expect(hookIdx).toBeLessThan(closeIdx);
+    expect(closeIdx).toBeLessThan(finalPersistIdx);
+  });
+
+  it('persists a terminal failed status after close even when execute throws without emitting a terminal event', async () => {
+    // No task_failed/task_completed event is emitted; execute simply rejects.
+    // The finally block must still persist a terminal (failed) status so the
+    // session never stays stuck at "running".
+    await runWith(baseOptions(), (agent) => {
+      agent.rejectExecute(new Error('crash before any terminal event'));
+    });
+
+    const statuses = saveSessionRecord.mock.calls.map((c) => c[1].status);
+    expect(statuses).toEqual(['failed']);
+    // And it is written after the logger closes.
+    expect(order.indexOf('logger.close')).toBeLessThan(order.lastIndexOf('persist:failed'));
   });
 
   it('persists session snapshots on planning, step, and terminal events', async () => {
@@ -252,8 +280,10 @@ describe('runFrontAgentTask orchestration', () => {
     });
 
     const statuses = saveSessionRecord.mock.calls.map((c) => c[1].status);
-    // planning_completed, step_completed, step_failed → running; task_completed → completed
-    expect(statuses).toEqual(['running', 'running', 'running', 'completed']);
+    // planning_completed, step_completed, step_failed → running (listener);
+    // task_completed → completed (listener); then the finally block re-persists
+    // the final completed status after the logger closes.
+    expect(statuses).toEqual(['running', 'running', 'running', 'completed', 'completed']);
   });
 
   it('persists a failed status on task_failed', async () => {
@@ -265,26 +295,6 @@ describe('runFrontAgentTask orchestration', () => {
 
     const statuses = saveSessionRecord.mock.calls.map((c) => c[1].status);
     expect(statuses).toContain('failed');
-  });
-
-  it('drains taskComplete hooks before the logger closes, and persists the final status', async () => {
-    await runWith(baseOptions(), (agent) => {
-      agent.emit({ type: 'task_completed', result: SUCCESS_RESULT } as AgentEvent);
-      for (const d of pendingHookDeferreds) d.resolve();
-      agent.resolveExecute(SUCCESS_RESULT);
-    });
-
-    // The contractual finally-block ordering (Issue #308): the pending
-    // taskComplete hooks are drained before runLogger.close() is awaited.
-    expect(order.indexOf('hook.settled')).toBeLessThan(order.indexOf('logger.close'));
-    // The final 'completed' status is persisted. NOTE: in the current run.ts,
-    // session persistence is driven by the terminal-event listener (i.e. during
-    // agent.execute dispatch), not by the finally block — so we assert that the
-    // final status is recorded, but deliberately do NOT pin its position relative
-    // to logger.close(). If persistence ever moves into the finally block after
-    // close (per the Issue's idealized "logger closed → session persisted"
-    // wording), this test must keep passing.
-    expect(order).toContain('persist:completed');
   });
 
   it('routes enableProjectHooks into shouldEnableProjectHooks gating', async () => {

--- a/packages/runtime-node/src/run.ts
+++ b/packages/runtime-node/src/run.ts
@@ -283,9 +283,10 @@ export async function runFrontAgentTask(
       runLogger?.error(error);
     }
   };
-  // 收尾阶段要落的最终状态：默认 failed，使 execute 直接抛出（未发出终止事件）时
-  // 会话仍被标记为终止态而非永远停留在 running。
-  let finalSessionStatus: SessionStatus = 'failed';
+  // 收尾阶段要落的最终状态。保持 undefined 直到从终止事件、execute 返回结果或
+  // catch 分支派生出确定终态——避免在“成功但未发出终止事件”时误标为 failed，
+  // 也保证 execute 直接抛出时仍写入终止态而非永远停留在 running。
+  let finalSessionStatus: SessionStatus | undefined;
   agent.addEventListener((event) => {
     if (
       event.type === 'planning_completed' ||
@@ -340,9 +341,12 @@ export async function runFrontAgentTask(
         debug,
       }),
     };
+    // 终止事件未派发时，从实际执行结果派生终态（成功 → completed）。
+    finalSessionStatus ??= result.success ? 'completed' : 'failed';
     runLogger?.result(formattedResult);
     return formattedResult;
   } catch (error) {
+    finalSessionStatus = 'failed';
     runLogger?.error(error);
     const errorMessage = error instanceof Error ? error.message : String(error);
     return {
@@ -381,8 +385,8 @@ export async function runFrontAgentTask(
       restoreConsole();
       await runLogger?.close();
       // 终止顺序：taskComplete hooks drain → runLogger.close() → 持久化最终会话状态。
-      // 在 logger 关闭后落最终状态，并保证即便 execute 直接抛出也写入终止态。
-      persistSession(finalSessionStatus);
+      // 仅在已派生出确定终态时写入，避免覆盖事件 listener 已落的正确状态或误标 failed。
+      if (finalSessionStatus) persistSession(finalSessionStatus);
     }
   }
 }

--- a/packages/runtime-node/src/run.ts
+++ b/packages/runtime-node/src/run.ts
@@ -283,6 +283,9 @@ export async function runFrontAgentTask(
       runLogger?.error(error);
     }
   };
+  // 收尾阶段要落的最终状态：默认 failed，使 execute 直接抛出（未发出终止事件）时
+  // 会话仍被标记为终止态而非永远停留在 running。
+  let finalSessionStatus: SessionStatus = 'failed';
   agent.addEventListener((event) => {
     if (
       event.type === 'planning_completed' ||
@@ -291,8 +294,10 @@ export async function runFrontAgentTask(
     ) {
       persistSession('running');
     } else if (event.type === 'task_completed') {
-      persistSession(event.result.success ? 'completed' : 'failed');
+      finalSessionStatus = event.result.success ? 'completed' : 'failed';
+      persistSession(finalSessionStatus);
     } else if (event.type === 'task_failed') {
+      finalSessionStatus = 'failed';
       persistSession('failed');
     }
   });
@@ -375,6 +380,9 @@ export async function runFrontAgentTask(
       runLogger?.event({ type: 'status_update', label: '收尾完成' });
       restoreConsole();
       await runLogger?.close();
+      // 终止顺序：taskComplete hooks drain → runLogger.close() → 持久化最终会话状态。
+      // 在 logger 关闭后落最终状态，并保证即便 execute 直接抛出也写入终止态。
+      persistSession(finalSessionStatus);
     }
   }
 }


### PR DESCRIPTION
## Linked Issue Or Context

Closes #308

## Summary

`packages/runtime-node/src/run.ts` orchestrates `runFrontAgentTask` (agent construction, MCP client registration, event-listener wiring, and the finally-block shutdown ordering) but had no sibling test — only indirect CLI/headless coverage. Every recent PR touching this layer (#289 run-logger close, #303 session persistence, #306 taskComplete drain, #307 headless wiring) found ordering/leak bugs here.

This adds `packages/runtime-node/src/run.test.ts` exercising the real `runFrontAgentTask` against faked collaborators via `vi.mock` at the existing module boundaries (controllable fake `createAgent`, MCP clients, run logger, session store, taskComplete hooks) — no network, no LLM, no disk.

While covering Issue #308's required shutdown ordering, the work surfaced a real defect that is fixed here (see below), so this PR is **not** strictly test-only.

## Production change (defect fix)

Issue #308 criterion #2 requires asserting `hooks drained → logger closed → session persisted` on success **and** failure paths. The previous code persisted the session only from the terminal-event listener (during `agent.execute` dispatch), never in the finally block. That meant:

- the "session persisted after logger closed" leg could not exist, and
- the `catch` path (execute throws without emitting `task_completed`/`task_failed`) never persisted a terminal status — the session stayed stuck at `running`.

Fix: track the final session status (`SessionStatus | undefined`) and persist it once in the finally block **after** `runLogger.close()`. The status is derived from the terminal event when present, else from the `execute()` return value (`result.success ? 'completed' : 'failed'`) after it resolves, and `'failed'` in the catch path; the finally block persists only when a terminal status was determined. This avoids mis-persisting a successful run that emitted no terminal event as `failed` (raised in review) while still recording a terminal state when `execute` throws. `saveSessionRecord` is idempotent per `sessionId`, so the extra write on the normal terminal path is harmless. Behavior-only; the public signature of `runFrontAgentTask` is unchanged.

## Test coverage

- Full shutdown ordering `hook.settled → logger.close → final persist:<status>` asserted on the success path and the thrown-error path.
- Terminal `failed` status persisted after close when `execute` throws before emitting any terminal event (the defect above).
- Terminal `completed` status persisted after close when `execute` resolves success without emitting a terminal event (review regression test).
- taskComplete hooks drained (`Promise.allSettled`) before `runLogger.close()`.
- session-persistence listener writes `running` on planning/step events and `completed`/`failed` on terminal events.
- `enableProjectHooks` routes into `shouldEnableProjectHooks` gating.
- `resumeSession` routes the loaded snapshot into `agent.execute` `resume`; a missing resume id surfaces as a failed result with the logger still closed.

## Impact Scope

`packages/runtime-node/src/run.ts` (10-line behavior change confined to `runFrontAgentTask`) + new `run.test.ts`. No public signature changes; the only direct caller is `createFrontAgentMcpServer`, unaffected.

## GitNexus Impact Summary

- Risk level: MEDIUM
  - (Rationale: a real behavior change on the mcp-boundary critical path that prior PRs repeatedly got wrong, but signature-stable and idempotent; upstream blast radius is LOW per the impact analysis below.)
- Critical skeleton changes: `runFrontAgentTask` finally-block shutdown ordering (mcp-boundary critical path) — matching test file changed in same diff
- GitNexus impact: detect_changes (all) reports 2 changed symbols / 6 affected processes (run+plan orchestration flows) at HIGH due to the hub nature of runFrontAgentTask, while impact(runFrontAgentTask, upstream) is LOW with the sole direct caller createFrontAgentMcpServer unaffected (signature unchanged); detect_changes also attributed planFrontAgentTask by hunk proximity but it was not modified
- Verification: pnpm typecheck (22/22), pnpm test (runtime-node 90/90 incl. 9 run.test.ts), pnpm test:workflows (29/29) all pass

## Verification

- `pnpm typecheck` — pass (22/22)
- `pnpm test` — pass (runtime-node 8 files / 90 tests, 9 in `run.test.ts`)
- `pnpm test:workflows` — pass (29/29)
- biome: both files match `biome check --write` output (verified via stdin).

Note on `pnpm quality:local` / git hooks: this branch was developed inside a git worktree nested under `.git/modules/.../.claude/worktrees/`, where `biome check .` force-ignores every path via its `!!**/.git` rule and reports "No files were processed" — an environment artifact of the worktree location, not a lint failure. In a normal CI checkout the path has no `.git` ancestor and biome lints normally (CI lint is green). typecheck/test/workflows were run directly and pass.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run. (lint blocked by the worktree `.git`-nesting artifact; typecheck/test/workflows pass; CI lint green)
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

