### PR TITLE
feat(desktop): foundation — typed IPC contract + execution reducer

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@frontagent/desktop",
+  "version": "2.1.1",
+  "description": "FrontAgent desktop app (Electron) — standalone GUI entry point reusing the Node runtime spine",
+  "private": true,
+  "type": "module",
+  "main": "./dist/electron/main.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@frontagent/core": "workspace:*",
+    "@frontagent/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
+  }
+}

--- a/apps/desktop/src/ipc/contract.ts
+++ b/apps/desktop/src/ipc/contract.ts
@@ -49,6 +49,13 @@ export interface RunTaskResponse {
 }
 
 export interface ApprovalDecisionInput {
+  /**
+   * Run the decision belongs to. Carried explicitly (symmetric with
+   * {@link ApprovalRequestEnvelope}) so the main process can route the decision
+   * to the right run's approval callback without an implicit approvalId->run
+   * lookup — the renderer may have several runs in flight.
+   */
+  runId: string;
   /** The `approvalId` carried by the `ApprovalRequest` being answered. */
   approvalId: string;
   approved: boolean;

--- a/apps/desktop/src/ipc/contract.ts
+++ b/apps/desktop/src/ipc/contract.ts
@@ -1,0 +1,92 @@
+/**
+ * Cross-process IPC contract for the FrontAgent desktop app.
+ *
+ * This is the load-bearing boundary between the Electron main process (which
+ * owns the Node runtime spine, `@frontagent/runtime-node`) and the renderer
+ * (the React UI). It is a graded contract surface: kept minimal and explicit
+ * so the accidental contract stays small. The renderer never imports runtime
+ * internals — it only speaks these types.
+ *
+ * Later PRs implement the preload bridge and the runtime wiring; this PR fixes
+ * the shape both sides agree on.
+ */
+import type { AgentEvent, AgentExecutionResult } from '@frontagent/core';
+import type { ApprovalRequest } from '@frontagent/shared';
+
+export type { AgentEvent, AgentExecutionResult, ApprovalRequest };
+
+/** Renderer -> Main request channels (invoke/handle). */
+export const IpcChannel = {
+  RunTask: 'fa:task:run',
+  CancelTask: 'fa:task:cancel',
+  RespondApproval: 'fa:approval:respond',
+  GetSettings: 'fa:settings:get',
+  SaveSettings: 'fa:settings:save',
+} as const;
+export type IpcChannel = (typeof IpcChannel)[keyof typeof IpcChannel];
+
+/** Main -> Renderer push channels (send/on). */
+export const IpcPush = {
+  AgentEvent: 'fa:agent:event',
+  ApprovalRequested: 'fa:approval:requested',
+} as const;
+export type IpcPush = (typeof IpcPush)[keyof typeof IpcPush];
+
+export interface RunTaskRequest {
+  /** Natural-language task description the agent should plan and execute. */
+  task: string;
+  /** Absolute path of the workspace the agent operates on. */
+  workspacePath: string;
+  /** Optional files to attach as relevant context. */
+  relevantFiles?: string[];
+  /** Optional dev-server / page URL for browser awareness. */
+  browserUrl?: string;
+}
+
+export interface RunTaskResponse {
+  /** Identifier the renderer uses to correlate pushed events with this run. */
+  runId: string;
+}
+
+export interface ApprovalDecisionInput {
+  /** The `approvalId` carried by the `ApprovalRequest` being answered. */
+  approvalId: string;
+  approved: boolean;
+  /** Optional maintainer note recorded with the decision. */
+  note?: string;
+}
+
+export interface DesktopSettings {
+  provider: string;
+  model: string;
+  baseUrl?: string;
+  defaultWorkspacePath?: string;
+}
+
+/** Envelope correlating a pushed agent event with its originating run. */
+export interface AgentEventEnvelope {
+  runId: string;
+  event: AgentEvent;
+}
+
+/** Envelope correlating a pushed approval request with its originating run. */
+export interface ApprovalRequestEnvelope {
+  runId: string;
+  request: ApprovalRequest;
+}
+
+/**
+ * The typed surface exposed on `window.frontagent` by the preload script.
+ * Renderer code depends only on this interface.
+ */
+export interface FrontAgentBridge {
+  runTask(req: RunTaskRequest): Promise<RunTaskResponse>;
+  cancelTask(runId: string): Promise<void>;
+  respondApproval(input: ApprovalDecisionInput): Promise<void>;
+  getSettings(): Promise<DesktopSettings>;
+  saveSettings(settings: DesktopSettings): Promise<void>;
+  /** Subscribe to agent events; returns an unsubscribe function. */
+  onAgentEvent(listener: (envelope: AgentEventEnvelope) => void): () => void;
+  /** Subscribe to approval requests; returns an unsubscribe function. */
+  onApprovalRequested(listener: (envelope: ApprovalRequestEnvelope) => void): () => void;
+}

--- a/apps/desktop/src/state/executionReducer.test.ts
+++ b/apps/desktop/src/state/executionReducer.test.ts
@@ -1,0 +1,242 @@
+import type { AgentEvent, AgentExecutionResult } from '@frontagent/core';
+import type { AgentTask, ExecutionPlan, ExecutionStep } from '@frontagent/shared';
+import { describe, expect, it } from 'vitest';
+import {
+  type ConsoleState,
+  consoleReducer,
+  initialConsoleState,
+  reduceEvents,
+  UNGROUPED_PHASE,
+} from './executionReducer.js';
+
+function task(description = '给登录页加深色模式'): AgentTask {
+  return { id: 't1', type: 'modify', description };
+}
+
+function step(overrides: Partial<ExecutionStep> = {}): ExecutionStep {
+  return {
+    stepId: 's1',
+    description: '编辑 theme.css',
+    action: 'write_file',
+    tool: 'mcp-file',
+    params: {},
+    dependencies: [],
+    validation: [],
+    status: 'pending',
+    ...overrides,
+  };
+}
+
+function plan(overrides: Partial<ExecutionPlan> = {}): ExecutionPlan {
+  return {
+    taskId: 't1',
+    summary: '两步：编辑样式并验证',
+    steps: [step()],
+    rollbackStrategy: {
+      enabled: true,
+      snapshotBeforeExecution: true,
+      rollbackOnFailure: true,
+      maxRollbackSteps: 5,
+    },
+    ...overrides,
+  };
+}
+
+function result(overrides: Partial<AgentExecutionResult> = {}): AgentExecutionResult {
+  return {
+    success: true,
+    taskId: 't1',
+    executedSteps: [],
+    duration: 0,
+    validations: [],
+    ...overrides,
+  };
+}
+
+describe('consoleReducer', () => {
+  it('starts a task and resets prior state', () => {
+    const dirty: ConsoleState = {
+      ...initialConsoleState,
+      status: 'failed',
+      error: 'old',
+      logSeq: 9,
+    };
+    const next = consoleReducer(dirty, { type: 'task_started', task: task() });
+
+    expect(next.status).toBe('planning');
+    expect(next.task).toBe('给登录页加深色模式');
+    expect(next.error).toBeUndefined();
+    expect(next.log).toHaveLength(1);
+    expect(next.log[0].text).toContain('任务开始');
+  });
+
+  it('seeds phases from the plan and moves to running', () => {
+    const next = consoleReducer(
+      { ...initialConsoleState, status: 'planning' },
+      {
+        type: 'planning_completed',
+        plan: plan({
+          phases: [{ phaseId: 'p1', name: '实现', description: '', stepIndices: [0, 1] }],
+        }),
+      },
+    );
+
+    expect(next.status).toBe('running');
+    expect(next.planSummary).toBe('两步：编辑样式并验证');
+    expect(next.phases).toHaveLength(1);
+    expect(next.phases[0]).toMatchObject({ name: '实现', status: 'pending', expectedSteps: 2 });
+  });
+
+  it('tracks a step through started -> completed and clears the active step', () => {
+    let state = consoleReducer(initialConsoleState, {
+      type: 'phase_started',
+      phase: '实现',
+      stepCount: 1,
+    });
+    state = consoleReducer(state, { type: 'step_started', step: step({ phase: '实现' }) });
+
+    expect(state.activeStepId).toBe('s1');
+    expect(state.phases[0].steps[0]).toMatchObject({ status: 'running', tool: 'mcp-file' });
+
+    state = consoleReducer(state, {
+      type: 'step_completed',
+      step: step({ phase: '实现' }),
+      result: { success: true, duration: 10 },
+    });
+
+    expect(state.activeStepId).toBeUndefined();
+    expect(state.phases[0].steps[0].status).toBe('completed');
+    expect(state.phases[0].steps).toHaveLength(1); // upsert, not duplicate
+  });
+
+  it('records step failures with the error message', () => {
+    const state = consoleReducer(initialConsoleState, {
+      type: 'step_failed',
+      step: step({ phase: '实现' }),
+      error: '路径不存在',
+    });
+
+    expect(state.phases[0].steps[0]).toMatchObject({ status: 'failed', error: '路径不存在' });
+    expect(state.log.at(-1)).toMatchObject({ level: 'error' });
+  });
+
+  it('groups steps without a phase under the active phase, else the ungrouped fallback', () => {
+    const active = consoleReducer(
+      consoleReducer(initialConsoleState, { type: 'phase_started', phase: '实现', stepCount: 1 }),
+      { type: 'step_started', step: step() }, // no phase field
+    );
+    expect(active.phases[0].steps[0].phase).toBe('实现');
+
+    const orphan = consoleReducer(initialConsoleState, { type: 'step_started', step: step() });
+    expect(orphan.phases[0].name).toBe(UNGROUPED_PHASE);
+  });
+
+  it('accumulates streamed tokens per step without logging', () => {
+    let state = consoleReducer(initialConsoleState, {
+      type: 'stream_token',
+      token: 'Hel',
+      stepId: 's1',
+    });
+    state = consoleReducer(state, { type: 'stream_token', token: 'lo', stepId: 's1' });
+
+    expect(state.tokensByStep.s1).toBe('Hello');
+    expect(state.log).toHaveLength(0);
+  });
+
+  it('surfaces security decisions in the log with the right level', () => {
+    const denied = consoleReducer(initialConsoleState, {
+      type: 'security_decision',
+      decision: {
+        decision: 'deny',
+        riskLevel: 'high',
+        reasonCode: 'shell_blocked',
+        message: 'rm -rf 被拦截',
+        toolName: 'run_command',
+        argsSummary: 'rm -rf /',
+        provenance: [],
+      },
+    });
+    expect(denied.log.at(-1)).toMatchObject({ level: 'error' });
+    expect(denied.log.at(-1)?.text).toContain('run_command');
+  });
+
+  it('completes and fails the run terminally', () => {
+    const done = consoleReducer(
+      { ...initialConsoleState, status: 'running', activeStepId: 's1' },
+      {
+        type: 'task_completed',
+        result: result({ success: true }),
+      },
+    );
+    expect(done.status).toBe('completed');
+    expect(done.activeStepId).toBeUndefined();
+    expect(done.result?.success).toBe(true);
+
+    const failed = consoleReducer(
+      { ...initialConsoleState, status: 'running' },
+      {
+        type: 'task_failed',
+        error: 'LLM 超时',
+      },
+    );
+    expect(failed.status).toBe('failed');
+    expect(failed.error).toBe('LLM 超时');
+  });
+
+  it('marks a phase completed and flags failures in the summary', () => {
+    let state = consoleReducer(initialConsoleState, {
+      type: 'phase_started',
+      phase: '验证',
+      stepCount: 2,
+    });
+    state = consoleReducer(state, {
+      type: 'phase_completed',
+      phase: '验证',
+      successCount: 1,
+      failureCount: 1,
+    });
+    expect(state.phases[0].status).toBe('completed');
+    expect(state.log.at(-1)).toMatchObject({ level: 'warn' });
+  });
+
+  it('reduces a full happy-path sequence deterministically', () => {
+    const events: AgentEvent[] = [
+      { type: 'task_started', task: task() },
+      { type: 'planning_started' },
+      {
+        type: 'planning_completed',
+        plan: plan({
+          phases: [{ phaseId: 'p1', name: '实现', description: '', stepIndices: [0] }],
+        }),
+      },
+      { type: 'phase_started', phase: '实现', stepCount: 1 },
+      { type: 'step_started', step: step({ phase: '实现' }) },
+      { type: 'stream_token', token: 'done', stepId: 's1' },
+      {
+        type: 'step_completed',
+        step: step({ phase: '实现' }),
+        result: { success: true, duration: 5 },
+      },
+      { type: 'phase_completed', phase: '实现', successCount: 1, failureCount: 0 },
+      { type: 'task_completed', result: result({ success: true }) },
+    ];
+
+    const final = reduceEvents(events);
+
+    expect(final.status).toBe('completed');
+    expect(final.phases).toHaveLength(1);
+    expect(final.phases[0].status).toBe('completed');
+    expect(final.phases[0].steps[0].status).toBe('completed');
+    expect(final.tokensByStep.s1).toBe('done');
+    expect(final.activeStepId).toBeUndefined();
+    // log keys are unique and monotonic
+    expect(new Set(final.log.map((line) => line.seq)).size).toBe(final.log.length);
+  });
+
+  it('does not mutate the input state', () => {
+    const before = { ...initialConsoleState };
+    const frozen = Object.freeze({ ...initialConsoleState, phases: Object.freeze([]) as never });
+    expect(() => consoleReducer(frozen, { type: 'planning_started' })).not.toThrow();
+    expect(initialConsoleState).toEqual(before);
+  });
+});

--- a/apps/desktop/src/state/executionReducer.test.ts
+++ b/apps/desktop/src/state/executionReducer.test.ts
@@ -270,6 +270,23 @@ describe('consoleReducer', () => {
 
     expect(state.phases[0].steps[0].status).toBe('completed');
   });
+
+  it('routes task_completed status by result.success so a failed run is never shown as completed', () => {
+    let state = consoleReducer(initialConsoleState, {
+      type: 'phase_started',
+      phase: '实现',
+      stepCount: 1,
+    });
+    state = consoleReducer(state, { type: 'step_started', step: step({ phase: '实现' }) });
+    state = consoleReducer(state, {
+      type: 'task_completed',
+      result: result({ success: false, error: '验证未通过' }),
+    });
+
+    expect(state.status).toBe('failed');
+    expect(state.error).toBe('验证未通过');
+    expect(state.phases[0].steps[0].status).toBe('failed');
+  });
 });
 
 describe('approval actions', () => {

--- a/apps/desktop/src/state/executionReducer.test.ts
+++ b/apps/desktop/src/state/executionReducer.test.ts
@@ -1,11 +1,13 @@
 import type { AgentEvent, AgentExecutionResult } from '@frontagent/core';
-import type { AgentTask, ExecutionPlan, ExecutionStep } from '@frontagent/shared';
+import type { AgentTask, ApprovalRequest, ExecutionPlan, ExecutionStep } from '@frontagent/shared';
 import { describe, expect, it } from 'vitest';
 import {
+  addApprovalRequest,
   type ConsoleState,
   consoleReducer,
   initialConsoleState,
   reduceEvents,
+  resolveApproval,
   UNGROUPED_PHASE,
 } from './executionReducer.js';
 
@@ -238,5 +240,74 @@ describe('consoleReducer', () => {
     const frozen = Object.freeze({ ...initialConsoleState, phases: Object.freeze([]) as never });
     expect(() => consoleReducer(frozen, { type: 'planning_started' })).not.toThrow();
     expect(initialConsoleState).toEqual(before);
+  });
+
+  it('terminalizes a step left running when the task fails', () => {
+    let state = consoleReducer(initialConsoleState, {
+      type: 'phase_started',
+      phase: '实现',
+      stepCount: 1,
+    });
+    state = consoleReducer(state, { type: 'step_started', step: step({ phase: '实现' }) });
+    expect(state.phases[0].steps[0].status).toBe('running');
+
+    state = consoleReducer(state, { type: 'task_failed', error: 'LLM 超时' });
+
+    expect(state.status).toBe('failed');
+    expect(state.phases[0].steps[0].status).toBe('failed');
+    expect(state.phases[0].steps[0].error).toContain('任务失败时中断');
+    expect(state.activeStepId).toBeUndefined();
+  });
+
+  it('terminalizes a dangling running step when the task completes', () => {
+    let state = consoleReducer(initialConsoleState, {
+      type: 'phase_started',
+      phase: '实现',
+      stepCount: 1,
+    });
+    state = consoleReducer(state, { type: 'step_started', step: step({ phase: '实现' }) });
+    state = consoleReducer(state, { type: 'task_completed', result: result({ success: true }) });
+
+    expect(state.phases[0].steps[0].status).toBe('completed');
+  });
+});
+
+describe('approval actions', () => {
+  function approval(overrides: Partial<ApprovalRequest> = {}): ApprovalRequest {
+    return {
+      decision: 'ask',
+      approvalId: 'a1',
+      createdAt: '2026-06-13T00:00:00Z',
+      riskLevel: 'high',
+      reasonCode: 'shell_ask',
+      message: '执行 npm install',
+      toolName: 'run_command',
+      argsSummary: 'npm install',
+      provenance: [],
+      ...overrides,
+    };
+  }
+
+  it('queues an approval request in the same state model and de-duplicates', () => {
+    const queued = addApprovalRequest(initialConsoleState, approval());
+    expect(queued.pendingApprovals).toHaveLength(1);
+    expect(queued.log.at(-1)).toMatchObject({ level: 'warn' });
+
+    const again = addApprovalRequest(queued, approval());
+    expect(again.pendingApprovals).toHaveLength(1); // deduped on approvalId
+  });
+
+  it('removes an approval from the queue once resolved', () => {
+    const queued = addApprovalRequest(initialConsoleState, approval());
+    const approved = resolveApproval(queued, 'a1', true);
+
+    expect(approved.pendingApprovals).toHaveLength(0);
+    expect(approved.log.at(-1)?.text).toContain('审批通过');
+  });
+
+  it('ignores resolving an unknown approval id', () => {
+    const queued = addApprovalRequest(initialConsoleState, approval());
+    const unchanged = resolveApproval(queued, 'nope', false);
+    expect(unchanged).toBe(queued);
   });
 });

