### PR TITLE
test(mcp-file): give get-ast ts-morph smoke tests a generous timeout

### DIFF
--- a/packages/mcp-file/src/tools/get-ast.test.ts
+++ b/packages/mcp-file/src/tools/get-ast.test.ts
@@ -53,68 +53,83 @@ afterEach(() => {
   roots = [];
 });
 
+// ts-morph 28's first getAST call pays the full Project + type-checker
+// cold-start cost (the returnType assertion forces getReturnType().getText()
+// type resolution). On cold CI runners this exceeds vitest's 5000ms default
+// and flakes the matrix non-deterministically, so give the getAST-invoking
+// smoke cases a generous explicit timeout. See issue #321.
+const TS_MORPH_COLD_START_TIMEOUT_MS = 20_000;
+
 describe('getAST (ts-morph smoke test)', () => {
-  it('extracts imports, exports, functions, classes, interfaces and type aliases from a .ts file', async () => {
-    const root = makeRoot();
-    writeFileSync(join(root, 'sample.ts'), TS_FIXTURE, 'utf-8');
+  it(
+    'extracts imports, exports, functions, classes, interfaces and type aliases from a .ts file',
+    async () => {
+      const root = makeRoot();
+      writeFileSync(join(root, 'sample.ts'), TS_FIXTURE, 'utf-8');
 
-    const result = await getAST({ path: 'sample.ts' }, root);
+      const result = await getAST({ path: 'sample.ts' }, root);
 
-    expect(result.success).toBe(true);
+      expect(result.success).toBe(true);
 
-    // getImportDeclarations / getNamedImports / getNamespaceImport /
-    // getDefaultImport / getModuleSpecifierValue / getStartLineNumber
-    expect(result.imports).toHaveLength(3);
-    const [named, namespace, def] = result.imports ?? [];
-    expect(named.moduleSpecifier).toBe('node:path');
-    expect(named.namedImports).toEqual(['join']);
-    expect(named.line).toBe(1);
-    expect(namespace.namespaceImport).toBe('fs');
-    expect(def.defaultImport).toBe('os');
+      // getImportDeclarations / getNamedImports / getNamespaceImport /
+      // getDefaultImport / getModuleSpecifierValue / getStartLineNumber
+      expect(result.imports).toHaveLength(3);
+      const [named, namespace, def] = result.imports ?? [];
+      expect(named.moduleSpecifier).toBe('node:path');
+      expect(named.namedImports).toEqual(['join']);
+      expect(named.line).toBe(1);
+      expect(namespace.namespaceImport).toBe('fs');
+      expect(def.defaultImport).toBe('os');
 
-    // getExportedDeclarations: ReadonlyMap iterated by key
-    expect(result.exports).toEqual(
-      expect.arrayContaining(['PI', 'greet', 'Greeter', 'GreetOptions', 'GreetResult']),
-    );
+      // getExportedDeclarations: ReadonlyMap iterated by key
+      expect(result.exports).toEqual(
+        expect.arrayContaining(['PI', 'greet', 'Greeter', 'GreetOptions', 'GreetResult']),
+      );
 
-    // getFunctions / isAsync / isExported / getParameters /
-    // getType().getText() / getReturnType().getText()
-    const greet = result.functions?.find((f) => f.name === 'greet');
-    expect(greet).toBeDefined();
-    expect(greet?.isAsync).toBe(true);
-    expect(greet?.isExported).toBe(true);
-    expect(greet?.parameters?.[0]).toContain('name: string');
-    // Loose match: type TEXT rendering may legitimately vary across TS engines
-    expect(greet?.returnType).toContain('Promise<string>');
+      // getFunctions / isAsync / isExported / getParameters /
+      // getType().getText() / getReturnType().getText()
+      const greet = result.functions?.find((f) => f.name === 'greet');
+      expect(greet).toBeDefined();
+      expect(greet?.isAsync).toBe(true);
+      expect(greet?.isExported).toBe(true);
+      expect(greet?.parameters?.[0]).toContain('name: string');
+      // Loose match: type TEXT rendering may legitimately vary across TS engines
+      expect(greet?.returnType).toContain('Promise<string>');
 
-    // getClasses / getInterfaces / getTypeAliases
-    expect(result.classes).toEqual([
-      expect.objectContaining({ name: 'Greeter', isExported: true }),
-    ]);
-    expect(result.interfaces).toEqual([
-      expect.objectContaining({ name: 'GreetOptions', isExported: true }),
-    ]);
-    expect(result.types).toEqual([
-      expect.objectContaining({ name: 'GreetResult', isExported: true }),
-    ]);
-  });
+      // getClasses / getInterfaces / getTypeAliases
+      expect(result.classes).toEqual([
+        expect.objectContaining({ name: 'Greeter', isExported: true }),
+      ]);
+      expect(result.interfaces).toEqual([
+        expect.objectContaining({ name: 'GreetOptions', isExported: true }),
+      ]);
+      expect(result.types).toEqual([
+        expect.objectContaining({ name: 'GreetResult', isExported: true }),
+      ]);
+    },
+    TS_MORPH_COLD_START_TIMEOUT_MS,
+  );
 
-  it('detects arrow-function, function-declaration and class React components in a .tsx file', async () => {
-    const root = makeRoot();
-    writeFileSync(join(root, 'components.tsx'), TSX_FIXTURE, 'utf-8');
+  it(
+    'detects arrow-function, function-declaration and class React components in a .tsx file',
+    async () => {
+      const root = makeRoot();
+      writeFileSync(join(root, 'components.tsx'), TSX_FIXTURE, 'utf-8');
 
-    const result = await getAST({ path: 'components.tsx' }, root);
+      const result = await getAST({ path: 'components.tsx' }, root);
 
-    expect(result.success).toBe(true);
-    const componentNames = (result.components ?? []).map((c) => c.name);
-    // Button: getVariableDeclarations + getInitializer + SyntaxKind.ArrowFunction
-    expect(componentNames).toContain('Button');
-    // Card: getFunctions + getBody() JSX heuristic (exercises jsx: 2 parsing)
-    expect(componentNames).toContain('Card');
-    // Panel: getClasses + getExtends
-    expect(componentNames).toContain('Panel');
-    expect(result.components?.find((c) => c.name === 'Panel')?.type).toBe('class');
-  });
+      expect(result.success).toBe(true);
+      const componentNames = (result.components ?? []).map((c) => c.name);
+      // Button: getVariableDeclarations + getInitializer + SyntaxKind.ArrowFunction
+      expect(componentNames).toContain('Button');
+      // Card: getFunctions + getBody() JSX heuristic (exercises jsx: 2 parsing)
+      expect(componentNames).toContain('Card');
+      // Panel: getClasses + getExtends
+      expect(componentNames).toContain('Panel');
+      expect(result.components?.find((c) => c.name === 'Panel')?.type).toBe('class');
+    },
+    TS_MORPH_COLD_START_TIMEOUT_MS,
+  );
 
   it('rejects unsupported file extensions', async () => {
     const root = makeRoot();


### PR DESCRIPTION
## Linked Issue Or Context

Closes #321

## Summary

The first `getAST` call in `packages/mcp-file/src/tools/get-ast.test.ts` pays ts-morph 28's full `Project` + type-checker cold-start cost (the `greet?.returnType` assertion forces `getReturnType().getText()` type resolution). On cold CI runners this exceeds vitest's 5000ms default and flakes the `check (20)`/`check (22)` matrix non-deterministically.

Fix: give the two `getAST`-invoking smoke cases an explicit 20s timeout via the `it(name, fn, timeout)` argument. The fast `rejects unsupported file extensions` case keeps the default.

## Impact Scope

Test-only. `packages/mcp-file/src/tools/get-ast.test.ts` only. No production source changed.

## Evidence of the flake

- Run `27455539616` on a commit that does NOT touch mcp-file: [`check (22)` failed on get-ast timeout](https://github.com/FrontAgent/FrontAgent/actions/runs/27455539616/job/81159307973).
- Same commit `5e0bd58` earlier run: `check (22)` passed get-ast at 5194ms while `check (20)` timed out at 6912ms — same code, opposite results.
- Re-run of `27455539616`: [`check (20)` failed again](https://github.com/FrontAgent/FrontAgent/actions/runs/27455539616/job/81160027935) while `check (22)` passed — ~50% flake per matrix leg.
- develop's own CI is intermittently red from this (run on `7828077` failed, `7523deb` passed).

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: None — test-only timeout argument added to two existing `getAST` smoke cases; no production code (`get-ast.ts`) or contract surface modified.
- GitNexus impact: detect_changes → 0 changed symbols / 0 affected processes (risk low, 1 changed file); impact(getAST, upstream) → risk LOW, 1 direct caller (server.ts), 0 affected processes. Additive test timeout only, so real blast radius is zero.
- Verification: `pnpm --filter @frontagent/mcp-file test` 101/101 pass; `pnpm typecheck` 22/22; `pnpm lint` clean (only a pre-existing unrelated info); CI `check (20)` and `check (22)` both pass on this PR without timeout flakes.

## Verification

- `pnpm --filter @frontagent/mcp-file test` → 101/101 pass (9 files)
- `pnpm typecheck` → 22/22 tasks
- `pnpm lint` → clean (1 pre-existing unrelated info in hallucination-guard)
- CI matrix `check (20)` + `check (22)` both green on this PR.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.