### PR TITLE
fix(core): migrate ai SDK to v5 line to clear GHSA-rwvc-j5jr-mgvh

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,15 +19,15 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^1.2.12",
-    "@ai-sdk/openai": "^1.3.24",
+    "@ai-sdk/anthropic": "^2.0.81",
+    "@ai-sdk/openai": "^2.0.106",
     "@frontagent/hallucination-guard": "workspace:*",
     "@frontagent/sdd": "workspace:*",
     "@frontagent/shared": "workspace:*",
     "@langchain/core": "^1.1.47",
     "@langchain/langgraph": "^1.3.2",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "ai": "^4.3.19",
+    "ai": "^5.0.199",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/packages/core/src/llm/llm-service.test.ts
+++ b/packages/core/src/llm/llm-service.test.ts
@@ -1,7 +1,40 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { z } from 'zod';
 import type { LLMConfig } from '../types.js';
 import { LLMService, normalizeProviderBaseURL } from './llm-service.js';
+
+const sdkMocks = vi.hoisted(() => {
+  const openaiChat = vi.fn(() => ({ modelId: 'mock-openai-chat' }));
+  const openaiProvider = Object.assign(
+    vi.fn(() => ({ modelId: 'mock-openai-default' })),
+    { chat: openaiChat },
+  );
+  const anthropicProvider = vi.fn(() => ({ modelId: 'mock-anthropic' }));
+  return {
+    generateText: vi.fn(),
+    streamText: vi.fn(),
+    generateObject: vi.fn(),
+    openaiChat,
+    openaiProvider,
+    createOpenAI: vi.fn(() => openaiProvider),
+    anthropicProvider,
+    createAnthropic: vi.fn(() => anthropicProvider),
+  };
+});
+
+vi.mock('ai', () => ({
+  generateText: sdkMocks.generateText,
+  streamText: sdkMocks.streamText,
+  generateObject: sdkMocks.generateObject,
+}));
+
+vi.mock('@ai-sdk/openai', () => ({
+  createOpenAI: sdkMocks.createOpenAI,
+}));
+
+vi.mock('@ai-sdk/anthropic', () => ({
+  createAnthropic: sdkMocks.createAnthropic,
+}));
 
 describe('normalizeProviderBaseURL', () => {
   it('returns undefined for undefined input', () => {
@@ -200,5 +233,121 @@ describe('LLMService', () => {
       expect(config.temperature).toBe(0.5);
       expect(config.model).toBe('gpt-4');
     });
+  });
+});
+
+describe('LLMService v5 SDK boundary', () => {
+  const envKeys = [
+    'MODEL',
+    'BASE_URL',
+    'API_KEY',
+    'OPENAI_BASE_URL',
+    'ANTHROPIC_BASE_URL',
+    'OPENAI_API_KEY',
+    'ANTHROPIC_API_KEY',
+  ];
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    savedEnv = {};
+    for (const key of envKeys) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+  });
+
+  function createDirectService(extra: Partial<LLMConfig> = {}): LLMService {
+    return new LLMService({
+      provider: 'openai',
+      model: 'gpt-4',
+      apiKey: 'test-key',
+      ...extra,
+    });
+  }
+
+  it('creates OpenAI models via openai.chat() to keep Chat Completions behavior', () => {
+    createDirectService();
+    expect(sdkMocks.createOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: 'test-key' }),
+    );
+    expect(sdkMocks.openaiChat).toHaveBeenCalledWith('gpt-4');
+    expect(sdkMocks.openaiProvider).not.toHaveBeenCalled();
+  });
+
+  it('creates Anthropic models with beta headers preserved', () => {
+    createDirectService({ provider: 'anthropic', model: 'claude-sonnet-4-5' });
+    expect(sdkMocks.createAnthropic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'test-key',
+        headers: { 'anthropic-beta': 'advanced-tool-use-2025-11-20' },
+      }),
+    );
+    expect(sdkMocks.anthropicProvider).toHaveBeenCalledWith('claude-sonnet-4-5');
+  });
+
+  it('passes maxOutputTokens (not maxTokens) to generateText', async () => {
+    sdkMocks.generateText.mockResolvedValue({ text: 'ok' });
+    const service = createDirectService();
+
+    const result = await service.generateText({
+      messages: [{ role: 'user', content: 'hi' }],
+      maxTokens: 1234,
+    });
+
+    expect(result).toBe('ok');
+    const callArgs = sdkMocks.generateText.mock.calls[0][0];
+    expect(callArgs.maxOutputTokens).toBe(1234);
+    expect(callArgs).not.toHaveProperty('maxTokens');
+  });
+
+  it('passes maxOutputTokens to streamText and yields textStream chunks', async () => {
+    sdkMocks.streamText.mockReturnValue({
+      textStream: (async function* () {
+        yield 'hello ';
+        yield 'world';
+      })(),
+    });
+    const service = createDirectService();
+
+    const chunks: string[] = [];
+    for await (const chunk of service.streamText({
+      messages: [{ role: 'user', content: 'hi' }],
+      maxTokens: 256,
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(['hello ', 'world']);
+    const callArgs = sdkMocks.streamText.mock.calls[0][0];
+    expect(callArgs.maxOutputTokens).toBe(256);
+    expect(callArgs).not.toHaveProperty('maxTokens');
+  });
+
+  it('passes maxOutputTokens to generateObject and returns the object', async () => {
+    sdkMocks.generateObject.mockResolvedValue({ object: { answer: 42 } });
+    const schema = { parse: (v: unknown) => v } as unknown as z.ZodType<{ answer: number }>;
+    const service = createDirectService();
+
+    const result = await service.generateObject({
+      messages: [{ role: 'user', content: 'hi' }],
+      schema,
+      maxTokens: 512,
+    });
+
+    expect(result).toEqual({ answer: 42 });
+    const callArgs = sdkMocks.generateObject.mock.calls[0][0];
+    expect(callArgs.maxOutputTokens).toBe(512);
+    expect(callArgs).not.toHaveProperty('maxTokens');
   });
 });

--- a/packages/core/src/llm/llm-service.ts
+++ b/packages/core/src/llm/llm-service.ts
@@ -1,7 +1,13 @@
 import { type AnthropicProviderSettings, createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
 import { logger } from '@frontagent/shared';
-import { type CoreMessage, generateObject, generateText, type LanguageModel, streamText } from 'ai';
+import {
+  generateObject,
+  generateText,
+  type LanguageModel,
+  type ModelMessage,
+  streamText,
+} from 'ai';
 import type { z } from 'zod';
 import type { LLMConfig, Message } from '../types.js';
 import {
@@ -122,7 +128,10 @@ export class LLMService {
     switch (provider) {
       case 'openai': {
         const openai = createOpenAI({ apiKey: key, baseURL: endpoint });
-        return openai(modelName);
+        // AI SDK v5: the callable provider defaults to the Responses API.
+        // Use .chat() explicitly to keep Chat Completions behavior for
+        // OpenAI-compatible baseURLs (normalizeProviderBaseURL strips /chat/completions).
+        return openai.chat(modelName);
       }
       case 'anthropic': {
         const betaHeaders: string[] = [];
@@ -148,7 +157,7 @@ export class LLMService {
     }
   }
 
-  private convertMessages(messages: Message[]): CoreMessage[] {
+  private convertMessages(messages: Message[]): ModelMessage[] {
     return messages.map((msg) => ({
       role: msg.role as 'system' | 'user' | 'assistant',
       content: msg.content,
@@ -162,7 +171,7 @@ export class LLMService {
     topK?: number;
   }) {
     return {
-      maxTokens: options.maxTokens ?? this.config.maxTokens ?? 4096,
+      maxOutputTokens: options.maxTokens ?? this.config.maxTokens ?? 4096,
       temperature: options.temperature ?? this.config.temperature ?? 0.7,
       topP: options.topP ?? this.config.topP,
       topK: options.topK ?? this.config.topK,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,11 +133,11 @@ importers:
   packages/core:
     dependencies:
       '@ai-sdk/anthropic':
-        specifier: ^1.2.12
-        version: 1.2.12(zod@3.25.76)
+        specifier: ^2.0.81
+        version: 2.0.82(zod@3.25.76)
       '@ai-sdk/openai':
-        specifier: ^1.3.24
-        version: 1.3.24(zod@3.25.76)
+        specifier: ^2.0.106
+        version: 2.0.107(zod@3.25.76)
       '@frontagent/hallucination-guard':
         specifier: workspace:*
         version: link:../hallucination-guard
@@ -157,8 +157,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       ai:
-        specifier: ^4.3.19
-        version: 4.3.19(react@18.3.1)(zod@3.25.76)
+        specifier: ^5.0.199
+        version: 5.0.200(zod@3.25.76)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -350,43 +350,33 @@ importers:
 
 packages:
 
-  '@ai-sdk/anthropic@1.2.12':
-    resolution: {integrity: sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==}
+  '@ai-sdk/anthropic@2.0.82':
+    resolution: {integrity: sha512-bMiG4rUwdgQ6+E2klFSaJ1BHO65zCrfHRqC/hkdhA19tmx8FqLoAmXpx92dcWsADFMtAzQd3Q9kRJ8zk4/PpnA==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.0.0
+      zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@1.3.24':
-    resolution: {integrity: sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==}
+  '@ai-sdk/gateway@2.0.99':
+    resolution: {integrity: sha512-ygKz4ov2B7BqG9KiFZK1AGBtMZIIPcSA2DTz/4TjIQPhLzFF40Q4/jSa5gzg3pAOranB1OvKSqL7VEP5m6cfWg==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.0.0
+      zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@2.2.8':
-    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
+  '@ai-sdk/openai@2.0.107':
+    resolution: {integrity: sha512-cWU7w1c0FhDiZBFfi0rZO+5qYlD+rCDE8Il1X0P6E7wejtghgyW2I6ihPNTXfrLT2J8DVeXnrwQMFfxfVNzstA==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.23.8
+      zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@1.1.3':
-    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
-    engines: {node: '>=18'}
-
-  '@ai-sdk/react@1.2.12':
-    resolution: {integrity: sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==}
+  '@ai-sdk/provider-utils@3.0.26':
+    resolution: {integrity: sha512-dNciNI4knep6z3cqDNng7yORCcBnEDBHZYj8rJLcLn9pLzEtNVkf6WLg9HR6AnVDDRxHsUeGAEqyF8M+FAtRgg==}
     engines: {node: '>=18'}
     peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      zod:
-        optional: true
+      zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/ui-utils@1.2.11':
-    resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
+  '@ai-sdk/provider@2.0.3':
+    resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
     engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.23.8
 
   '@alcalzone/ansi-tokenize@0.1.3':
     resolution: {integrity: sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==}
@@ -447,9 +437,6 @@ packages:
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
-
-  '@dmsnell/diff-match-patch@1.1.0':
-    resolution: {integrity: sha512-yejLPmM5pjsGvxS9gXablUSbInW7H976c/FJ4iQxWIm7/38xBySRemTPDe34lhg1gVLbJntX0+sH0jYfU+PN9A==}
 
   '@emnapi/runtime@1.11.0':
     resolution: {integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==}
@@ -1254,6 +1241,10 @@ packages:
   '@types/vscode@1.120.0':
     resolution: {integrity: sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==}
 
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
+
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
@@ -1299,15 +1290,11 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ai@4.3.19:
-    resolution: {integrity: sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==}
+  ai@5.0.200:
+    resolution: {integrity: sha512-2CEpePqUQKXl7nQH3AMUcotFV6ZeSm7IPYLNsqRQkjn0hCYQxXyRVj8agYIa0g3XqAFy5rfw385Drj+IwUEt8g==}
     engines: {node: '>=18'}
     peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      react:
-        optional: true
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -1553,10 +1540,6 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
-
-  dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1988,11 +1971,6 @@ packages:
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
-  jsondiffpatch@0.7.6:
-    resolution: {integrity: sha512-zE9+AXFq+MkTolDor2Cw1nJzLC0aleqPkYf52Kb4Kn4mJcka/gFHpGI2JBVEJCfWOvBl0OoxZS+wuLdislQcqg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
@@ -2400,9 +2378,6 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
-  secure-json-parse@2.7.0:
-    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
-
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
@@ -2549,11 +2524,6 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  swr@2.4.1:
-    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
-    peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   table-layout@4.1.1:
     resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==}
     engines: {node: '>=12.17'}
@@ -2565,10 +2535,6 @@ packages:
   thread-stream@4.2.0:
     resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
     engines: {node: '>=20'}
-
-  throttleit@2.1.0:
-    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
-    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -2741,11 +2707,6 @@ packages:
 
   url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
-
-  use-sync-external-store@1.6.0:
-    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -2926,45 +2887,35 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/anthropic@1.2.12(zod@3.25.76)':
+  '@ai-sdk/anthropic@2.0.82(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.26(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/openai@1.3.24(zod@3.25.76)':
+  '@ai-sdk/gateway@2.0.99(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.26(zod@3.25.76)
+      '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
+  '@ai-sdk/openai@2.0.107(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.12
-      secure-json-parse: 2.7.0
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.26(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/provider@1.1.3':
+  '@ai-sdk/provider-utils@3.0.26(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 3.25.76
+
+  '@ai-sdk/provider@2.0.3':
     dependencies:
       json-schema: 0.4.0
-
-  '@ai-sdk/react@1.2.12(react@18.3.1)(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
-      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
-      react: 18.3.1
-      swr: 2.4.1(react@18.3.1)
-      throttleit: 2.1.0
-    optionalDependencies:
-      zod: 3.25.76
-
-  '@ai-sdk/ui-utils@1.2.11(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
 
   '@alcalzone/ansi-tokenize@0.1.3':
     dependencies:
@@ -3007,8 +2958,6 @@ snapshots:
     optional: true
 
   '@cfworker/json-schema@4.1.1': {}
-
-  '@dmsnell/diff-match-patch@1.1.0': {}
 
   '@emnapi/runtime@1.11.0':
     dependencies:
@@ -3597,6 +3546,8 @@ snapshots:
 
   '@types/vscode@1.120.0': {}
 
+  '@vercel/oidc@3.1.0': {}
+
   '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -3657,17 +3608,13 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@4.3.19(react@18.3.1)(zod@3.25.76):
+  ai@5.0.200(zod@3.25.76):
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
-      '@ai-sdk/react': 1.2.12(react@18.3.1)(zod@3.25.76)
-      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
+      '@ai-sdk/gateway': 2.0.99(zod@3.25.76)
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.26(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
-      jsondiffpatch: 0.7.6
       zod: 3.25.76
-    optionalDependencies:
-      react: 18.3.1
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -3892,8 +3839,6 @@ snapshots:
       object-keys: 1.1.1
 
   depd@2.0.0: {}
-
-  dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
@@ -4396,10 +4341,6 @@ snapshots:
 
   jsonc-parser@3.3.1: {}
 
-  jsondiffpatch@0.7.6:
-    dependencies:
-      '@dmsnell/diff-match-patch': 1.1.0
-
   jsonfile@6.2.1:
     dependencies:
       universalify: 2.0.1
@@ -4834,8 +4775,6 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  secure-json-parse@2.7.0: {}
-
   secure-json-parse@4.1.0: {}
 
   semver-compare@1.0.0: {}
@@ -5020,12 +4959,6 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  swr@2.4.1(react@18.3.1):
-    dependencies:
-      dequal: 2.0.3
-      react: 18.3.1
-      use-sync-external-store: 1.6.0(react@18.3.1)
-
   table-layout@4.1.1:
     dependencies:
       array-back: 6.2.3
@@ -5042,8 +4975,6 @@ snapshots:
   thread-stream@4.2.0:
     dependencies:
       real-require: 1.0.0
-
-  throttleit@2.1.0: {}
 
   tinybench@2.9.0: {}
 
@@ -5188,10 +5119,6 @@ snapshots:
   unpipe@1.0.0: {}
 
   url-join@4.0.1: {}
-
-  use-sync-external-store@1.6.0(react@18.3.1):
-    dependencies:
-      react: 18.3.1
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## Linked Issue Or Context

Closes #312 — `ai@4.3.19` carried two low-severity advisories; this migrates the AI SDK to the v5 line.

## Summary

Migrates `packages/core` from `ai@4.x` to the `ai@5.x` line with v2 provider packages, clearing GHSA-rwvc-j5jr-mgvh and following the official v4→v5 migration guide.

- `ai` `^4.3.19` → `^5.0.199`, `@ai-sdk/openai` `^1.3.24` → `^2.0.106`, `@ai-sdk/anthropic` `^1.2.12` → `^2.0.81` (lockfile resolves `ai@5.0.200`, providers `@2.0.x`).
- All AI-SDK usage in the monorepo lives in one file (`packages/core/src/llm/llm-service.ts`). v5 API changes applied at the single SDK boundary:
  - `CoreMessage` → `ModelMessage` (canonical v5 type name).
  - `maxTokens` → `maxOutputTokens` in `buildCallSettings`. **This is load-bearing, not cosmetic:** v5 reads `maxOutputTokens` and silently ignores the old `maxTokens` key; because the settings object is spread into the SDK call, TypeScript does not flag the stale key, so without this change v5 would silently cap output at its default. New tests pin the correct key.
  - `openai(model)` → `openai.chat(model)`: the v5 callable provider defaults to the Responses API; `.chat()` keeps Chat Completions behavior, which is required because `normalizeProviderBaseURL` targets `/chat/completions`-compatible gateways.
- `LLMService`'s own public option API (`maxTokens` on its methods and in `LLMConfig`) is intentionally unchanged; only the private SDK boundary changed, so no caller signatures change.
- `apps/vscode` consumes the advisory transitively via `@frontagent/core` only (the `"ai"` entry in its `package.json` is a `keywords` value, not a dependency) — no code change needed; full-workspace typecheck/build confirm it compiles against v5.

## Impact Scope

- `packages/core/package.json` (3 dependency lines)
- `packages/core/src/llm/llm-service.ts` (import, openai factory, `convertMessages` return type, `buildCallSettings` key)
- `packages/core/src/llm/llm-service.test.ts` (5 new SDK-boundary tests, file-wide ai/provider mocks)
- `pnpm-lock.yaml` (regenerated via `pnpm install`)

## Security advisory status after migration

`pnpm audit` before: 2 low advisories (`ai` GHSA-rwvc-j5jr-mgvh + `@ai-sdk/provider-utils` GHSA-866g-f22w-33x8). After: 1 low.

| Advisory | Package | Status |
|---|---|---|
| GHSA-rwvc-j5jr-mgvh (low) | `ai` | **Cleared** — vulnerable `< 5.0.52`; now on `5.0.200`. |
| GHSA-866g-f22w-33x8 (low) | `@ai-sdk/provider-utils` | **Still flagged** — installed `3.0.26` is within the vulnerable range `<= 3.0.97`. GitHub lists `first_patched_version: null` for this line (verified live via `gh api /advisories/GHSA-866g-f22w-33x8`), so there is no upstream fix to adopt. Severity is low (uncontrolled resource consumption). Will re-check on future SDK bumps. |

`pnpm audit` after migration:
```
low  @ai-sdk/provider-utils has an Uncontrolled Resource Consumption issue
Package              @ai-sdk/provider-utils
Vulnerable versions  <=3.0.97
Patched versions     <0.0.0
More info            https://github.com/advisories/GHSA-866g-f22w-33x8
1 vulnerabilities found  Severity: 1 low
```

## GitNexus Impact Summary

- **Risk level**: MEDIUM (per `detect_changes`). `LLMService` as a class is a CRITICAL-risk hub on upstream `impact` (20 direct callers, 10 processes), but mitigated: only the private SDK boundary changed; the public API surface is unchanged, so no caller is affected.
- **Critical skeleton changes**: None to public contracts. Changes are confined to `LLMService` internals (`createModel`, `convertMessages`, `buildCallSettings`); method signatures and `LLMConfig` are unchanged.
- **GitNexus impact**: `detect_changes` (scope=all) reports 4 changed symbols, all inside `LLMService` (`createModel`/`convertMessages`/`buildCallSettings`/`LLMService`), and 2 affected processes (`Main → ConvertMessages`, `Main → BuildCallSettings`) — no unexpected symbols or flows. Upstream `impact({target: "LLMService"})` = CRITICAL (hub) and `impact({target: "buildCallSettings"})` = HIGH; the blast radius is contained because the public option API is preserved.
- **Verification**: `pnpm typecheck` (22/22), `pnpm test` (22/22, core 686 incl. 5 new), `pnpm test:workflows` (29/29), `pnpm build:verify` (CLI + VSCode bundled) all pass; per-file `biome check` passes.

## Verification

- `pnpm --filter @frontagent/core test`: 686 passed (681 baseline + 5 new SDK-boundary tests).
- `pnpm typecheck` (full workspace): 22/22 — apps/vscode and apps/cli compile against v5.
- `pnpm test`, `pnpm test:workflows`, `pnpm build:verify`: all pass.
- `pnpm audit`: GHSA-rwvc-j5jr-mgvh gone; 1 low remaining (provider-utils, no patch available).
- Lint: top-level `biome check .` reports 0 files inside an agent git worktree (the `.git`-path ignore matches), so it was validated per-file via `biome check packages/core/src/llm/*.ts` (passes); CI lint in a normal checkout remains authoritative.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [ ] I have run `pnpm quality:precommit`, or explained why it could not run. (Top-level biome lint processes 0 files in an agent worktree; validated per-file instead, CI authoritative.)
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run. (Ran all sub-gates directly; only the worktree-specific biome lint was substituted with per-file lint.)
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