--- a/apps/desktop/src/state/executionReducer.test.ts
+++ b/apps/desktop/src/state/executionReducer.test.ts
@@ -256,6 +256,7 @@ describe('consoleReducer', () => {
     expect(state.status).toBe('failed');
     expect(state.phases[0].steps[0].status).toBe('failed');
     expect(state.phases[0].steps[0].error).toContain('任务失败时中断');
+    expect(state.phases[0].status).toBe('completed'); // active phase lane is closed out
     expect(state.activeStepId).toBeUndefined();
   });
 
@@ -269,6 +270,7 @@ describe('consoleReducer', () => {
     state = consoleReducer(state, { type: 'task_completed', result: result({ success: true }) });
 
     expect(state.phases[0].steps[0].status).toBe('completed');
+    expect(state.phases[0].status).toBe('completed'); // active phase lane is closed out
   });
 
   it('routes task_completed status by result.success so a failed run is never shown as completed', () => {

--- a/apps/desktop/src/state/executionReducer.ts
+++ b/apps/desktop/src/state/executionReducer.ts
@@ -113,9 +113,11 @@ function resolvePhaseName(state: ConsoleState, stepPhase: string | undefined): s
 }
 
 /**
- * Force any still-`running` step to a terminal state. Used when the run ends
- * (succeeded or failed) so a step interrupted mid-flight is never left dangling
- * in the UI. `error` is attached when terminalizing as failed.
+ * Close out a run that has ended: force any still-`running` step to a terminal
+ * state and any still-`active` phase lane to `completed`, so a finished run is
+ * never rendered as in-progress. `error` is attached to steps terminalized as
+ * failed. (Phase status has no `failed` variant — step-level status carries the
+ * failure detail.)
  */
 function terminalizeRunningSteps(
   phases: PhaseView[],
@@ -124,6 +126,7 @@ function terminalizeRunningSteps(
 ): PhaseView[] {
   return phases.map((phase) => ({
     ...phase,
+    status: phase.status === 'active' ? 'completed' : phase.status,
     steps: phase.steps.map((step) =>
       step.status === 'running' ? { ...step, status, error: error ?? step.error } : step,
     ),

--- a/apps/desktop/src/state/executionReducer.ts
+++ b/apps/desktop/src/state/executionReducer.ts
@@ -8,6 +8,7 @@
  * mutates its input — every branch returns a new state object.
  */
 import type { AgentEvent, AgentExecutionResult } from '@frontagent/core';
+import type { ApprovalRequest } from '@frontagent/shared';
 
 export type RunStatus = 'idle' | 'planning' | 'running' | 'completed' | 'failed';
 export type StepStatusView = 'pending' | 'running' | 'completed' | 'failed';
@@ -50,6 +51,14 @@ export interface ConsoleState {
   log: LogLine[];
   /** Accumulated streamed tokens keyed by step id. */
   tokensByStep: Record<string, string>;
+  /**
+   * Outstanding approval requests awaiting a decision. Approvals do not flow
+   * through the `AgentEvent` union — they arrive on a separate bridge channel —
+   * so they are applied via {@link addApprovalRequest} / {@link resolveApproval}
+   * rather than `consoleReducer`. They live here so the whole console renders
+   * from one state model (one truth, not a parallel UI-owned store).
+   */
+  pendingApprovals: ApprovalRequest[];
   result?: AgentExecutionResult;
   error?: string;
   /** Monotonic counter backing stable log keys. */
@@ -61,6 +70,7 @@ export const initialConsoleState: ConsoleState = {
   phases: [],
   log: [],
   tokensByStep: {},
+  pendingApprovals: [],
   logSeq: 0,
 };
 
@@ -100,6 +110,24 @@ function upsertStep(phase: PhaseView, step: StepView): PhaseView {
 
 function resolvePhaseName(state: ConsoleState, stepPhase: string | undefined): string {
   return stepPhase ?? activePhaseName(state) ?? UNGROUPED_PHASE;
+}
+
+/**
+ * Force any still-`running` step to a terminal state. Used when the run ends
+ * (succeeded or failed) so a step interrupted mid-flight is never left dangling
+ * in the UI. `error` is attached when terminalizing as failed.
+ */
+function terminalizeRunningSteps(
+  phases: PhaseView[],
+  status: 'completed' | 'failed',
+  error?: string,
+): PhaseView[] {
+  return phases.map((phase) => ({
+    ...phase,
+    steps: phase.steps.map((step) =>
+      step.status === 'running' ? { ...step, status, error: error ?? step.error } : step,
+    ),
+  }));
 }
 
 export function consoleReducer(state: ConsoleState, event: AgentEvent): ConsoleState {
@@ -260,14 +288,30 @@ export function consoleReducer(state: ConsoleState, event: AgentEvent): ConsoleS
 
     case 'task_completed':
       return appendLog(
-        { ...state, status: 'completed', result: event.result, activeStepId: undefined },
+        {
+          ...state,
+          status: 'completed',
+          result: event.result,
+          activeStepId: undefined,
+          phases: terminalizeRunningSteps(
+            state.phases,
+            event.result.success ? 'completed' : 'failed',
+            event.result.success ? undefined : '任务结束时该步骤仍未完成',
+          ),
+        },
         event.result.success ? 'success' : 'warn',
         `任务完成${event.result.success ? '' : '（部分失败）'}`,
       );
 
     case 'task_failed':
       return appendLog(
-        { ...state, status: 'failed', error: event.error, activeStepId: undefined },
+        {
+          ...state,
+          status: 'failed',
+          error: event.error,
+          activeStepId: undefined,
+          phases: terminalizeRunningSteps(state.phases, 'failed', `任务失败时中断: ${event.error}`),
+        },
         'error',
         `任务失败: ${event.error}`,
       );
@@ -283,6 +327,43 @@ export function reduceEvents(
   state: ConsoleState = initialConsoleState,
 ): ConsoleState {
   return events.reduce(consoleReducer, state);
+}
+
+/**
+ * Record an incoming approval request. Approvals arrive on a separate bridge
+ * channel (not the `AgentEvent` stream), so they have their own action while
+ * still living in {@link ConsoleState}. De-duplicates on `approvalId`.
+ */
+export function addApprovalRequest(state: ConsoleState, request: ApprovalRequest): ConsoleState {
+  if (state.pendingApprovals.some((pending) => pending.approvalId === request.approvalId)) {
+    return state;
+  }
+  return appendLog(
+    { ...state, pendingApprovals: [...state.pendingApprovals, request] },
+    'warn',
+    `等待审批 [${request.riskLevel}] ${request.toolName}: ${request.message}`,
+  );
+}
+
+/** Remove a resolved approval request from the pending queue once a decision is made. */
+export function resolveApproval(
+  state: ConsoleState,
+  approvalId: string,
+  approved: boolean,
+): ConsoleState {
+  if (!state.pendingApprovals.some((pending) => pending.approvalId === approvalId)) {
+    return state;
+  }
+  return appendLog(
+    {
+      ...state,
+      pendingApprovals: state.pendingApprovals.filter(
+        (pending) => pending.approvalId !== approvalId,
+      ),
+    },
+    approved ? 'info' : 'warn',
+    `审批${approved ? '通过' : '拒绝'}: ${approvalId}`,
+  );
 }
 
 function assertNever(event: never): never {

--- a/apps/desktop/src/state/executionReducer.ts
+++ b/apps/desktop/src/state/executionReducer.ts
@@ -1,0 +1,290 @@
+/**
+ * Pure, framework-agnostic reducer that folds the agent's `AgentEvent` stream
+ * into a renderable console state. Kept free of React/Electron so it can be
+ * unit-tested in isolation and reused by any renderer.
+ *
+ * Design: events arrive in causal order (planning -> phases -> steps ->
+ * completion). The reducer is total over the `AgentEvent` union and never
+ * mutates its input — every branch returns a new state object.
+ */
+import type { AgentEvent, AgentExecutionResult } from '@frontagent/core';
+
+export type RunStatus = 'idle' | 'planning' | 'running' | 'completed' | 'failed';
+export type StepStatusView = 'pending' | 'running' | 'completed' | 'failed';
+export type PhaseStatusView = 'pending' | 'active' | 'completed';
+export type LogLevel = 'info' | 'success' | 'warn' | 'error';
+
+/** Phase name used when a step arrives without an explicit phase grouping. */
+export const UNGROUPED_PHASE = 'execution';
+
+export interface StepView {
+  id: string;
+  title: string;
+  phase: string;
+  status: StepStatusView;
+  tool?: string;
+  detail?: string;
+  error?: string;
+}
+
+export interface PhaseView {
+  name: string;
+  status: PhaseStatusView;
+  /** Steps the phase announced it would run (0 when not yet known). */
+  expectedSteps: number;
+  steps: StepView[];
+}
+
+export interface LogLine {
+  seq: number;
+  level: LogLevel;
+  text: string;
+}
+
+export interface ConsoleState {
+  status: RunStatus;
+  task?: string;
+  planSummary?: string;
+  phases: PhaseView[];
+  activeStepId?: string;
+  log: LogLine[];
+  /** Accumulated streamed tokens keyed by step id. */
+  tokensByStep: Record<string, string>;
+  result?: AgentExecutionResult;
+  error?: string;
+  /** Monotonic counter backing stable log keys. */
+  logSeq: number;
+}
+
+export const initialConsoleState: ConsoleState = {
+  status: 'idle',
+  phases: [],
+  log: [],
+  tokensByStep: {},
+  logSeq: 0,
+};
+
+function appendLog(state: ConsoleState, level: LogLevel, text: string): ConsoleState {
+  return {
+    ...state,
+    logSeq: state.logSeq + 1,
+    log: [...state.log, { seq: state.logSeq + 1, level, text }],
+  };
+}
+
+function activePhaseName(state: ConsoleState): string | undefined {
+  return state.phases.find((phase) => phase.status === 'active')?.name;
+}
+
+/** Return a copy of `phases` guaranteeing a phase with `name` exists. */
+function ensurePhase(phases: PhaseView[], name: string): PhaseView[] {
+  if (phases.some((phase) => phase.name === name)) return phases;
+  return [...phases, { name, status: 'pending', expectedSteps: 0, steps: [] }];
+}
+
+function mapPhase(
+  phases: PhaseView[],
+  name: string,
+  fn: (phase: PhaseView) => PhaseView,
+): PhaseView[] {
+  return phases.map((phase) => (phase.name === name ? fn(phase) : phase));
+}
+
+function upsertStep(phase: PhaseView, step: StepView): PhaseView {
+  const exists = phase.steps.some((existing) => existing.id === step.id);
+  const steps = exists
+    ? phase.steps.map((existing) => (existing.id === step.id ? { ...existing, ...step } : existing))
+    : [...phase.steps, step];
+  return { ...phase, steps };
+}
+
+function resolvePhaseName(state: ConsoleState, stepPhase: string | undefined): string {
+  return stepPhase ?? activePhaseName(state) ?? UNGROUPED_PHASE;
+}
+
+export function consoleReducer(state: ConsoleState, event: AgentEvent): ConsoleState {
+  switch (event.type) {
+    case 'task_started':
+      return appendLog(
+        { ...initialConsoleState, status: 'planning', task: event.task.description },
+        'info',
+        `任务开始: ${event.task.description}`,
+      );
+
+    case 'status_update':
+      return appendLog(
+        state,
+        'info',
+        event.detail ? `${event.label} — ${event.detail}` : event.label,
+      );
+
+    case 'planning_started':
+      return appendLog({ ...state, status: 'planning' }, 'info', '规划开始');
+
+    case 'rag_retrieved':
+      return appendLog(state, 'info', `RAG 检索: ${event.matches.length} 条匹配`);
+
+    case 'filesense_navigated':
+      return appendLog(
+        state,
+        'info',
+        `Filesense 导航: ${event.paths.length} 路径 / ${event.entries} 条目`,
+      );
+
+    case 'planning_completed': {
+      const seeded = (event.plan.phases ?? []).reduce(
+        (phases, phase) =>
+          mapPhase(ensurePhase(phases, phase.name), phase.name, (existing) => ({
+            ...existing,
+            expectedSteps: phase.stepIndices.length,
+          })),
+        state.phases,
+      );
+      return appendLog(
+        { ...state, status: 'running', planSummary: event.plan.summary, phases: seeded },
+        'success',
+        `规划完成: ${event.plan.steps.length} 步`,
+      );
+    }
+
+    case 'phase_started': {
+      const phases = mapPhase(ensurePhase(state.phases, event.phase), event.phase, (phase) => ({
+        ...phase,
+        status: 'active',
+        expectedSteps: event.stepCount,
+      }));
+      return appendLog(
+        { ...state, phases },
+        'info',
+        `阶段开始: ${event.phase} (${event.stepCount} 步)`,
+      );
+    }
+
+    case 'phase_completed': {
+      const phases = mapPhase(state.phases, event.phase, (phase) => ({
+        ...phase,
+        status: 'completed',
+      }));
+      return appendLog(
+        { ...state, phases },
+        event.failureCount > 0 ? 'warn' : 'success',
+        `阶段完成: ${event.phase} (成功 ${event.successCount} / 失败 ${event.failureCount})`,
+      );
+    }
+
+    case 'step_started': {
+      const phaseName = resolvePhaseName(state, event.step.phase);
+      const phases = mapPhase(ensurePhase(state.phases, phaseName), phaseName, (phase) =>
+        upsertStep(phase, {
+          id: event.step.stepId,
+          title: event.step.description,
+          phase: phaseName,
+          status: 'running',
+          tool: event.step.tool,
+        }),
+      );
+      return appendLog(
+        { ...state, phases, activeStepId: event.step.stepId },
+        'info',
+        `步骤开始: ${event.step.description}`,
+      );
+    }
+
+    case 'step_completed': {
+      const phaseName = resolvePhaseName(state, event.step.phase);
+      const phases = mapPhase(ensurePhase(state.phases, phaseName), phaseName, (phase) =>
+        upsertStep(phase, {
+          id: event.step.stepId,
+          title: event.step.description,
+          phase: phaseName,
+          status: 'completed',
+          tool: event.step.tool,
+        }),
+      );
+      const cleared = state.activeStepId === event.step.stepId ? undefined : state.activeStepId;
+      return appendLog(
+        { ...state, phases, activeStepId: cleared },
+        'success',
+        `步骤完成: ${event.step.description}`,
+      );
+    }
+
+    case 'step_failed': {
+      const phaseName = resolvePhaseName(state, event.step.phase);
+      const phases = mapPhase(ensurePhase(state.phases, phaseName), phaseName, (phase) =>
+        upsertStep(phase, {
+          id: event.step.stepId,
+          title: event.step.description,
+          phase: phaseName,
+          status: 'failed',
+          tool: event.step.tool,
+          error: event.error,
+        }),
+      );
+      const cleared = state.activeStepId === event.step.stepId ? undefined : state.activeStepId;
+      return appendLog(
+        { ...state, phases, activeStepId: cleared },
+        'error',
+        `步骤失败: ${event.step.description} — ${event.error}`,
+      );
+    }
+
+    case 'security_decision':
+      return appendLog(
+        state,
+        event.decision.decision === 'deny' ? 'error' : 'warn',
+        `安全决策 [${event.decision.riskLevel}] ${event.decision.toolName}: ${event.decision.message}`,
+      );
+
+    case 'stream_token':
+      return {
+        ...state,
+        tokensByStep: {
+          ...state.tokensByStep,
+          [event.stepId]: (state.tokensByStep[event.stepId] ?? '') + event.token,
+        },
+      };
+
+    case 'validation_failed':
+      return appendLog(
+        state,
+        'warn',
+        `校验失败${event.result.blockedBy?.length ? `: ${event.result.blockedBy.join(', ')}` : ''}`,
+      );
+
+    case 'rollback_started':
+      return appendLog(state, 'warn', `回滚开始: ${event.snapshotId}`);
+
+    case 'rollback_completed':
+      return appendLog(state, 'info', `回滚完成: ${event.snapshotId}`);
+
+    case 'task_completed':
+      return appendLog(
+        { ...state, status: 'completed', result: event.result, activeStepId: undefined },
+        event.result.success ? 'success' : 'warn',
+        `任务完成${event.result.success ? '' : '（部分失败）'}`,
+      );
+
+    case 'task_failed':
+      return appendLog(
+        { ...state, status: 'failed', error: event.error, activeStepId: undefined },
+        'error',
+        `任务失败: ${event.error}`,
+      );
+
+    default:
+      return assertNever(event);
+  }
+}
+
+/** Fold a whole event sequence from the initial state — convenient for tests and replays. */
+export function reduceEvents(
+  events: AgentEvent[],
+  state: ConsoleState = initialConsoleState,
+): ConsoleState {
+  return events.reduce(consoleReducer, state);
+}
+
+function assertNever(event: never): never {
+  throw new Error(`Unhandled agent event: ${JSON.stringify(event)}`);
+}

--- a/apps/desktop/src/state/executionReducer.ts
+++ b/apps/desktop/src/state/executionReducer.ts
@@ -287,11 +287,15 @@ export function consoleReducer(state: ConsoleState, event: AgentEvent): ConsoleS
       return appendLog(state, 'info', `回滚完成: ${event.snapshotId}`);
 
     case 'task_completed':
+      // A `task_completed` event only means the run reached its end — the run
+      // may still have failed. Route the status by `result.success` so the UI
+      // can rely on `status` alone and never paints a failed run as successful.
       return appendLog(
         {
           ...state,
-          status: 'completed',
+          status: event.result.success ? 'completed' : 'failed',
           result: event.result,
+          error: event.result.success ? state.error : (event.result.error ?? state.error),
           activeStepId: undefined,
           phases: terminalizeRunningSteps(
             state.phases,
@@ -300,7 +304,7 @@ export function consoleReducer(state: ConsoleState, event: AgentEvent): ConsoleS
           ),
         },
         event.result.success ? 'success' : 'warn',
-        `任务完成${event.result.success ? '' : '（部分失败）'}`,
+        `任务完成${event.result.success ? '' : '（失败）'}`,
       );
 
     case 'task_failed':

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,22 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  apps/desktop:
+    dependencies:
+      '@frontagent/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@frontagent/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(vite@7.3.2(@types/node@25.9.1)(yaml@2.9.0))
+
   apps/vscode:
     devDependencies:
       '@frontagent/runtime-node':


### PR DESCRIPTION
Closes #325. First incremental slice (1/3) of the standalone Electron desktop app.

## What this adds

A third FrontAgent entry point alongside the CLI and VS Code extension: `apps/desktop`, reusing `@frontagent/runtime-node` as its execution spine. This PR establishes the load-bearing architecture only — no heavy runtime deps.

- **`apps/desktop` scaffold** — pnpm workspace member (`package.json`, `tsconfig.json`) wired into turbo `build`/`typecheck`/`test`. Only `@frontagent/core` + `@frontagent/shared` (type-only) deps; no React/Electron/Vite yet.
- **`src/ipc/contract.ts`** — the typed cross-process IPC boundary: channel names, request/response payloads, and the `FrontAgentBridge` interface the renderer will depend on. A deliberately minimal, explicit contract surface (keel §2) that re-exports the `AgentEvent` / `ApprovalRequest` types it carries across the process boundary.
- **`src/state/executionReducer.ts`** — a pure, framework-agnostic reducer `(ConsoleState, AgentEvent) -> ConsoleState` modeling run status, phase lanes, step states, log lines, per-step stream tokens, and the final result. Total over the `AgentEvent` union; never mutates input.
- **`executionReducer.test.ts`** — 11 vitest cases across the full event union (planning → phases → steps → success/failure, security decisions, token streaming, phase summaries, immutability, full happy-path replay).

## Incremental roadmap

1. **This PR — foundation** (contract + reducer + tests).
2. Renderer UI (React + Vite, frontend-design) driven by a mock event stream — browser-reviewable.
3. Electron main/preload shell + runtime bridge wiring to `@frontagent/runtime-node`.

## Why this slice first

Fixes the architectural boundary (IPC contract) and the testable heart (reducer) with zero heavy deps, so the UI and Electron PRs attach to a verified spine rather than redesigning at the end.

## GitNexus Impact Summary

- **Risk level:** Low.
- **Critical skeleton changes:** None — purely additive new package (`apps/desktop`); no existing symbol, export, or execution flow modified. `pnpm-lock.yaml` updated to link the new workspace member.
- **GitNexus impact:** `detect_changes` (scope=staged, repo=FrontAgent) → `changed_count: 0`, `affected_count: 0`, `risk_level: low`, `changed_files: 6`. No indexed symbols or processes affected (new files not yet in graph; nothing existing touched).
- **Verification:** `pnpm lint` (1 pre-existing info only), `pnpm typecheck` (23/23 tasks), `pnpm test` (23/23 tasks; desktop 11/11). Pre-commit `quality:precommit` gate ran green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)