### PR TITLE
feat(desktop): renderer UI — Task Console + Settings (React + Vite)

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -4,12 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FrontAgent · Console</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
+    <!-- Fonts are bundled via @fontsource (imported in main.tsx); no remote font CDN. -->
   </head>
   <body>
     <div id="root"></div>

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FrontAgent · Console</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/renderer/main.tsx"></script>
+  </body>
+</html>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,6 +13,9 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@fontsource/chakra-petch": "^5.2.0",
+    "@fontsource/ibm-plex-mono": "^5.2.0",
+    "@fontsource/ibm-plex-sans": "^5.2.0",
     "@frontagent/core": "workspace:*",
     "@frontagent/shared": "workspace:*",
     "react": "^19.2.0",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,18 +6,24 @@
   "type": "module",
   "main": "./dist/electron/main.js",
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "dev": "vite",
+    "build": "vite build",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },
   "dependencies": {
     "@frontagent/core": "workspace:*",
-    "@frontagent/shared": "workspace:*"
+    "@frontagent/shared": "workspace:*",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
   },
   "devDependencies": {
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "@vitejs/plugin-react": "^5.1.0",
     "typescript": "^6.0.3",
+    "vite": "^7.1.0",
     "vitest": "^4.1.7"
   }
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,7 +7,7 @@
   "main": "./dist/electron/main.js",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "tsc --noEmit && vite build",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/apps/desktop/src/ipc/contract.ts
+++ b/apps/desktop/src/ipc/contract.ts
@@ -87,6 +87,16 @@ export interface ApprovalRequestEnvelope {
  * Renderer code depends only on this interface.
  */
 export interface FrontAgentBridge {
+  /**
+   * Start a task.
+   *
+   * **Timing contract:** the returned promise MUST resolve with the `runId`
+   * *before* any {@link AgentEventEnvelope} or {@link ApprovalRequestEnvelope}
+   * for that run is pushed. The renderer store gates incoming envelopes on the
+   * resolved active `runId`; any envelope delivered before resolution is
+   * dropped. PR3's Electron main/preload implementation must therefore reply to
+   * the `RunTask` invoke first, then begin streaming the run's events.
+   */
   runTask(req: RunTaskRequest): Promise<RunTaskResponse>;
   cancelTask(runId: string): Promise<void>;
   respondApproval(input: ApprovalDecisionInput): Promise<void>;

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -11,8 +11,8 @@ type View = 'console' | 'settings';
 
 export function App({ bridge }: { bridge: FrontAgentBridge }) {
   const [view, setView] = useState<View>('console');
-  const { state, runTask, respondApproval } = useConsoleState(bridge);
-  const running = state.status === 'running' || state.status === 'planning';
+  const { state, launching, runTask, respondApproval } = useConsoleState(bridge);
+  const running = launching || state.status === 'running' || state.status === 'planning';
 
   return (
     <div className="shell">

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import type { FrontAgentBridge } from '../ipc/contract.js';
+import { EventStream } from './components/EventStream.js';
+import { ExecutionTimeline } from './components/ExecutionTimeline.js';
+import { SettingsPanel } from './components/SettingsPanel.js';
+import { StatusPill } from './components/StatusPill.js';
+import { TaskComposer } from './components/TaskComposer.js';
+import { useConsoleState } from './store/useConsoleState.js';
+
+type View = 'console' | 'settings';
+
+export function App({ bridge }: { bridge: FrontAgentBridge }) {
+  const [view, setView] = useState<View>('console');
+  const { state, runTask, respondApproval } = useConsoleState(bridge);
+  const running = state.status === 'running' || state.status === 'planning';
+
+  return (
+    <div className="shell">
+      <aside className="rail">
+        <div className="brand">
+          <div className="brand-mark" />
+          <div className="brand-name">
+            FrontAgent
+            <small>Console</small>
+          </div>
+        </div>
+        <nav className="nav">
+          <button
+            type="button"
+            className="nav-item"
+            data-active={view === 'console'}
+            onClick={() => setView('console')}
+          >
+            <span className="nav-dot" /> 任务控制台
+          </button>
+          <button
+            type="button"
+            className="nav-item"
+            data-active={view === 'settings'}
+            onClick={() => setView('settings')}
+          >
+            <span className="nav-dot" /> 设置
+          </button>
+        </nav>
+        <div className="rail-foot">
+          v2.1.1 · electron
+          <br />
+          spine · runtime-node
+          <br />
+          mock bridge · PR2
+        </div>
+      </aside>
+
+      <main className="main">
+        <header className="topbar">
+          <h1>{view === 'console' ? '任务控制台' : '设置'}</h1>
+          <span className="spacer" />
+          <StatusPill status={state.status} />
+        </header>
+
+        {view === 'console' ? (
+          <div className="console">
+            <section className="timeline-col">
+              <TaskComposer disabled={running} onRun={runTask} />
+              <ExecutionTimeline phases={state.phases} activeStepId={state.activeStepId} />
+            </section>
+            <EventStream state={state} onApproval={respondApproval} />
+          </div>
+        ) : (
+          <SettingsPanel bridge={bridge} />
+        )}
+      </main>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/ApprovalDrawer.tsx
+++ b/apps/desktop/src/renderer/components/ApprovalDrawer.tsx
@@ -1,0 +1,36 @@
+import type { ApprovalRequest } from '../../ipc/contract.js';
+
+export function ApprovalDrawer({
+  request,
+  onDecide,
+}: {
+  request: ApprovalRequest;
+  onDecide: (approvalId: string, approved: boolean) => void;
+}) {
+  return (
+    <div className="approval">
+      <div className="approval-head">
+        ⚠ 需要审批 · {request.toolName}
+        <span className="risk">{request.riskLevel}</span>
+      </div>
+      <div className="approval-msg">{request.message}</div>
+      <div className="approval-cmd">$ {request.argsSummary}</div>
+      <div className="approval-actions">
+        <button
+          type="button"
+          className="btn btn-danger"
+          onClick={() => onDecide(request.approvalId, false)}
+        >
+          拒绝
+        </button>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={() => onDecide(request.approvalId, true)}
+        >
+          批准
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/EventStream.tsx
+++ b/apps/desktop/src/renderer/components/EventStream.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from 'react';
+import type { ConsoleState } from '../../state/executionReducer.js';
+import { ApprovalDrawer } from './ApprovalDrawer.js';
+
+export function EventStream({
+  state,
+  onApproval,
+}: {
+  state: ConsoleState;
+  onApproval: (approvalId: string, approved: boolean) => void;
+}) {
+  const logRef = useRef<HTMLDivElement>(null);
+  const activeTokens = state.activeStepId ? state.tokensByStep[state.activeStepId] : undefined;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-scroll on every appended log line
+  useEffect(() => {
+    logRef.current?.scrollTo({ top: logRef.current.scrollHeight });
+  }, [state.log.length, activeTokens]);
+
+  return (
+    <aside className="stream">
+      <div className="stream-head">⚡ 遥测流 · TELEMETRY</div>
+
+      {state.pendingApprovals.map((request) => (
+        <ApprovalDrawer key={request.approvalId} request={request} onDecide={onApproval} />
+      ))}
+
+      {activeTokens ? (
+        <div className="tokens">
+          <div className="tokens-head">流式输出 · {state.activeStepId}</div>
+          <div className="tokens-body">{activeTokens}</div>
+        </div>
+      ) : null}
+
+      <div className="stream-log" ref={logRef}>
+        {state.log.length === 0 ? (
+          <div className="log-line" data-l="info">
+            <span className="log-text" style={{ color: 'var(--ink-faint)' }}>
+              空 · 暂无事件
+            </span>
+          </div>
+        ) : (
+          state.log.map((line) => (
+            <div className="log-line" data-l={line.level} key={line.seq}>
+              <span className="log-seq">{String(line.seq).padStart(3, '0')}</span>
+              <span className="log-text">{line.text}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/apps/desktop/src/renderer/components/ExecutionTimeline.tsx
+++ b/apps/desktop/src/renderer/components/ExecutionTimeline.tsx
@@ -1,0 +1,78 @@
+import type { PhaseStatusView, PhaseView } from '../../state/executionReducer.js';
+
+const PHASE_TAG: Record<PhaseStatusView, string> = {
+  pending: '待执行',
+  active: '进行中',
+  completed: '已完成',
+};
+
+export function ExecutionTimeline({
+  phases,
+  activeStepId,
+}: {
+  phases: PhaseView[];
+  activeStepId?: string;
+}) {
+  if (phases.length === 0) {
+    return (
+      <div className="lanes">
+        <div className="lanes-empty">
+          <span className="glyph">⌖</span>
+          等待任务编排
+          <br />
+          运行一个任务以查看实时阶段与步骤遥测
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="lanes">
+      {phases.map((phase, index) => (
+        <section className="lane" key={phase.name}>
+          <header className="lane-head">
+            <span className="lane-idx">{String(index + 1).padStart(2, '0')}</span>
+            <span className="lane-name">{phase.name}</span>
+            <span className="lane-tag" data-s={phase.status}>
+              {PHASE_TAG[phase.status]}
+            </span>
+            <span className="lane-meta">
+              {phase.steps.length}/{Math.max(phase.expectedSteps, phase.steps.length)} 步
+            </span>
+          </header>
+          <div className="steps">
+            {phase.steps.length === 0 ? (
+              <div className="step" data-s="pending">
+                <span className="step-icon" />
+                <div className="step-body">
+                  <div className="step-title" style={{ color: 'var(--ink-faint)' }}>
+                    等待步骤…
+                  </div>
+                </div>
+              </div>
+            ) : (
+              phase.steps.map((step) => (
+                <div
+                  className="step"
+                  data-s={step.status}
+                  key={step.id}
+                  data-active={step.id === activeStepId}
+                >
+                  <span className="step-icon" />
+                  <div className="step-body">
+                    <div className="step-title">{step.title}</div>
+                    <div className="step-sub">
+                      <span>#{step.id}</span>
+                      {step.tool ? <span className="step-tool">{step.tool}</span> : null}
+                    </div>
+                    {step.error ? <div className="step-err">⚠ {step.error}</div> : null}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/SettingsPanel.tsx
@@ -32,7 +32,8 @@ export function SettingsPanel({ bridge }: { bridge: FrontAgentBridge }) {
     <div className="settings">
       <h2>设置</h2>
       <p className="hint">
-        凭据与默认值在本机保存（PR3 接入安全存储）。Base URL 留空使用 provider 默认。
+        设置仅在本会话内保存（刷新后不保留）；本机安全存储与持久化在 PR3 接入。Base URL 留空使用
+        provider 默认。
       </p>
       {FIELDS.map((field) => (
         <div className="setting-group" key={field.key}>

--- a/apps/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/SettingsPanel.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import type { DesktopSettings, FrontAgentBridge } from '../../ipc/contract.js';
+
+const FIELDS: { key: keyof DesktopSettings; label: string; placeholder: string }[] = [
+  { key: 'provider', label: 'Provider', placeholder: 'anthropic' },
+  { key: 'model', label: 'Model', placeholder: 'claude-opus-4-8' },
+  { key: 'baseUrl', label: 'Base URL', placeholder: 'https://api.anthropic.com' },
+  { key: 'defaultWorkspacePath', label: '默认工作区', placeholder: '~/projects' },
+];
+
+export function SettingsPanel({ bridge }: { bridge: FrontAgentBridge }) {
+  const [settings, setSettings] = useState<DesktopSettings | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    bridge.getSettings().then(setSettings);
+  }, [bridge]);
+
+  if (!settings) return <div className="settings">加载中…</div>;
+
+  const update = (key: keyof DesktopSettings, value: string) => {
+    setSettings({ ...settings, [key]: value });
+    setSaved(false);
+  };
+
+  const save = async () => {
+    await bridge.saveSettings(settings);
+    setSaved(true);
+  };
+
+  return (
+    <div className="settings">
+      <h2>设置</h2>
+      <p className="hint">
+        凭据与默认值在本机保存（PR3 接入安全存储）。Base URL 留空使用 provider 默认。
+      </p>
+      {FIELDS.map((field) => (
+        <div className="setting-group" key={field.key}>
+          <label htmlFor={field.key}>{field.label}</label>
+          <input
+            id={field.key}
+            value={settings[field.key] ?? ''}
+            placeholder={field.placeholder}
+            onChange={(e) => update(field.key, e.target.value)}
+          />
+        </div>
+      ))}
+      <button type="button" className="btn btn-primary" onClick={save}>
+        保存设置
+        {saved ? <span className="settings-saved">✓ 已保存</span> : null}
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/StatusPill.tsx
+++ b/apps/desktop/src/renderer/components/StatusPill.tsx
@@ -1,0 +1,18 @@
+import type { RunStatus } from '../../state/executionReducer.js';
+
+const LABELS: Record<RunStatus, string> = {
+  idle: '待命',
+  planning: '规划中',
+  running: '执行中',
+  completed: '已完成',
+  failed: '失败',
+};
+
+export function StatusPill({ status }: { status: RunStatus }) {
+  return (
+    <span className="status-pill" data-status={status}>
+      <span className="beacon" />
+      {LABELS[status]}
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/components/TaskComposer.tsx
+++ b/apps/desktop/src/renderer/components/TaskComposer.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import type { RunTaskRequest } from '../../ipc/contract.js';
+
+export function TaskComposer({
+  disabled,
+  onRun,
+}: {
+  disabled: boolean;
+  onRun: (req: RunTaskRequest) => void;
+}) {
+  const [task, setTask] = useState('为登录页添加深色模式切换');
+  const [workspacePath, setWorkspacePath] = useState('~/projects/login-page');
+  const [browserUrl, setBrowserUrl] = useState('http://localhost:5173');
+
+  const submit = () => {
+    if (disabled || task.trim().length === 0) return;
+    onRun({ task: task.trim(), workspacePath, browserUrl: browserUrl || undefined });
+  };
+
+  return (
+    <div className="composer">
+      <textarea
+        value={task}
+        onChange={(e) => setTask(e.target.value)}
+        placeholder="描述要让 FrontAgent 执行的前端任务…"
+        onKeyDown={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') submit();
+        }}
+      />
+      <div className="composer-row">
+        <div className="field">
+          <label htmlFor="ws">工作区</label>
+          <input id="ws" value={workspacePath} onChange={(e) => setWorkspacePath(e.target.value)} />
+        </div>
+        <div className="field">
+          <label htmlFor="url">URL</label>
+          <input id="url" value={browserUrl} onChange={(e) => setBrowserUrl(e.target.value)} />
+        </div>
+        <button type="button" className="btn btn-primary" disabled={disabled} onClick={submit}>
+          {disabled ? '执行中…' : '运行任务 ⌘↵'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -1,5 +1,17 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+// Fonts are bundled (not loaded from a remote CDN) so the packaged desktop app
+// works offline and needs no third-party network requests.
+import '@fontsource/chakra-petch/500.css';
+import '@fontsource/chakra-petch/600.css';
+import '@fontsource/chakra-petch/700.css';
+import '@fontsource/ibm-plex-sans/400.css';
+import '@fontsource/ibm-plex-sans/500.css';
+import '@fontsource/ibm-plex-sans/600.css';
+import '@fontsource/ibm-plex-sans/700.css';
+import '@fontsource/ibm-plex-mono/400.css';
+import '@fontsource/ibm-plex-mono/500.css';
+import '@fontsource/ibm-plex-mono/600.css';
 import { App } from './App.js';
 import { createMockBridge } from './mock/mockBridge.js';
 import './theme.css';

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -1,0 +1,18 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App.js';
+import { createMockBridge } from './mock/mockBridge.js';
+import './theme.css';
+
+// PR 2 runs the renderer against the in-browser mock bridge. PR 3 swaps this
+// for the preload bridge exposed by the Electron main process over IPC.
+const bridge = createMockBridge();
+
+const root = document.getElementById('root');
+if (!root) throw new Error('missing #root');
+
+createRoot(root).render(
+  <StrictMode>
+    <App bridge={bridge} />
+  </StrictMode>,
+);

--- a/apps/desktop/src/renderer/mock/mockBridge.test.ts
+++ b/apps/desktop/src/renderer/mock/mockBridge.test.ts
@@ -44,6 +44,34 @@ describe('mock bridge driving the console store', () => {
     store.dispose();
   });
 
+  it('resets state when a new run starts after a previous run finished', async () => {
+    const store = createConsoleStore(createMockBridge());
+
+    // First run to completion.
+    await store.runTask({ task: 'demo', workspacePath: '/tmp/demo' });
+    await vi.advanceTimersByTimeAsync(12_000);
+    await store.respondApproval(store.getState().pendingApprovals[0]?.approvalId as string, true);
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(store.getState().status).toBe('completed');
+
+    // Second run: the store eagerly resets before any event arrives.
+    await store.runTask({ task: 'again', workspacePath: '/tmp/demo' });
+    const reset = store.getState();
+    expect(reset.status).toBe('idle');
+    expect(reset.result).toBeUndefined();
+    expect(reset.pendingApprovals).toHaveLength(0);
+    expect(reset.phases).toHaveLength(0);
+    expect(reset.log).toHaveLength(0);
+
+    // And the fresh run rebuilds cleanly with no leftovers from the first.
+    await vi.advanceTimersByTimeAsync(12_000);
+    const second = store.getState();
+    expect(second.phases.map((p) => p.name)).toEqual(['实现', '验证']);
+    expect(second.pendingApprovals).toHaveLength(1);
+    expect(second.result).toBeUndefined();
+    store.dispose();
+  });
+
   it('fails the run when the approval is rejected', async () => {
     const store = createConsoleStore(createMockBridge());
     await store.runTask({ task: 'demo', workspacePath: '/tmp/demo' });

--- a/apps/desktop/src/renderer/mock/mockBridge.test.ts
+++ b/apps/desktop/src/renderer/mock/mockBridge.test.ts
@@ -8,6 +8,7 @@ describe('mock bridge driving the console store', () => {
 
   it('replays the scripted run into phase lanes and pauses on an approval', async () => {
     const store = createConsoleStore(createMockBridge());
+    store.subscribe(() => {});
 
     await store.runTask({ task: 'demo', workspacePath: '/tmp/demo' });
     await vi.advanceTimersByTimeAsync(12_000);
@@ -28,6 +29,7 @@ describe('mock bridge driving the console store', () => {
 
   it('completes the run when the approval is granted', async () => {
     const store = createConsoleStore(createMockBridge());
+    store.subscribe(() => {});
     await store.runTask({ task: 'demo', workspacePath: '/tmp/demo' });
     await vi.advanceTimersByTimeAsync(12_000);
 
@@ -46,6 +48,7 @@ describe('mock bridge driving the console store', () => {
 
   it('resets state when a new run starts after a previous run finished', async () => {
     const store = createConsoleStore(createMockBridge());
+    store.subscribe(() => {});
 
     // First run to completion.
     await store.runTask({ task: 'demo', workspacePath: '/tmp/demo' });
@@ -74,6 +77,7 @@ describe('mock bridge driving the console store', () => {
 
   it('fails the run when the approval is rejected', async () => {
     const store = createConsoleStore(createMockBridge());
+    store.subscribe(() => {});
     await store.runTask({ task: 'demo', workspacePath: '/tmp/demo' });
     await vi.advanceTimersByTimeAsync(12_000);
 

--- a/apps/desktop/src/renderer/mock/mockBridge.test.ts
+++ b/apps/desktop/src/renderer/mock/mockBridge.test.ts
@@ -57,10 +57,11 @@ describe('mock bridge driving the console store', () => {
     await vi.advanceTimersByTimeAsync(4_000);
     expect(store.getState().status).toBe('completed');
 
-    // Second run: the store eagerly resets before any event arrives.
+    // Second run: the store resets and enters 'planning' before any event
+    // arrives (so the composer stays disabled through the launch window).
     await store.runTask({ task: 'again', workspacePath: '/tmp/demo' });
     const reset = store.getState();
-    expect(reset.status).toBe('idle');
+    expect(reset.status).toBe('planning');
     expect(reset.result).toBeUndefined();
     expect(reset.pendingApprovals).toHaveLength(0);
     expect(reset.phases).toHaveLength(0);

--- a/apps/desktop/src/renderer/mock/mockBridge.test.ts
+++ b/apps/desktop/src/renderer/mock/mockBridge.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createConsoleStore } from '../store/consoleStore.js';
+import { createMockBridge } from './mockBridge.js';
+
+describe('mock bridge driving the console store', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('replays the scripted run into phase lanes and pauses on an approval', async () => {
+    const store = createConsoleStore(createMockBridge());
+
+    await store.runTask({ task: 'demo', workspacePath: '/tmp/demo' });
+    await vi.advanceTimersByTimeAsync(12_000);
+
+    const state = store.getState();
+    expect(state.task).toContain('深色模式');
+    expect(state.phases.map((p) => p.name)).toEqual(['实现', '验证']);
+    // The 实现 phase ran two steps to completion.
+    const impl = state.phases.find((p) => p.name === '实现');
+    expect(impl?.status).toBe('completed');
+    expect(impl?.steps.every((s) => s.status === 'completed')).toBe(true);
+    // The run is paused on a pending approval, not yet terminal.
+    expect(state.pendingApprovals).toHaveLength(1);
+    expect(state.status).toBe('running');
+
+    store.dispose();
+  });
+
+  it('completes the run when the approval is granted', async () => {
+    const store = createConsoleStore(createMockBridge());
+    await store.runTask({ task: 'demo', workspacePath: '/tmp/demo' });
+    await vi.advanceTimersByTimeAsync(12_000);
+
+    const approvalId = store.getState().pendingApprovals[0]?.approvalId;
+    expect(approvalId).toBeTruthy();
+
+    await store.respondApproval(approvalId as string, true);
+    await vi.advanceTimersByTimeAsync(4_000);
+
+    const state = store.getState();
+    expect(state.pendingApprovals).toHaveLength(0);
+    expect(state.status).toBe('completed');
+    expect(state.result?.success).toBe(true);
+    store.dispose();
+  });
+
+  it('fails the run when the approval is rejected', async () => {
+    const store = createConsoleStore(createMockBridge());
+    await store.runTask({ task: 'demo', workspacePath: '/tmp/demo' });
+    await vi.advanceTimersByTimeAsync(12_000);
+
+    const approvalId = store.getState().pendingApprovals[0]?.approvalId as string;
+    await store.respondApproval(approvalId, false);
+    await vi.advanceTimersByTimeAsync(4_000);
+
+    const state = store.getState();
+    expect(state.status).toBe('failed');
+    expect(state.pendingApprovals).toHaveLength(0);
+    store.dispose();
+  });
+});

--- a/apps/desktop/src/renderer/mock/mockBridge.ts
+++ b/apps/desktop/src/renderer/mock/mockBridge.ts
@@ -1,0 +1,227 @@
+/**
+ * In-browser mock of the {@link FrontAgentBridge}. Replays a scripted agent run
+ * (planning -> two phases -> approval -> completion) so the renderer is fully
+ * exercisable without the Electron main process or a real runtime. PR 3
+ * replaces this with the preload bridge over IPC.
+ */
+import type {
+  AgentEvent,
+  AgentEventEnvelope,
+  ApprovalDecisionInput,
+  ApprovalRequest,
+  ApprovalRequestEnvelope,
+  DesktopSettings,
+  FrontAgentBridge,
+  RunTaskRequest,
+  RunTaskResponse,
+} from '../../ipc/contract.js';
+
+type AgentListener = (envelope: AgentEventEnvelope) => void;
+type ApprovalListener = (envelope: ApprovalRequestEnvelope) => void;
+
+const STEP_DELAY_MS = 650;
+
+function scriptedRun(runId: string): { event: AgentEvent; after: number }[] {
+  const mk = (event: AgentEvent, after: number) => ({ event, after });
+  let t = 0;
+  const at = () => (t += STEP_DELAY_MS);
+  void runId;
+  return [
+    mk(
+      {
+        type: 'task_started',
+        task: { id: 't1', type: 'modify', description: '为登录页添加深色模式切换' },
+      },
+      (t = 200),
+    ),
+    mk({ type: 'planning_started' }, at()),
+    mk(
+      {
+        type: 'planning_completed',
+        plan: {
+          taskId: 't1',
+          summary: '两阶段：实现深色模式样式与切换，然后验证可访问性',
+          steps: [],
+          phases: [
+            { phaseId: 'p1', name: '实现', description: '', stepIndices: [0, 1] },
+            { phaseId: 'p2', name: '验证', description: '', stepIndices: [2] },
+          ],
+          rollbackStrategy: {
+            enabled: true,
+            snapshotBeforeExecution: true,
+            rollbackOnFailure: true,
+            maxRollbackSteps: 5,
+          },
+        },
+      },
+      at(),
+    ),
+    mk({ type: 'phase_started', phase: '实现', stepCount: 2 }, at()),
+    mk(
+      {
+        type: 'step_started',
+        step: stepFixture('s1', '新增 theme.dark.css 变量', '实现', 'write_file'),
+      },
+      at(),
+    ),
+    mk(
+      { type: 'stream_token', token: ':root[data-theme="dark"] { --bg: #0b0e14; }', stepId: 's1' },
+      at(),
+    ),
+    mk(
+      {
+        type: 'step_completed',
+        step: stepFixture('s1', '新增 theme.dark.css 变量', '实现', 'write_file'),
+        result: { success: true, duration: 420 },
+      },
+      at(),
+    ),
+    mk(
+      {
+        type: 'step_started',
+        step: stepFixture('s2', '在 Header 接入主题切换按钮', '实现', 'apply_patch'),
+      },
+      at(),
+    ),
+    mk(
+      {
+        type: 'step_completed',
+        step: stepFixture('s2', '在 Header 接入主题切换按钮', '实现', 'apply_patch'),
+        result: { success: true, duration: 510 },
+      },
+      at(),
+    ),
+    mk({ type: 'phase_completed', phase: '实现', successCount: 2, failureCount: 0 }, at()),
+    mk({ type: 'phase_started', phase: '验证', stepCount: 1 }, at()),
+    mk(
+      {
+        type: 'step_started',
+        step: stepFixture('s3', '运行 dev server 并截图校验对比度', '验证', 'run_command'),
+      },
+      at(),
+    ),
+  ];
+}
+
+// The ExecutionStep shape carried by step_* events.
+type ScriptStep = Extract<AgentEvent, { type: 'step_started' }>['step'];
+
+function stepFixture(stepId: string, description: string, phase: string, tool: string): ScriptStep {
+  return {
+    stepId,
+    description,
+    action: 'write_file',
+    tool,
+    params: {},
+    dependencies: [],
+    validation: [],
+    status: 'running',
+    phase,
+  };
+}
+
+function approvalFixture(): ApprovalRequest {
+  return {
+    decision: 'ask',
+    approvalId: 'apv-1',
+    createdAt: new Date().toISOString(),
+    riskLevel: 'high',
+    reasonCode: 'shell_ask',
+    message: '该步骤需要执行 `pnpm dev` 启动本地服务器以截图校验。',
+    toolName: 'run_command',
+    argsSummary: 'pnpm dev --port 5173',
+    provenance: [],
+  };
+}
+
+export function createMockBridge(): FrontAgentBridge {
+  const agentListeners = new Set<AgentListener>();
+  const approvalListeners = new Set<ApprovalListener>();
+  let settings: DesktopSettings = {
+    provider: 'anthropic',
+    model: 'claude-opus-4-8',
+    baseUrl: '',
+    defaultWorkspacePath: '~/projects/login-page',
+  };
+  const timers: ReturnType<typeof setTimeout>[] = [];
+
+  return {
+    async runTask(_req: RunTaskRequest): Promise<RunTaskResponse> {
+      const runId = `run-${Date.now()}`;
+      const script = scriptedRun(runId);
+      for (const { event, after } of script) {
+        timers.push(
+          setTimeout(() => {
+            for (const listener of agentListeners) listener({ runId, event });
+          }, after),
+        );
+      }
+      // Pause for approval just after the verify step starts; resume on decision.
+      const approvalAt = (script.at(-1)?.after ?? 0) + STEP_DELAY_MS;
+      timers.push(
+        setTimeout(() => {
+          for (const listener of approvalListeners) listener({ runId, request: approvalFixture() });
+        }, approvalAt),
+      );
+      return { runId };
+    },
+    async cancelTask(): Promise<void> {
+      for (const timer of timers) clearTimeout(timer);
+      timers.length = 0;
+    },
+    async respondApproval(input: ApprovalDecisionInput): Promise<void> {
+      const runId = input.runId;
+      const tail: AgentEvent[] = input.approved
+        ? [
+            {
+              type: 'step_completed',
+              step: stepFixture('s3', '运行 dev server 并截图校验对比度', '验证', 'run_command'),
+              result: { success: true, duration: 880 },
+            },
+            { type: 'phase_completed', phase: '验证', successCount: 1, failureCount: 0 },
+            {
+              type: 'task_completed',
+              result: {
+                success: true,
+                taskId: 't1',
+                executedSteps: [],
+                duration: 3120,
+                validations: [],
+              },
+            },
+          ]
+        : [
+            {
+              type: 'step_failed',
+              step: stepFixture('s3', '运行 dev server 并截图校验对比度', '验证', 'run_command'),
+              error: '用户拒绝了 shell 审批',
+            },
+            { type: 'task_failed', error: '验证阶段被用户中断' },
+          ];
+      tail.forEach((event, index) => {
+        timers.push(
+          setTimeout(
+            () => {
+              for (const listener of agentListeners) listener({ runId, event });
+            },
+            (index + 1) * STEP_DELAY_MS,
+          ),
+        );
+      });
+    },
+    async getSettings(): Promise<DesktopSettings> {
+      return settings;
+    },
+    async saveSettings(next: DesktopSettings): Promise<void> {
+      settings = next;
+    },
+    onAgentEvent(listener) {
+      agentListeners.add(listener);
+      return () => agentListeners.delete(listener);
+    },
+    onApprovalRequested(listener) {
+      approvalListeners.add(listener);
+      return () => approvalListeners.delete(listener);
+    },
+  };
+}

--- a/apps/desktop/src/renderer/store/consoleStore.test.ts
+++ b/apps/desktop/src/renderer/store/consoleStore.test.ts
@@ -60,6 +60,7 @@ function createControllableBridge(
   return {
     bridge,
     responded,
+    activeListenerCount: () => agentListeners.size + approvalListeners.size,
     setRunId: (id: string) => {
       activeRunId = id;
     },
@@ -111,6 +112,7 @@ describe('consoleStore run isolation', () => {
   it('ignores agent events from a run that is not the active one', async () => {
     const ctl = createControllableBridge('R1');
     const store = createConsoleStore(ctl.bridge);
+    store.subscribe(() => {});
     await store.runTask({ task: 't', workspacePath: '/w' });
 
     ctl.emitEvent('OLD', stepStarted('s9', '旧阶段'));
@@ -124,6 +126,7 @@ describe('consoleStore run isolation', () => {
   it('ignores approval requests from a stale run and does not repoint the active run', async () => {
     const ctl = createControllableBridge('R1');
     const store = createConsoleStore(ctl.bridge);
+    store.subscribe(() => {});
     await store.runTask({ task: 't', workspacePath: '/w' });
 
     ctl.emitApproval('OLD', approval('old-apv'));
@@ -137,6 +140,7 @@ describe('consoleStore run isolation', () => {
   it('routes respondApproval to the active run even after interleaved stale envelopes', async () => {
     const ctl = createControllableBridge('R1');
     const store = createConsoleStore(ctl.bridge);
+    store.subscribe(() => {});
     await store.runTask({ task: 't', workspacePath: '/w' });
 
     ctl.emitApproval('R1', approval('apv-1'));
@@ -154,6 +158,7 @@ describe('consoleStore run isolation', () => {
   it('drops late envelopes from a prior run during the launch window (before runTask resolves)', async () => {
     const ctl = createControllableBridge('R2', { defer: true });
     const store = createConsoleStore(ctl.bridge);
+    store.subscribe(() => {});
 
     const launch = store.runTask({ task: 't', workspacePath: '/w' });
     expect(store.isLaunching()).toBe(true);
@@ -177,6 +182,7 @@ describe('consoleStore run isolation', () => {
   it('does not start a second run while a launch is in flight', async () => {
     const ctl = createControllableBridge('R1', { defer: true });
     const store = createConsoleStore(ctl.bridge);
+    store.subscribe(() => {});
 
     const first = store.runTask({ task: 't', workspacePath: '/w' });
     const second = store.runTask({ task: 't again', workspacePath: '/w' }); // re-entrant click
@@ -191,6 +197,7 @@ describe('consoleStore run isolation', () => {
   it('restores the pending approval when respondApproval fails to reach main', async () => {
     const ctl = createControllableBridge('R1', { deferRespond: true });
     const store = createConsoleStore(ctl.bridge);
+    store.subscribe(() => {});
     await store.runTask({ task: 't', workspacePath: '/w' });
     ctl.emitApproval('R1', approval('apv-1'));
     expect(store.getState().pendingApprovals).toHaveLength(1);
@@ -208,6 +215,7 @@ describe('consoleStore run isolation', () => {
   it('does not send a decision for an approval that is not pending (idempotent on double click)', async () => {
     const ctl = createControllableBridge('R1');
     const store = createConsoleStore(ctl.bridge);
+    store.subscribe(() => {});
     await store.runTask({ task: 't', workspacePath: '/w' });
     ctl.emitApproval('R1', approval('apv-1'));
 
@@ -222,6 +230,7 @@ describe('consoleStore run isolation', () => {
   it('does not restore a stale approval into a new run when the failed send resolves late', async () => {
     const ctl = createControllableBridge('R1', { deferRespond: true });
     const store = createConsoleStore(ctl.bridge);
+    store.subscribe(() => {});
     await store.runTask({ task: 't', workspacePath: '/w' });
     ctl.emitApproval('R1', approval('apv-1'));
 
@@ -242,6 +251,7 @@ describe('consoleStore run isolation', () => {
   it('returns to an explainable failed state and stops accepting envelopes when runTask rejects', async () => {
     const ctl = createControllableBridge('R1', { defer: true });
     const store = createConsoleStore(ctl.bridge);
+    store.subscribe(() => {});
 
     const launch = store.runTask({ task: 't', workspacePath: '/w' });
     ctl.failRun(new Error('IPC down'));
@@ -256,5 +266,29 @@ describe('consoleStore run isolation', () => {
     ctl.emitEvent('R1', stepStarted('s1', '实现'));
     expect(store.getState().phases).toHaveLength(0);
     store.dispose();
+  });
+});
+
+describe('consoleStore bridge-listener lifecycle', () => {
+  it('does not subscribe to the bridge until the first subscribe (StrictMode-safe construction)', () => {
+    const ctl = createControllableBridge('R1');
+    // Constructing the store must be side-effect-free: a render discarded by
+    // React StrictMode (whose effect cleanup never runs) must not leak listeners.
+    const store = createConsoleStore(ctl.bridge);
+    expect(ctl.activeListenerCount()).toBe(0);
+
+    const unsubscribe = store.subscribe(() => {});
+    expect(ctl.activeListenerCount()).toBeGreaterThan(0); // attached lazily on first subscribe
+
+    unsubscribe();
+    expect(ctl.activeListenerCount()).toBe(0); // detached on last unsubscribe
+  });
+
+  it('leaves no bridge listeners after a subscribe/dispose cycle', () => {
+    const ctl = createControllableBridge('R1');
+    const store = createConsoleStore(ctl.bridge);
+    store.subscribe(() => {});
+    store.dispose();
+    expect(ctl.activeListenerCount()).toBe(0);
   });
 });

--- a/apps/desktop/src/renderer/store/consoleStore.test.ts
+++ b/apps/desktop/src/renderer/store/consoleStore.test.ts
@@ -179,6 +179,21 @@ describe('consoleStore run isolation', () => {
     store.dispose();
   });
 
+  it('does not start a second run after runId resolves but before the first event', async () => {
+    const ctl = createControllableBridge('R1'); // runTask resolves immediately; no events emitted
+    const store = createConsoleStore(ctl.bridge);
+    store.subscribe(() => {});
+
+    await store.runTask({ task: 't', workspacePath: '/w' });
+    // runId has resolved but no agent event has arrived yet.
+    expect(store.getState().status).toBe('planning'); // store is busy
+    expect(store.isLaunching()).toBe(false);
+
+    await store.runTask({ task: 'again', workspacePath: '/w' });
+    expect(ctl.runTaskCalls()).toBe(1); // second launch rejected — single active run
+    store.dispose();
+  });
+
   it('does not start a second run while a launch is in flight', async () => {
     const ctl = createControllableBridge('R1', { defer: true });
     const store = createConsoleStore(ctl.bridge);
@@ -236,7 +251,9 @@ describe('consoleStore run isolation', () => {
 
     const pending = store.respondApproval('apv-1', true); // decisionRunId = R1, awaits gate
 
-    // A new run starts before the (doomed) approval send settles.
+    // R1 ends, then a new run starts before the (doomed) approval send settles.
+    // (The single-active-run guard requires R1 to be terminal before R2 starts.)
+    ctl.emitEvent('R1', { type: 'task_failed', error: '中断' });
     ctl.setRunId('R2');
     await store.runTask({ task: 'again', workspacePath: '/w' });
 

--- a/apps/desktop/src/renderer/store/consoleStore.test.ts
+++ b/apps/desktop/src/renderer/store/consoleStore.test.ts
@@ -7,14 +7,27 @@ import type {
 } from '../../ipc/contract.js';
 import { createConsoleStore } from './consoleStore.js';
 
-/** Bridge whose envelopes are emitted by the test, so we can inject stale/interleaved runs. */
-function createControllableBridge(runId: string) {
+/**
+ * Bridge whose envelopes are emitted by the test, so we can inject
+ * stale/interleaved runs. `runTask` can be deferred so the launch window
+ * (before the new run id resolves) is observable.
+ */
+function createControllableBridge(runId: string, opts: { defer?: boolean } = {}) {
   const agentListeners = new Set<(e: { runId: string; event: AgentEvent }) => void>();
   const approvalListeners = new Set<(e: { runId: string; request: ApprovalRequest }) => void>();
   const responded: ApprovalDecisionInput[] = [];
+  let runTaskCalls = 0;
+  let settle: () => void = () => {};
+  let fail: (error: unknown) => void = () => {};
+  const gate = new Promise<void>((resolve, reject) => {
+    settle = resolve;
+    fail = reject;
+  });
 
   const bridge: FrontAgentBridge = {
     async runTask() {
+      runTaskCalls += 1;
+      if (opts.defer) await gate;
       return { runId };
     },
     async cancelTask() {},
@@ -38,6 +51,9 @@ function createControllableBridge(runId: string) {
   return {
     bridge,
     responded,
+    runTaskCalls: () => runTaskCalls,
+    settleRun: () => settle(),
+    failRun: (error: unknown) => fail(error),
     emitEvent(rid: string, event: AgentEvent) {
       for (const listener of agentListeners) listener({ runId: rid, event });
     },
@@ -111,7 +127,6 @@ describe('consoleStore run isolation', () => {
     await store.runTask({ task: 't', workspacePath: '/w' });
 
     ctl.emitApproval('R1', approval('apv-1'));
-    // A late envelope from a previous run arrives in between.
     ctl.emitApproval('OLD', approval('old-apv'));
     ctl.emitEvent('OLD', stepStarted('s9', '旧阶段'));
 
@@ -120,6 +135,62 @@ describe('consoleStore run isolation', () => {
     expect(ctl.responded).toHaveLength(1);
     expect(ctl.responded[0]).toMatchObject({ runId: 'R1', approvalId: 'apv-1', approved: true });
     expect(store.getState().pendingApprovals).toHaveLength(0);
+    store.dispose();
+  });
+
+  it('drops late envelopes from a prior run during the launch window (before runTask resolves)', async () => {
+    const ctl = createControllableBridge('R2', { defer: true });
+    const store = createConsoleStore(ctl.bridge);
+
+    const launch = store.runTask({ task: 't', workspacePath: '/w' });
+    expect(store.isLaunching()).toBe(true);
+
+    // While the new run id has not resolved yet, a late envelope from the prior
+    // run (or any run) must be ignored — the old run was invalidated.
+    ctl.emitEvent('R1', stepStarted('s9', '旧阶段'));
+    ctl.emitApproval('R1', approval('old-apv'));
+    expect(store.getState().phases).toHaveLength(0);
+    expect(store.getState().pendingApprovals).toHaveLength(0);
+
+    ctl.settleRun();
+    await launch;
+    expect(store.isLaunching()).toBe(false);
+
+    ctl.emitEvent('R2', stepStarted('s1', '实现'));
+    expect(store.getState().phases.map((p) => p.name)).toEqual(['实现']);
+    store.dispose();
+  });
+
+  it('does not start a second run while a launch is in flight', async () => {
+    const ctl = createControllableBridge('R1', { defer: true });
+    const store = createConsoleStore(ctl.bridge);
+
+    const first = store.runTask({ task: 't', workspacePath: '/w' });
+    const second = store.runTask({ task: 't again', workspacePath: '/w' }); // re-entrant click
+    expect(ctl.runTaskCalls()).toBe(1); // second call short-circuited
+
+    ctl.settleRun();
+    await Promise.all([first, second]);
+    expect(ctl.runTaskCalls()).toBe(1);
+    store.dispose();
+  });
+
+  it('returns to an explainable failed state and stops accepting envelopes when runTask rejects', async () => {
+    const ctl = createControllableBridge('R1', { defer: true });
+    const store = createConsoleStore(ctl.bridge);
+
+    const launch = store.runTask({ task: 't', workspacePath: '/w' });
+    ctl.failRun(new Error('IPC down'));
+    await launch;
+
+    const state = store.getState();
+    expect(state.status).toBe('failed');
+    expect(state.error).toContain('任务启动失败');
+    expect(store.isLaunching()).toBe(false);
+
+    // The old run was invalidated; nothing folds in afterwards.
+    ctl.emitEvent('R1', stepStarted('s1', '实现'));
+    expect(store.getState().phases).toHaveLength(0);
     store.dispose();
   });
 });

--- a/apps/desktop/src/renderer/store/consoleStore.test.ts
+++ b/apps/desktop/src/renderer/store/consoleStore.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  AgentEvent,
+  ApprovalDecisionInput,
+  ApprovalRequest,
+  FrontAgentBridge,
+} from '../../ipc/contract.js';
+import { createConsoleStore } from './consoleStore.js';
+
+/** Bridge whose envelopes are emitted by the test, so we can inject stale/interleaved runs. */
+function createControllableBridge(runId: string) {
+  const agentListeners = new Set<(e: { runId: string; event: AgentEvent }) => void>();
+  const approvalListeners = new Set<(e: { runId: string; request: ApprovalRequest }) => void>();
+  const responded: ApprovalDecisionInput[] = [];
+
+  const bridge: FrontAgentBridge = {
+    async runTask() {
+      return { runId };
+    },
+    async cancelTask() {},
+    async respondApproval(input) {
+      responded.push(input);
+    },
+    async getSettings() {
+      return { provider: 'anthropic', model: 'claude-opus-4-8' };
+    },
+    async saveSettings() {},
+    onAgentEvent(listener) {
+      agentListeners.add(listener);
+      return () => agentListeners.delete(listener);
+    },
+    onApprovalRequested(listener) {
+      approvalListeners.add(listener);
+      return () => approvalListeners.delete(listener);
+    },
+  };
+
+  return {
+    bridge,
+    responded,
+    emitEvent(rid: string, event: AgentEvent) {
+      for (const listener of agentListeners) listener({ runId: rid, event });
+    },
+    emitApproval(rid: string, request: ApprovalRequest) {
+      for (const listener of approvalListeners) listener({ runId: rid, request });
+    },
+  };
+}
+
+function stepStarted(stepId: string, phase: string): AgentEvent {
+  return {
+    type: 'step_started',
+    step: {
+      stepId,
+      description: `step ${stepId}`,
+      action: 'write_file',
+      tool: 'mcp-file',
+      params: {},
+      dependencies: [],
+      validation: [],
+      status: 'running',
+      phase,
+    },
+  };
+}
+
+function approval(approvalId: string): ApprovalRequest {
+  return {
+    decision: 'ask',
+    approvalId,
+    createdAt: '2026-06-13T00:00:00Z',
+    riskLevel: 'high',
+    reasonCode: 'shell_ask',
+    message: 'm',
+    toolName: 'run_command',
+    argsSummary: 'a',
+    provenance: [],
+  };
+}
+
+describe('consoleStore run isolation', () => {
+  it('ignores agent events from a run that is not the active one', async () => {
+    const ctl = createControllableBridge('R1');
+    const store = createConsoleStore(ctl.bridge);
+    await store.runTask({ task: 't', workspacePath: '/w' });
+
+    ctl.emitEvent('OLD', stepStarted('s9', '旧阶段'));
+    expect(store.getState().phases).toHaveLength(0); // stale event dropped
+
+    ctl.emitEvent('R1', stepStarted('s1', '实现'));
+    expect(store.getState().phases.map((p) => p.name)).toEqual(['实现']); // active event folded
+    store.dispose();
+  });
+
+  it('ignores approval requests from a stale run and does not repoint the active run', async () => {
+    const ctl = createControllableBridge('R1');
+    const store = createConsoleStore(ctl.bridge);
+    await store.runTask({ task: 't', workspacePath: '/w' });
+
+    ctl.emitApproval('OLD', approval('old-apv'));
+    expect(store.getState().pendingApprovals).toHaveLength(0); // stale approval dropped
+
+    ctl.emitApproval('R1', approval('apv-1'));
+    expect(store.getState().pendingApprovals.map((a) => a.approvalId)).toEqual(['apv-1']);
+    store.dispose();
+  });
+
+  it('routes respondApproval to the active run even after interleaved stale envelopes', async () => {
+    const ctl = createControllableBridge('R1');
+    const store = createConsoleStore(ctl.bridge);
+    await store.runTask({ task: 't', workspacePath: '/w' });
+
+    ctl.emitApproval('R1', approval('apv-1'));
+    // A late envelope from a previous run arrives in between.
+    ctl.emitApproval('OLD', approval('old-apv'));
+    ctl.emitEvent('OLD', stepStarted('s9', '旧阶段'));
+
+    await store.respondApproval('apv-1', true);
+
+    expect(ctl.responded).toHaveLength(1);
+    expect(ctl.responded[0]).toMatchObject({ runId: 'R1', approvalId: 'apv-1', approved: true });
+    expect(store.getState().pendingApprovals).toHaveLength(0);
+    store.dispose();
+  });
+});

--- a/apps/desktop/src/renderer/store/consoleStore.test.ts
+++ b/apps/desktop/src/renderer/store/consoleStore.test.ts
@@ -16,6 +16,7 @@ function createControllableBridge(runId: string, opts: { defer?: boolean } = {})
   const agentListeners = new Set<(e: { runId: string; event: AgentEvent }) => void>();
   const approvalListeners = new Set<(e: { runId: string; request: ApprovalRequest }) => void>();
   const responded: ApprovalDecisionInput[] = [];
+  let rejectRespond = false;
   let runTaskCalls = 0;
   let settle: () => void = () => {};
   let fail: (error: unknown) => void = () => {};
@@ -32,6 +33,7 @@ function createControllableBridge(runId: string, opts: { defer?: boolean } = {})
     },
     async cancelTask() {},
     async respondApproval(input) {
+      if (rejectRespond) throw new Error('IPC down');
       responded.push(input);
     },
     async getSettings() {
@@ -51,6 +53,9 @@ function createControllableBridge(runId: string, opts: { defer?: boolean } = {})
   return {
     bridge,
     responded,
+    setRejectRespond: (value: boolean) => {
+      rejectRespond = value;
+    },
     runTaskCalls: () => runTaskCalls,
     settleRun: () => settle(),
     failRun: (error: unknown) => fail(error),
@@ -172,6 +177,22 @@ describe('consoleStore run isolation', () => {
     ctl.settleRun();
     await Promise.all([first, second]);
     expect(ctl.runTaskCalls()).toBe(1);
+    store.dispose();
+  });
+
+  it('restores the pending approval when respondApproval fails to reach main', async () => {
+    const ctl = createControllableBridge('R1');
+    const store = createConsoleStore(ctl.bridge);
+    await store.runTask({ task: 't', workspacePath: '/w' });
+    ctl.emitApproval('R1', approval('apv-1'));
+    expect(store.getState().pendingApprovals).toHaveLength(1);
+
+    ctl.setRejectRespond(true);
+    await store.respondApproval('apv-1', true);
+
+    // Optimistic clear was rolled back so the user can retry the gate.
+    expect(store.getState().pendingApprovals.map((a) => a.approvalId)).toEqual(['apv-1']);
+    expect(ctl.responded).toHaveLength(0);
     store.dispose();
   });
 

--- a/apps/desktop/src/renderer/store/consoleStore.test.ts
+++ b/apps/desktop/src/renderer/store/consoleStore.test.ts
@@ -12,11 +12,14 @@ import { createConsoleStore } from './consoleStore.js';
  * stale/interleaved runs. `runTask` can be deferred so the launch window
  * (before the new run id resolves) is observable.
  */
-function createControllableBridge(runId: string, opts: { defer?: boolean } = {}) {
+function createControllableBridge(
+  runId: string,
+  opts: { defer?: boolean; deferRespond?: boolean } = {},
+) {
   const agentListeners = new Set<(e: { runId: string; event: AgentEvent }) => void>();
   const approvalListeners = new Set<(e: { runId: string; request: ApprovalRequest }) => void>();
   const responded: ApprovalDecisionInput[] = [];
-  let rejectRespond = false;
+  let activeRunId = runId;
   let runTaskCalls = 0;
   let settle: () => void = () => {};
   let fail: (error: unknown) => void = () => {};
@@ -24,16 +27,20 @@ function createControllableBridge(runId: string, opts: { defer?: boolean } = {})
     settle = resolve;
     fail = reject;
   });
+  let failRespondGate: (error: unknown) => void = () => {};
+  const respondGate = new Promise<void>((_, reject) => {
+    failRespondGate = reject;
+  });
 
   const bridge: FrontAgentBridge = {
     async runTask() {
       runTaskCalls += 1;
       if (opts.defer) await gate;
-      return { runId };
+      return { runId: activeRunId };
     },
     async cancelTask() {},
     async respondApproval(input) {
-      if (rejectRespond) throw new Error('IPC down');
+      if (opts.deferRespond) await respondGate; // rejected by failRespond()
       responded.push(input);
     },
     async getSettings() {
@@ -53,9 +60,10 @@ function createControllableBridge(runId: string, opts: { defer?: boolean } = {})
   return {
     bridge,
     responded,
-    setRejectRespond: (value: boolean) => {
-      rejectRespond = value;
+    setRunId: (id: string) => {
+      activeRunId = id;
     },
+    failRespond: (error: unknown) => failRespondGate(error),
     runTaskCalls: () => runTaskCalls,
     settleRun: () => settle(),
     failRun: (error: unknown) => fail(error),
@@ -181,18 +189,53 @@ describe('consoleStore run isolation', () => {
   });
 
   it('restores the pending approval when respondApproval fails to reach main', async () => {
-    const ctl = createControllableBridge('R1');
+    const ctl = createControllableBridge('R1', { deferRespond: true });
     const store = createConsoleStore(ctl.bridge);
     await store.runTask({ task: 't', workspacePath: '/w' });
     ctl.emitApproval('R1', approval('apv-1'));
     expect(store.getState().pendingApprovals).toHaveLength(1);
 
-    ctl.setRejectRespond(true);
-    await store.respondApproval('apv-1', true);
+    const pending = store.respondApproval('apv-1', true);
+    expect(store.getState().pendingApprovals).toHaveLength(0); // optimistic clear
+    ctl.failRespond(new Error('IPC down'));
+    await pending;
 
-    // Optimistic clear was rolled back so the user can retry the gate.
+    // Same run, so the cleared approval is rolled back for the user to retry.
     expect(store.getState().pendingApprovals.map((a) => a.approvalId)).toEqual(['apv-1']);
-    expect(ctl.responded).toHaveLength(0);
+    store.dispose();
+  });
+
+  it('does not send a decision for an approval that is not pending (idempotent on double click)', async () => {
+    const ctl = createControllableBridge('R1');
+    const store = createConsoleStore(ctl.bridge);
+    await store.runTask({ task: 't', workspacePath: '/w' });
+    ctl.emitApproval('R1', approval('apv-1'));
+
+    await store.respondApproval('apv-1', true);
+    await store.respondApproval('apv-1', true); // stale double-click
+    await store.respondApproval('missing', false); // unknown id
+
+    expect(ctl.responded).toHaveLength(1); // only the first, real decision was sent
+    store.dispose();
+  });
+
+  it('does not restore a stale approval into a new run when the failed send resolves late', async () => {
+    const ctl = createControllableBridge('R1', { deferRespond: true });
+    const store = createConsoleStore(ctl.bridge);
+    await store.runTask({ task: 't', workspacePath: '/w' });
+    ctl.emitApproval('R1', approval('apv-1'));
+
+    const pending = store.respondApproval('apv-1', true); // decisionRunId = R1, awaits gate
+
+    // A new run starts before the (doomed) approval send settles.
+    ctl.setRunId('R2');
+    await store.runTask({ task: 'again', workspacePath: '/w' });
+
+    ctl.failRespond(new Error('IPC down'));
+    await pending;
+
+    // The R1 approval must not leak back into the R2 run's state.
+    expect(store.getState().pendingApprovals).toHaveLength(0);
     store.dispose();
   });
 

--- a/apps/desktop/src/renderer/store/consoleStore.ts
+++ b/apps/desktop/src/renderer/store/consoleStore.ts
@@ -102,9 +102,16 @@ export function createConsoleStore(bridge: FrontAgentBridge): ConsoleStore {
     },
     async respondApproval(approvalId, approved, note) {
       if (!currentRunId) return;
+      const pending = state.pendingApprovals.find((a) => a.approvalId === approvalId);
       // Optimistically clear the approval from the queue, then notify main.
       set(resolveApproval(state, approvalId, approved));
-      await bridge.respondApproval({ runId: currentRunId, approvalId, approved, note });
+      try {
+        await bridge.respondApproval({ runId: currentRunId, approvalId, approved, note });
+      } catch {
+        // The decision did not reach main — restore the approval so the user
+        // can retry instead of losing a pending gate.
+        if (pending) set(addApprovalRequest(state, pending));
+      }
     },
     dispose() {
       offEvent();

--- a/apps/desktop/src/renderer/store/consoleStore.ts
+++ b/apps/desktop/src/renderer/store/consoleStore.ts
@@ -44,12 +44,16 @@ export function createConsoleStore(bridge: FrontAgentBridge): ConsoleStore {
     emit();
   };
 
+  // `currentRunId` is established authoritatively by `runTask` (the invoke
+  // returns the id before the main process streams). Listeners only fold
+  // envelopes for the active run, so a previous run's late events or approvals
+  // can never pollute the current one.
   const offEvent = bridge.onAgentEvent(({ runId, event }) => {
-    currentRunId = runId;
+    if (runId !== currentRunId) return;
     set(consoleReducer(state, event));
   });
   const offApproval = bridge.onApprovalRequested(({ runId, request }) => {
-    currentRunId = runId;
+    if (runId !== currentRunId) return;
     set(addApprovalRequest(state, request));
   });
 

--- a/apps/desktop/src/renderer/store/consoleStore.ts
+++ b/apps/desktop/src/renderer/store/consoleStore.ts
@@ -60,6 +60,11 @@ export function createConsoleStore(bridge: FrontAgentBridge): ConsoleStore {
       return () => listeners.delete(listener);
     },
     async runTask(req) {
+      // Reset immediately so a re-run never shows the previous run's phases,
+      // log, tokens or pending approvals during the gap before `task_started`
+      // arrives (the reducer also resets on task_started; this is the eager UI
+      // clear).
+      set(initialConsoleState);
       const { runId } = await bridge.runTask(req);
       currentRunId = runId;
     },

--- a/apps/desktop/src/renderer/store/consoleStore.ts
+++ b/apps/desktop/src/renderer/store/consoleStore.ts
@@ -17,12 +17,13 @@ import {
 
 export interface ConsoleStore {
   getState(): ConsoleState;
+  /** True between calling `runTask` and the bridge resolving the new run id. */
+  isLaunching(): boolean;
   subscribe(listener: () => void): () => void;
   runTask(req: RunTaskRequest): Promise<void>;
   /**
    * Answer the current pending approval. `runId` is tracked internally from the
-   * live event/approval envelopes (the desktop drives one active run), so the
-   * UI only supplies the decision.
+   * active run (the desktop drives one run), so the UI only supplies the decision.
    */
   respondApproval(approvalId: string, approved: boolean, note?: string): Promise<void>;
   /** Detach the bridge subscriptions. */
@@ -32,6 +33,10 @@ export interface ConsoleStore {
 export function createConsoleStore(bridge: FrontAgentBridge): ConsoleStore {
   let state = initialConsoleState;
   let currentRunId: string | undefined;
+  let launching = false;
+  // Monotonic launch token: guards against a slower earlier `runTask` resolving
+  // after a newer launch and clobbering the active run id.
+  let launchSeq = 0;
   const listeners = new Set<() => void>();
 
   const emit = () => {
@@ -44,10 +49,14 @@ export function createConsoleStore(bridge: FrontAgentBridge): ConsoleStore {
     emit();
   };
 
-  // `currentRunId` is established authoritatively by `runTask` (the invoke
-  // returns the id before the main process streams). Listeners only fold
-  // envelopes for the active run, so a previous run's late events or approvals
-  // can never pollute the current one.
+  const setLaunching = (value: boolean) => {
+    if (value === launching) return;
+    launching = value;
+    emit();
+  };
+
+  // Listeners fold only envelopes for the active run, so a previous/cancelled
+  // run's late events or approvals can never pollute the current console.
   const offEvent = bridge.onAgentEvent(({ runId, event }) => {
     if (runId !== currentRunId) return;
     set(consoleReducer(state, event));
@@ -59,18 +68,37 @@ export function createConsoleStore(bridge: FrontAgentBridge): ConsoleStore {
 
   return {
     getState: () => state,
+    isLaunching: () => launching,
     subscribe(listener) {
       listeners.add(listener);
       return () => listeners.delete(listener);
     },
     async runTask(req) {
-      // Reset immediately so a re-run never shows the previous run's phases,
-      // log, tokens or pending approvals during the gap before `task_started`
-      // arrives (the reducer also resets on task_started; this is the eager UI
-      // clear).
+      // Reject re-entrant launches: the composer is disabled while launching,
+      // but guard here too so a fast double-click can't start two runs.
+      if (launching) return;
+      const seq = ++launchSeq;
+      // Atomically invalidate the old run BEFORE clearing state, so a late
+      // envelope from the previous run can't slip through the `runId` gate and
+      // pollute the freshly-cleared console during the await window.
+      currentRunId = undefined;
       set(initialConsoleState);
-      const { runId } = await bridge.runTask(req);
-      currentRunId = runId;
+      setLaunching(true);
+      try {
+        const { runId } = await bridge.runTask(req);
+        if (seq !== launchSeq) return; // superseded by a newer launch
+        currentRunId = runId;
+      } catch (error) {
+        if (seq === launchSeq) {
+          // Leave the UI in an explainable failed state; the old run stays
+          // invalidated (currentRunId === undefined) so nothing else folds in.
+          set(
+            consoleReducer(initialConsoleState, { type: 'task_failed', error: launchError(error) }),
+          );
+        }
+      } finally {
+        if (seq === launchSeq) setLaunching(false);
+      }
     },
     async respondApproval(approvalId, approved, note) {
       if (!currentRunId) return;
@@ -84,4 +112,9 @@ export function createConsoleStore(bridge: FrontAgentBridge): ConsoleStore {
       listeners.clear();
     },
   };
+}
+
+function launchError(error: unknown): string {
+  const detail = error instanceof Error ? error.message : String(error);
+  return `任务启动失败: ${detail}`;
 }

--- a/apps/desktop/src/renderer/store/consoleStore.ts
+++ b/apps/desktop/src/renderer/store/consoleStore.ts
@@ -55,23 +55,40 @@ export function createConsoleStore(bridge: FrontAgentBridge): ConsoleStore {
     emit();
   };
 
-  // Listeners fold only envelopes for the active run, so a previous/cancelled
-  // run's late events or approvals can never pollute the current console.
-  const offEvent = bridge.onAgentEvent(({ runId, event }) => {
-    if (runId !== currentRunId) return;
-    set(consoleReducer(state, event));
-  });
-  const offApproval = bridge.onApprovalRequested(({ runId, request }) => {
-    if (runId !== currentRunId) return;
-    set(addApprovalRequest(state, request));
-  });
+  // Bridge subscription is attached lazily on the first `subscribe` and torn
+  // down on the last unsubscribe — NOT at construction. Constructing the store
+  // is side-effect-free, so a render discarded by React StrictMode (whose
+  // effects/cleanup never run) cannot leak bridge listeners.
+  let detachBridge: (() => void) | null = null;
+  const attachBridge = () => {
+    if (detachBridge) return;
+    // Listeners fold only envelopes for the active run, so a previous/cancelled
+    // run's late events or approvals can never pollute the current console.
+    const offEvent = bridge.onAgentEvent(({ runId, event }) => {
+      if (runId !== currentRunId) return;
+      set(consoleReducer(state, event));
+    });
+    const offApproval = bridge.onApprovalRequested(({ runId, request }) => {
+      if (runId !== currentRunId) return;
+      set(addApprovalRequest(state, request));
+    });
+    detachBridge = () => {
+      offEvent();
+      offApproval();
+      detachBridge = null;
+    };
+  };
 
   return {
     getState: () => state,
     isLaunching: () => launching,
     subscribe(listener) {
+      if (listeners.size === 0) attachBridge();
       listeners.add(listener);
-      return () => listeners.delete(listener);
+      return () => {
+        listeners.delete(listener);
+        if (listeners.size === 0) detachBridge?.();
+      };
     },
     async runTask(req) {
       // Reject re-entrant launches: the composer is disabled while launching,
@@ -119,8 +136,7 @@ export function createConsoleStore(bridge: FrontAgentBridge): ConsoleStore {
       }
     },
     dispose() {
-      offEvent();
-      offApproval();
+      detachBridge?.();
       listeners.clear();
     },
   };

--- a/apps/desktop/src/renderer/store/consoleStore.ts
+++ b/apps/desktop/src/renderer/store/consoleStore.ts
@@ -91,9 +91,13 @@ export function createConsoleStore(bridge: FrontAgentBridge): ConsoleStore {
       };
     },
     async runTask(req) {
-      // Reject re-entrant launches: the composer is disabled while launching,
-      // but guard here too so a fast double-click can't start two runs.
-      if (launching) return;
+      // Busy when a launch is in flight OR a run has started and not yet
+      // terminated — including the window after `runId` resolves but before the
+      // first event arrives. Reject re-entry so the single-active-run model
+      // can't fan out into multiple real backend tasks on a fast double-click.
+      const hasActiveRun =
+        currentRunId !== undefined && state.status !== 'completed' && state.status !== 'failed';
+      if (launching || hasActiveRun) return;
       const seq = ++launchSeq;
       // Atomically invalidate the old run BEFORE clearing state, so a late
       // envelope from the previous run can't slip through the `runId` gate and
@@ -105,6 +109,9 @@ export function createConsoleStore(bridge: FrontAgentBridge): ConsoleStore {
         const { runId } = await bridge.runTask(req);
         if (seq !== launchSeq) return; // superseded by a newer launch
         currentRunId = runId;
+        // Enter 'planning' immediately so the composer stays disabled through
+        // the window between runId resolution and the first agent event.
+        set({ ...initialConsoleState, status: 'planning' });
       } catch (error) {
         if (seq === launchSeq) {
           // Leave the UI in an explainable failed state; the old run stays

--- a/apps/desktop/src/renderer/store/consoleStore.ts
+++ b/apps/desktop/src/renderer/store/consoleStore.ts
@@ -103,14 +103,19 @@ export function createConsoleStore(bridge: FrontAgentBridge): ConsoleStore {
     async respondApproval(approvalId, approved, note) {
       if (!currentRunId) return;
       const pending = state.pendingApprovals.find((a) => a.approvalId === approvalId);
+      // Only act on an approval still in the queue, so a double-click or a
+      // stale handler can't resend the same decision.
+      if (!pending) return;
+      const decisionRunId = currentRunId;
       // Optimistically clear the approval from the queue, then notify main.
       set(resolveApproval(state, approvalId, approved));
       try {
-        await bridge.respondApproval({ runId: currentRunId, approvalId, approved, note });
+        await bridge.respondApproval({ runId: decisionRunId, approvalId, approved, note });
       } catch {
         // The decision did not reach main — restore the approval so the user
-        // can retry instead of losing a pending gate.
-        if (pending) set(addApprovalRequest(state, pending));
+        // can retry. Only if we're still on the same run: a new run may have
+        // started during the await, and we must not leak a stale approval into it.
+        if (currentRunId === decisionRunId) set(addApprovalRequest(state, pending));
       }
     },
     dispose() {

--- a/apps/desktop/src/renderer/store/consoleStore.ts
+++ b/apps/desktop/src/renderer/store/consoleStore.ts
@@ -1,0 +1,78 @@
+/**
+ * Framework-free console store. Subscribes to a {@link FrontAgentBridge},
+ * folds the agent event stream through the pure `consoleReducer`, and applies
+ * approval requests/decisions to the same `ConsoleState`. Kept out of React so
+ * it can be unit-tested against the mock bridge with no DOM.
+ *
+ * The React layer consumes this through `useSyncExternalStore`.
+ */
+import type { FrontAgentBridge, RunTaskRequest } from '../../ipc/contract.js';
+import {
+  addApprovalRequest,
+  type ConsoleState,
+  consoleReducer,
+  initialConsoleState,
+  resolveApproval,
+} from '../../state/executionReducer.js';
+
+export interface ConsoleStore {
+  getState(): ConsoleState;
+  subscribe(listener: () => void): () => void;
+  runTask(req: RunTaskRequest): Promise<void>;
+  /**
+   * Answer the current pending approval. `runId` is tracked internally from the
+   * live event/approval envelopes (the desktop drives one active run), so the
+   * UI only supplies the decision.
+   */
+  respondApproval(approvalId: string, approved: boolean, note?: string): Promise<void>;
+  /** Detach the bridge subscriptions. */
+  dispose(): void;
+}
+
+export function createConsoleStore(bridge: FrontAgentBridge): ConsoleStore {
+  let state = initialConsoleState;
+  let currentRunId: string | undefined;
+  const listeners = new Set<() => void>();
+
+  const emit = () => {
+    for (const listener of listeners) listener();
+  };
+
+  const set = (next: ConsoleState) => {
+    if (next === state) return;
+    state = next;
+    emit();
+  };
+
+  const offEvent = bridge.onAgentEvent(({ runId, event }) => {
+    currentRunId = runId;
+    set(consoleReducer(state, event));
+  });
+  const offApproval = bridge.onApprovalRequested(({ runId, request }) => {
+    currentRunId = runId;
+    set(addApprovalRequest(state, request));
+  });
+
+  return {
+    getState: () => state,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    async runTask(req) {
+      const { runId } = await bridge.runTask(req);
+      currentRunId = runId;
+    },
+    async respondApproval(approvalId, approved, note) {
+      if (!currentRunId) return;
+      // Optimistically clear the approval from the queue, then notify main.
+      set(resolveApproval(state, approvalId, approved));
+      await bridge.respondApproval({ runId: currentRunId, approvalId, approved, note });
+    },
+    dispose() {
+      offEvent();
+      offApproval();
+      listeners.clear();
+    },
+  };
+}

--- a/apps/desktop/src/renderer/store/useConsoleState.ts
+++ b/apps/desktop/src/renderer/store/useConsoleState.ts
@@ -5,6 +5,7 @@ import { type ConsoleStore, createConsoleStore } from './consoleStore.js';
 /** React binding over {@link createConsoleStore}. Returns the live state plus the store actions. */
 export function useConsoleState(bridge: FrontAgentBridge): {
   state: ReturnType<ConsoleStore['getState']>;
+  launching: boolean;
   runTask: ConsoleStore['runTask'];
   respondApproval: ConsoleStore['respondApproval'];
 } {
@@ -12,6 +13,7 @@ export function useConsoleState(bridge: FrontAgentBridge): {
   useEffect(() => () => store.dispose(), [store]);
 
   const state = useSyncExternalStore(store.subscribe, store.getState, store.getState);
+  const launching = useSyncExternalStore(store.subscribe, store.isLaunching, store.isLaunching);
 
-  return { state, runTask: store.runTask, respondApproval: store.respondApproval };
+  return { state, launching, runTask: store.runTask, respondApproval: store.respondApproval };
 }

--- a/apps/desktop/src/renderer/store/useConsoleState.ts
+++ b/apps/desktop/src/renderer/store/useConsoleState.ts
@@ -1,0 +1,17 @@
+import { useEffect, useMemo, useSyncExternalStore } from 'react';
+import type { FrontAgentBridge } from '../../ipc/contract.js';
+import { type ConsoleStore, createConsoleStore } from './consoleStore.js';
+
+/** React binding over {@link createConsoleStore}. Returns the live state plus the store actions. */
+export function useConsoleState(bridge: FrontAgentBridge): {
+  state: ReturnType<ConsoleStore['getState']>;
+  runTask: ConsoleStore['runTask'];
+  respondApproval: ConsoleStore['respondApproval'];
+} {
+  const store = useMemo(() => createConsoleStore(bridge), [bridge]);
+  useEffect(() => () => store.dispose(), [store]);
+
+  const state = useSyncExternalStore(store.subscribe, store.getState, store.getState);
+
+  return { state, runTask: store.runTask, respondApproval: store.respondApproval };
+}

--- a/apps/desktop/src/renderer/theme.css
+++ b/apps/desktop/src/renderer/theme.css
@@ -1,0 +1,755 @@
+/* ============================================================================
+   FrontAgent Console — "mission-control instrument" design system.
+   Dark telemetry cockpit: signal-amber active execution, teal perception,
+   coral failure, on layered graphite with grain + scanline atmosphere.
+   ========================================================================== */
+
+:root {
+  /* graphite base */
+  --bg-0: #07090f;
+  --bg-1: #0b0e16;
+  --bg-2: #111521;
+  --bg-3: #161b2b;
+  --line: #232a3d;
+  --line-bright: #313a52;
+
+  /* ink */
+  --ink: #e8ecf6;
+  --ink-dim: #9aa3bb;
+  --ink-faint: #5f6880;
+
+  /* signals */
+  --amber: #ffb627;
+  --amber-soft: #ffcf6b;
+  --teal: #3ad6bb;
+  --coral: #ff5d6c;
+  --violet: #8b7bff;
+
+  --amber-glow: rgba(255, 182, 39, 0.16);
+  --teal-glow: rgba(58, 214, 187, 0.14);
+  --coral-glow: rgba(255, 93, 108, 0.14);
+
+  --font-display: "Chakra Petch", system-ui, sans-serif;
+  --font-body: "IBM Plex Sans", system-ui, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+
+  --radius: 4px;
+  --radius-lg: 8px;
+  --rail-w: 232px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  font-family: var(--font-body);
+  color: var(--ink);
+  background-color: var(--bg-0);
+  background-image:
+    radial-gradient(1100px 620px at 78% -8%, var(--amber-glow), transparent 60%),
+    radial-gradient(900px 520px at 8% 108%, var(--teal-glow), transparent 55%),
+    linear-gradient(var(--bg-0), var(--bg-0));
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+
+/* fine scanline + grain overlay */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  background-image: repeating-linear-gradient(
+    0deg,
+    rgba(255, 255, 255, 0.014) 0px,
+    rgba(255, 255, 255, 0.014) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  mix-blend-mode: overlay;
+  opacity: 0.5;
+}
+
+/* ---- shell ------------------------------------------------------------- */
+.shell {
+  display: grid;
+  grid-template-columns: var(--rail-w) 1fr;
+  height: 100%;
+}
+
+.rail {
+  border-right: 1px solid var(--line);
+  background: linear-gradient(180deg, var(--bg-1), var(--bg-0));
+  display: flex;
+  flex-direction: column;
+  padding: 22px 18px;
+  gap: 28px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+.brand-mark {
+  width: 30px;
+  height: 30px;
+  border-radius: 7px;
+  background: radial-gradient(circle at 30% 25%, var(--amber-soft), var(--amber) 55%, #b8761a);
+  box-shadow:
+    0 0 0 1px rgba(255, 182, 39, 0.4),
+    0 6px 18px var(--amber-glow);
+  position: relative;
+}
+.brand-mark::after {
+  content: "";
+  position: absolute;
+  inset: 8px;
+  border: 1.5px solid rgba(7, 9, 15, 0.78);
+  border-radius: 2px;
+}
+.brand-name {
+  font-family: var(--font-display);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  font-size: 15px;
+}
+.brand-name small {
+  display: block;
+  font-family: var(--font-mono);
+  font-weight: 400;
+  font-size: 9.5px;
+  letter-spacing: 0.34em;
+  color: var(--ink-faint);
+  text-transform: uppercase;
+  margin-top: 2px;
+}
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  font-size: 13.5px;
+  color: var(--ink-dim);
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: all 0.15s ease;
+  font-family: var(--font-display);
+  letter-spacing: 0.02em;
+}
+.nav-item:hover {
+  background: var(--bg-2);
+  color: var(--ink);
+}
+.nav-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ink-faint);
+}
+.nav-item[data-active="true"] {
+  background: linear-gradient(90deg, var(--amber-glow), transparent);
+  border-color: var(--line-bright);
+  color: var(--ink);
+}
+.nav-item[data-active="true"] .nav-dot {
+  background: var(--amber);
+  box-shadow: 0 0 8px var(--amber);
+}
+
+.rail-foot {
+  margin-top: auto;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--ink-faint);
+  letter-spacing: 0.08em;
+  line-height: 1.7;
+}
+
+/* ---- main -------------------------------------------------------------- */
+.main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  height: 100%;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 26px;
+  border-bottom: 1px solid var(--line);
+  background: linear-gradient(180deg, rgba(17, 21, 33, 0.7), transparent);
+}
+.topbar h1 {
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+.topbar .spacer {
+  flex: 1;
+}
+
+/* status pill */
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--line-bright);
+  background: var(--bg-2);
+  color: var(--ink-dim);
+}
+.status-pill .beacon {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ink-faint);
+}
+.status-pill[data-status="running"],
+.status-pill[data-status="planning"] {
+  color: var(--amber-soft);
+  border-color: rgba(255, 182, 39, 0.4);
+}
+.status-pill[data-status="running"] .beacon,
+.status-pill[data-status="planning"] .beacon {
+  background: var(--amber);
+  box-shadow: 0 0 8px var(--amber);
+  animation: pulse 1.2s ease-in-out infinite;
+}
+.status-pill[data-status="completed"] {
+  color: var(--teal);
+  border-color: rgba(58, 214, 187, 0.4);
+}
+.status-pill[data-status="completed"] .beacon {
+  background: var(--teal);
+  box-shadow: 0 0 8px var(--teal);
+}
+.status-pill[data-status="failed"] {
+  color: var(--coral);
+  border-color: rgba(255, 93, 108, 0.4);
+}
+.status-pill[data-status="failed"] .beacon {
+  background: var(--coral);
+  box-shadow: 0 0 8px var(--coral);
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+/* console grid: timeline + telemetry stream */
+.console {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr 388px;
+  min-height: 0;
+}
+.timeline-col {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-right: 1px solid var(--line);
+}
+
+/* composer */
+.composer {
+  padding: 20px 26px;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.composer textarea {
+  width: 100%;
+  resize: none;
+  background: var(--bg-1);
+  border: 1px solid var(--line-bright);
+  border-radius: var(--radius-lg);
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 14px;
+  line-height: 1.5;
+  padding: 13px 15px;
+  min-height: 76px;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+.composer textarea:focus {
+  outline: none;
+  border-color: var(--amber);
+  box-shadow: 0 0 0 3px var(--amber-glow);
+}
+.composer-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+.field {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 8px 11px;
+}
+.field label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+.field input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+}
+.field input:focus {
+  outline: none;
+}
+
+.btn {
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  font-size: 13px;
+  border-radius: var(--radius);
+  padding: 10px 20px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+}
+.btn-primary {
+  background: linear-gradient(180deg, var(--amber-soft), var(--amber));
+  color: #1a1206;
+  box-shadow: 0 6px 18px var(--amber-glow);
+}
+.btn-primary:hover:not(:disabled) {
+  filter: brightness(1.08);
+  transform: translateY(-1px);
+}
+.btn-primary:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.btn-ghost {
+  background: var(--bg-2);
+  border-color: var(--line-bright);
+  color: var(--ink-dim);
+}
+.btn-ghost:hover {
+  color: var(--ink);
+  border-color: var(--ink-faint);
+}
+
+/* phase lanes */
+.lanes {
+  flex: 1;
+  overflow-y: auto;
+  padding: 22px 26px 60px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.lanes-empty {
+  margin: auto;
+  text-align: center;
+  color: var(--ink-faint);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  letter-spacing: 0.08em;
+  line-height: 2;
+}
+.lanes-empty .glyph {
+  font-size: 34px;
+  opacity: 0.5;
+  display: block;
+  margin-bottom: 10px;
+}
+
+.lane {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(180deg, var(--bg-2), var(--bg-1));
+  overflow: hidden;
+  animation: rise 0.4s ease both;
+}
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+}
+.lane-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--line);
+  background: var(--bg-2);
+}
+.lane-idx {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-faint);
+  letter-spacing: 0.1em;
+}
+.lane-name {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.03em;
+}
+.lane-meta {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-dim);
+}
+.lane-tag {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 3px 8px;
+  border-radius: 3px;
+  border: 1px solid var(--line-bright);
+  color: var(--ink-faint);
+}
+.lane-tag[data-s="active"] {
+  color: var(--amber-soft);
+  border-color: rgba(255, 182, 39, 0.45);
+  background: var(--amber-glow);
+}
+.lane-tag[data-s="completed"] {
+  color: var(--teal);
+  border-color: rgba(58, 214, 187, 0.4);
+}
+
+.steps {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.step {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 11px 13px;
+  border-radius: var(--radius);
+  border: 1px solid transparent;
+  background: var(--bg-1);
+  position: relative;
+}
+.step[data-s="running"] {
+  border-color: rgba(255, 182, 39, 0.4);
+  background: linear-gradient(90deg, var(--amber-glow), var(--bg-1) 70%);
+}
+.step[data-s="failed"] {
+  border-color: rgba(255, 93, 108, 0.35);
+}
+.step-icon {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  margin-top: 2px;
+  flex-shrink: 0;
+  border: 1.5px solid var(--ink-faint);
+}
+.step[data-s="running"] .step-icon {
+  border-color: var(--amber);
+  border-top-color: transparent;
+  animation: spin 0.8s linear infinite;
+}
+.step[data-s="completed"] .step-icon {
+  border-color: var(--teal);
+  background: radial-gradient(circle, var(--teal) 40%, transparent 45%);
+}
+.step[data-s="failed"] .step-icon {
+  border-color: var(--coral);
+  background: var(--coral-glow);
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.step-body {
+  flex: 1;
+  min-width: 0;
+}
+.step-title {
+  font-size: 13.5px;
+  line-height: 1.45;
+}
+.step-sub {
+  display: flex;
+  gap: 10px;
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--ink-faint);
+}
+.step-tool {
+  color: var(--violet);
+}
+.step-err {
+  color: var(--coral);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  margin-top: 5px;
+}
+
+/* telemetry / event stream */
+.stream {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--bg-0);
+}
+.stream-head {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.stream-log {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px 40px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.65;
+}
+.log-line {
+  display: flex;
+  gap: 10px;
+  padding: 2px 0;
+  animation: fade 0.3s ease both;
+}
+@keyframes fade {
+  from {
+    opacity: 0;
+  }
+}
+.log-seq {
+  color: var(--ink-faint);
+  flex-shrink: 0;
+}
+.log-line[data-l="success"] .log-text {
+  color: var(--teal);
+}
+.log-line[data-l="warn"] .log-text {
+  color: var(--amber-soft);
+}
+.log-line[data-l="error"] .log-text {
+  color: var(--coral);
+}
+.log-line[data-l="info"] .log-text {
+  color: var(--ink-dim);
+}
+
+.tokens {
+  margin: 12px 16px;
+  border: 1px dashed var(--line-bright);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+  background: var(--bg-1);
+}
+.tokens-head {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 6px;
+}
+.tokens-body {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--amber-soft);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.tokens-body::after {
+  content: "▋";
+  animation: pulse 1s steps(2) infinite;
+  color: var(--amber);
+}
+
+/* approval drawer */
+.approval {
+  margin: 14px 16px 0;
+  border: 1px solid rgba(255, 182, 39, 0.5);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(180deg, rgba(255, 182, 39, 0.1), var(--bg-2));
+  padding: 15px;
+  box-shadow: 0 0 30px var(--amber-glow);
+  animation: rise 0.35s ease both;
+}
+.approval-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 13.5px;
+  color: var(--amber-soft);
+  letter-spacing: 0.03em;
+  margin-bottom: 9px;
+}
+.approval-head .risk {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--coral);
+  border: 1px solid rgba(255, 93, 108, 0.4);
+  padding: 2px 7px;
+  border-radius: 3px;
+}
+.approval-msg {
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--ink);
+  margin-bottom: 8px;
+}
+.approval-cmd {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--ink-dim);
+  background: var(--bg-0);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 8px 10px;
+  margin-bottom: 12px;
+  word-break: break-all;
+}
+.approval-actions {
+  display: flex;
+  gap: 9px;
+}
+.approval-actions .btn {
+  flex: 1;
+  padding: 9px;
+}
+.btn-danger {
+  background: var(--bg-2);
+  border-color: rgba(255, 93, 108, 0.45);
+  color: var(--coral);
+}
+.btn-danger:hover {
+  background: var(--coral-glow);
+}
+
+/* settings */
+.settings {
+  flex: 1;
+  overflow-y: auto;
+  padding: 30px 40px;
+  max-width: 640px;
+}
+.settings h2 {
+  font-family: var(--font-display);
+  font-size: 18px;
+  letter-spacing: 0.03em;
+  margin-bottom: 4px;
+}
+.settings .hint {
+  color: var(--ink-faint);
+  font-size: 13px;
+  margin-bottom: 26px;
+}
+.setting-group {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  margin-bottom: 20px;
+}
+.setting-group label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+.setting-group input {
+  background: var(--bg-1);
+  border: 1px solid var(--line-bright);
+  border-radius: var(--radius);
+  padding: 11px 13px;
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+.setting-group input:focus {
+  outline: none;
+  border-color: var(--amber);
+  box-shadow: 0 0 0 3px var(--amber-glow);
+}
+.settings-saved {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--teal);
+  margin-left: 12px;
+}
+
+/* scrollbars */
+::-webkit-scrollbar {
+  width: 9px;
+  height: 9px;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--line-bright);
+  border-radius: 5px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -1,6 +1,12 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": ["node"],
+    "noEmit": true,
     "outDir": "./dist",
     "rootDir": "./src"
   },

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,0 +1,15 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+// Renderer-only build for the desktop app. The Electron main/preload bundle
+// is wired in a later PR; for now the renderer runs in a browser against the
+// mock bridge so the UI is reviewable on its own.
+export default defineConfig({
+  root: __dirname,
+  base: './',
+  plugins: [react()],
+  build: {
+    outDir: 'dist/renderer',
+    emptyOutDir: true,
+  },
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,8 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "typescript": "^6.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,7 +195,7 @@ importers:
         version: 1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1)
       '@langchain/langgraph':
         specifier: ^1.3.2
-        version: 1.3.6(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)
+        version: 1.3.6(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
@@ -209,6 +209,12 @@ importers:
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -2530,6 +2536,11 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
@@ -3676,7 +3687,7 @@ snapshots:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1)
       uuid: 14.0.0
 
-  '@langchain/langgraph-sdk@1.9.18(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@langchain/langgraph-sdk@1.9.18(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1)
       '@langchain/protocol': 0.0.16
@@ -3685,14 +3696,14 @@ snapshots:
       p-retry: 7.1.1
       uuid: 14.0.0
     optionalDependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
-  '@langchain/langgraph@1.3.6(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)':
+  '@langchain/langgraph@1.3.6(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1)
       '@langchain/langgraph-checkpoint': 1.0.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))
-      '@langchain/langgraph-sdk': 1.9.18(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@langchain/langgraph-sdk': 1.9.18(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@langchain/protocol': 0.0.16
       '@standard-schema/spec': 1.1.0
       uuid: 14.0.0
@@ -5124,6 +5135,12 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,15 @@ importers:
 
   apps/desktop:
     dependencies:
+      '@fontsource/chakra-petch':
+        specifier: ^5.2.0
+        version: 5.2.7
+      '@fontsource/ibm-plex-mono':
+        specifier: ^5.2.0
+        version: 5.2.7
+      '@fontsource/ibm-plex-sans':
+        specifier: ^5.2.0
+        version: 5.2.8
       '@frontagent/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -186,7 +195,7 @@ importers:
         version: 1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1)
       '@langchain/langgraph':
         specifier: ^1.3.2
-        version: 1.3.6(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@19.2.7(react@18.3.1))(react@18.3.1)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)
+        version: 1.3.6(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
@@ -869,6 +878,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource/chakra-petch@5.2.7':
+    resolution: {integrity: sha512-GLbun5WZJNAEc8FtWxwcgo+4Kurqdwejvf671l+YfIjyQgPvTjyxXYP7Ffg2HAY89NGnp3oOvKQjRzfm/fBECw==}
+
+  '@fontsource/ibm-plex-mono@5.2.7':
+    resolution: {integrity: sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==}
+
+  '@fontsource/ibm-plex-sans@5.2.8':
+    resolution: {integrity: sha512-eztSXjDhPhcpxNIiGTgMebdLP9qS4rWkysuE1V7c+DjOR0qiezaiDaTwQE7bTnG5HxAY/8M43XKDvs3cYq6ZYQ==}
 
   '@hono/node-server@2.0.3':
     resolution: {integrity: sha512-a0jV+/HRe3G5zjFID3zObAQFdkl6zpxTuqktdDDXS3MJKcrZIkB8OkLpNBlY/WXFqv2HF4a0takPej+aNFczWA==}
@@ -3457,6 +3475,12 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
+  '@fontsource/chakra-petch@5.2.7': {}
+
+  '@fontsource/ibm-plex-mono@5.2.7': {}
+
+  '@fontsource/ibm-plex-sans@5.2.8': {}
+
   '@hono/node-server@2.0.3(hono@4.12.21)':
     dependencies:
       hono: 4.12.21
@@ -3652,7 +3676,7 @@ snapshots:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1)
       uuid: 14.0.0
 
-  '@langchain/langgraph-sdk@1.9.18(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@19.2.7(react@18.3.1))(react@18.3.1)':
+  '@langchain/langgraph-sdk@1.9.18(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1)
       '@langchain/protocol': 0.0.16
@@ -3661,14 +3685,14 @@ snapshots:
       p-retry: 7.1.1
       uuid: 14.0.0
     optionalDependencies:
-      react: 18.3.1
-      react-dom: 19.2.7(react@18.3.1)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
-  '@langchain/langgraph@1.3.6(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@19.2.7(react@18.3.1))(react@18.3.1)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)':
+  '@langchain/langgraph@1.3.6(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1)
       '@langchain/langgraph-checkpoint': 1.0.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))
-      '@langchain/langgraph-sdk': 1.9.18(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@19.2.7(react@18.3.1))(react@18.3.1)
+      '@langchain/langgraph-sdk': 1.9.18(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@langchain/protocol': 0.0.16
       '@standard-schema/spec': 1.1.0
       uuid: 14.0.0
@@ -5100,12 +5124,6 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
-
-  react-dom@19.2.7(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-      scheduler: 0.27.0
-    optional: true
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,10 +114,28 @@ importers:
       '@frontagent/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      react:
+        specifier: ^19.2.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.7(react@19.2.7)
     devDependencies:
+      '@types/react':
+        specifier: ^19.2.0
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.0
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.0
+        version: 5.2.0(vite@7.3.2(@types/node@25.9.1)(yaml@2.9.0))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vite:
+        specifier: ^7.1.0
+        version: 7.3.2(@types/node@25.9.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.7
         version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(vite@7.3.2(@types/node@25.9.1)(yaml@2.9.0))
@@ -168,7 +186,7 @@ importers:
         version: 1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1)
       '@langchain/langgraph':
         specifier: ^1.3.2
-        version: 1.3.6(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react@18.3.1)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)
+        version: 1.3.6(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@19.2.7(react@18.3.1))(react@18.3.1)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
@@ -397,6 +415,89 @@ packages:
   '@alcalzone/ansi-tokenize@0.1.3':
     resolution: {integrity: sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==}
     engines: {node: '>=14.13.1'}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
 
   '@biomejs/biome@2.4.16':
     resolution: {integrity: sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==}
@@ -930,8 +1031,21 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@ladybugdb/core-darwin-arm64@0.17.1':
     resolution: {integrity: sha512-JG/uzmolEh3wXJ/ME1EaTH5LTDQ9Cs+Q3Czul8pW2eWbWQZghQU3jjM++7ST7Bla5BX/WITqwPqPoC+sL+slfA==}
@@ -1053,6 +1167,9 @@ packages:
 
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
   '@rollup/rollup-android-arm-eabi@4.61.1':
     resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
@@ -1221,6 +1338,18 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1251,8 +1380,16 @@ packages:
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
   '@types/react@18.3.29':
     resolution: {integrity: sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==}
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/vscode@1.120.0':
     resolution: {integrity: sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==}
@@ -1260,6 +1397,12 @@ packages:
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
+
+  '@vitejs/plugin-react@5.2.0':
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
@@ -1373,6 +1516,11 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  baseline-browser-mapping@2.10.37:
+    resolution: {integrity: sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
@@ -1385,6 +1533,11 @@ packages:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -1396,6 +1549,9 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1578,6 +1734,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  electron-to-chromium@1.5.372:
+    resolution: {integrity: sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -1748,6 +1907,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -1968,6 +2131,11 @@ packages:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   json-bignum@0.0.3:
     resolution: {integrity: sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==}
     engines: {node: '>=0.8'}
@@ -1983,6 +2151,11 @@ packages:
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
@@ -2036,6 +2209,9 @@ packages:
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2129,6 +2305,10 @@ packages:
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
+
+  node-releases@2.0.47:
+    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
+    engines: {node: '>=18'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2332,14 +2512,27 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
   react-reconciler@0.29.2:
     resolution: {integrity: sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
       react: ^18.3.1
 
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
   readable-stream@2.3.8:
@@ -2394,11 +2587,18 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.8.0:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
@@ -2721,6 +2921,12 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
 
@@ -2870,6 +3076,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
@@ -2937,6 +3146,118 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 4.0.0
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@biomejs/biome@2.4.16':
     optionalDependencies:
@@ -3261,7 +3582,24 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@ladybugdb/core-darwin-arm64@0.17.1':
     optional: true
@@ -3314,7 +3652,7 @@ snapshots:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1)
       uuid: 14.0.0
 
-  '@langchain/langgraph-sdk@1.9.18(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react@18.3.1)':
+  '@langchain/langgraph-sdk@1.9.18(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@19.2.7(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1)
       '@langchain/protocol': 0.0.16
@@ -3324,12 +3662,13 @@ snapshots:
       uuid: 14.0.0
     optionalDependencies:
       react: 18.3.1
+      react-dom: 19.2.7(react@18.3.1)
 
-  '@langchain/langgraph@1.3.6(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react@18.3.1)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)':
+  '@langchain/langgraph@1.3.6(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@19.2.7(react@18.3.1))(react@18.3.1)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1)
       '@langchain/langgraph-checkpoint': 1.0.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))
-      '@langchain/langgraph-sdk': 1.9.18(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react@18.3.1)
+      '@langchain/langgraph-sdk': 1.9.18(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(ws@8.20.1))(react-dom@19.2.7(react@18.3.1))(react@18.3.1)
       '@langchain/protocol': 0.0.16
       '@standard-schema/spec': 1.1.0
       uuid: 14.0.0
@@ -3420,6 +3759,8 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.1': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/rollup-android-arm-eabi@4.61.1':
     optional: true
@@ -3528,6 +3869,27 @@ snapshots:
   '@turbo/windows-arm64@2.9.16':
     optional: true
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -3555,14 +3917,34 @@ snapshots:
 
   '@types/prop-types@15.7.15': {}
 
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
   '@types/react@18.3.29':
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
+
   '@types/vscode@1.120.0': {}
 
   '@vercel/oidc@3.1.0': {}
+
+  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@25.9.1)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.2(@types/node@25.9.1)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -3685,6 +4067,8 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  baseline-browser-mapping@2.10.37: {}
+
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
@@ -3705,6 +4089,14 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.37
+      caniuse-lite: 1.0.30001799
+      electron-to-chromium: 1.5.372
+      node-releases: 2.0.47
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
   bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -3716,6 +4108,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  caniuse-lite@1.0.30001799: {}
 
   chai@6.2.2: {}
 
@@ -3871,6 +4265,8 @@ snapshots:
   eastasianwidth@0.2.0: {}
 
   ee-first@1.1.1: {}
+
+  electron-to-chromium@1.5.372: {}
 
   emoji-regex@10.6.0: {}
 
@@ -4073,6 +4469,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -4345,6 +4743,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsesc@3.1.0: {}
+
   json-bignum@0.0.3: {}
 
   json-schema-traverse@1.0.0: {}
@@ -4354,6 +4754,8 @@ snapshots:
   json-schema@0.4.0: {}
 
   json-stringify-safe@5.0.1: {}
+
+  json5@2.2.3: {}
 
   jsonc-parser@3.3.1: {}
 
@@ -4397,6 +4799,10 @@ snapshots:
   lru-cache@10.4.3: {}
 
   lru-cache@11.5.1: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   magic-string@0.30.21:
     dependencies:
@@ -4464,6 +4870,8 @@ snapshots:
   node-api-headers@1.9.0: {}
 
   node-gyp-build@4.8.4: {}
+
+  node-releases@2.0.47: {}
 
   object-assign@4.1.1: {}
 
@@ -4693,15 +5101,30 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-dom@19.2.7(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      scheduler: 0.27.0
+    optional: true
+
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
   react-reconciler@0.29.2(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-refresh@0.18.0: {}
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  react@19.2.7: {}
 
   readable-stream@2.3.8:
     dependencies:
@@ -4791,9 +5214,13 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  scheduler@0.27.0: {}
+
   secure-json-parse@4.1.0: {}
 
   semver-compare@1.0.0: {}
+
+  semver@6.3.1: {}
 
   semver@7.8.0: {}
 
@@ -5134,6 +5561,12 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   url-join@4.0.1: {}
 
   util-deprecate@1.0.2: {}
@@ -5225,6 +5658,8 @@ snapshots:
   ws@8.20.1: {}
 
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yallist@5.0.0: {}
 


### PR DESCRIPTION
Closes #327. Incremental slice 2/3 of the desktop app (follows #326).

## What this adds

The desktop **renderer** as a React + Vite app, consuming the foundation from #326 (the `executionReducer` + `FrontAgentBridge` contract), driven by a **mock bridge** so it is fully reviewable in a browser — no Electron yet.

- **Tooling**: React 19 + Vite 7 + `@vitejs/plugin-react` added to `apps/desktop`; renderer-only `vite build` → `dist/renderer`; tsconfig switched to `Bundler`/`react-jsx` with `vite/client` types. (`apps/cli` keeps React 18 for Ink; the two coexist under pnpm.)
- **State binding**: `consoleStore` — a framework-free store that subscribes to a `FrontAgentBridge`, folds `AgentEvent`s through the PR1 reducer, applies approvals, and tracks the active `runId` so approval decisions self-route. `useConsoleState` binds it via `useSyncExternalStore`.
- **Task Console**: composer (task / workspace / URL), a live **phase-lane execution timeline**, a streaming **telemetry/log** panel, per-step **token stream**, and an **approval drawer** bound to `pendingApprovals`.
- **Settings**: panel over the `DesktopSettings` shape (in-memory; persistence in PR3).
- **mockBridge**: replays a scripted run (planning → 2 phases → approval → completion/failure) so the UI runs standalone.

## Design (frontend-design)

A dark **mission-control / engineering-instrument** console — telemetry-style phase/step lanes. Chakra Petch (display) + IBM Plex Sans (body) + IBM Plex Mono (telemetry); signal-amber active / teal success / coral failure on layered graphite; grain + scanline atmosphere. Deliberately not generic-AI.

To review visually: `pnpm --filter @frontagent/desktop dev` and open the Vite URL.

## Incremental roadmap

1. ✅ #326 — foundation (contract + reducer).
2. **This PR** — renderer UI on the mock bridge.
3. Electron main/preload shell + runtime bridge wiring to `@frontagent/runtime-node`.

## Non-goals (PR3)

No Electron main/preload, no real runtime wiring, no settings persistence — the renderer talks only to the mock bridge here.

## GitNexus Impact Summary

- **Risk level:** Low.
- **Critical skeleton changes:** None — additive renderer code under `apps/desktop`; no existing symbol or execution flow modified. `package.json`/`tsconfig.json` updated for the renderer build; `pnpm-lock.yaml` adds React/Vite.
- **GitNexus impact:** `detect_changes` (scope=staged, repo=FrontAgent) → `changed_count: 0`, `affected_count: 0`, `risk_level: low`, `changed_files: 19`. No indexed symbols/processes affected.
- **Verification:** `pnpm lint` (1 pre-existing info), `pnpm typecheck` (23/23), `pnpm test` (23/23; desktop suite covers the mock-driven store through approval grant/reject), and `vite build` of the renderer all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)