### PR TITLE
feat(desktop): main-process runtime bridge core + settings store

### DIFF
--- a/apps/desktop/src/main/runtimeBridge.test.ts
+++ b/apps/desktop/src/main/runtimeBridge.test.ts
@@ -1,0 +1,151 @@
+import type { AgentEvent } from '@frontagent/core';
+import type { ApprovalRequest } from '@frontagent/shared';
+import { describe, expect, it } from 'vitest';
+import { createRuntimeBridge, type RuntimeRunner } from './runtimeBridge.js';
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function approval(approvalId = 'apv-1'): ApprovalRequest {
+  return {
+    decision: 'ask',
+    approvalId,
+    createdAt: '2026-06-13T00:00:00Z',
+    riskLevel: 'high',
+    reasonCode: 'shell_ask',
+    message: 'm',
+    toolName: 'run_command',
+    argsSummary: 'a',
+    provenance: [],
+  };
+}
+
+interface Sent {
+  channel: string;
+  payload: { runId: string; event?: AgentEvent; request?: ApprovalRequest };
+}
+
+function harness(run: RuntimeRunner, runId = 'R1') {
+  const sent: Sent[] = [];
+  const bridge = createRuntimeBridge({
+    run,
+    send: (channel, payload) => sent.push({ channel, payload: payload as Sent['payload'] }),
+    generateRunId: () => runId,
+  });
+  return { bridge, sent };
+}
+
+describe('createRuntimeBridge', () => {
+  it('returns the runId before any event is forwarded (timing contract)', async () => {
+    const { bridge, sent } = harness(async ({ onEvent }) => {
+      onEvent?.({ type: 'planning_started' });
+    });
+
+    const res = bridge.runTask({ task: 't', workspacePath: '/w' });
+    expect(res.runId).toBe('R1');
+    expect(sent).toHaveLength(0); // run deferred — no events emitted synchronously
+
+    await tick();
+    expect(sent[0]).toMatchObject({
+      channel: 'fa:agent:event',
+      payload: { runId: 'R1', event: { type: 'planning_started' } },
+    });
+  });
+
+  it('maps the request and forwards events as envelopes', async () => {
+    let received: { task: string; projectRoot: string; files?: string[]; url?: string } | undefined;
+    const { bridge, sent } = harness(async (opts) => {
+      received = {
+        task: opts.task,
+        projectRoot: opts.projectRoot,
+        files: opts.files,
+        url: opts.url,
+      };
+      opts.onEvent?.({ type: 'phase_started', phase: '实现', stepCount: 1 });
+    });
+
+    bridge.runTask({
+      task: '加深色模式',
+      workspacePath: '/proj',
+      relevantFiles: ['a.ts'],
+      browserUrl: 'http://x',
+    });
+    await tick();
+
+    expect(received).toEqual({
+      task: '加深色模式',
+      projectRoot: '/proj',
+      files: ['a.ts'],
+      url: 'http://x',
+    });
+    expect(sent.at(-1)?.payload.event).toMatchObject({ type: 'phase_started', phase: '实现' });
+  });
+
+  it('round-trips an approval: respondApproval resolves the runtime promise', async () => {
+    let approved: boolean | undefined;
+    const { bridge, sent } = harness(async ({ onApprovalRequest }) => {
+      approved = await onApprovalRequest?.(approval('apv-1'));
+    });
+
+    bridge.runTask({ task: 't', workspacePath: '/w' });
+    await tick();
+    expect(sent.some((s) => s.channel === 'fa:approval:requested')).toBe(true);
+    expect(bridge.activeRunCount()).toBe(1);
+
+    bridge.respondApproval({ runId: 'R1', approvalId: 'apv-1', approved: true });
+    await tick();
+
+    expect(approved).toBe(true);
+    expect(bridge.activeRunCount()).toBe(0); // run finished and was dropped
+  });
+
+  it('ignores a stale or unknown approval id', async () => {
+    let approved: boolean | undefined;
+    const { bridge } = harness(async ({ onApprovalRequest }) => {
+      approved = await onApprovalRequest?.(approval('apv-1'));
+    });
+
+    bridge.runTask({ task: 't', workspacePath: '/w' });
+    await tick();
+
+    bridge.respondApproval({ runId: 'R1', approvalId: 'wrong', approved: true });
+    bridge.respondApproval({ runId: 'OTHER', approvalId: 'apv-1', approved: true });
+    await tick();
+
+    expect(approved).toBeUndefined(); // still pending
+    expect(bridge.activeRunCount()).toBe(1);
+  });
+
+  it('aborts the run signal on cancelTask', async () => {
+    let signal: AbortSignal | undefined;
+    const { bridge } = harness(
+      ({ signal: s }) =>
+        new Promise<void>((resolve) => {
+          signal = s;
+          s?.addEventListener('abort', () => resolve());
+        }),
+    );
+
+    bridge.runTask({ task: 't', workspacePath: '/w' });
+    await tick();
+    expect(signal?.aborted).toBe(false);
+
+    bridge.cancelTask('R1');
+    await tick();
+    expect(signal?.aborted).toBe(true);
+    expect(bridge.activeRunCount()).toBe(0);
+  });
+
+  it('forwards a task_failed event when the runtime throws', async () => {
+    const { bridge, sent } = harness(async () => {
+      throw new Error('boom');
+    });
+
+    bridge.runTask({ task: 't', workspacePath: '/w' });
+    await tick();
+
+    const failed = sent.find((s) => s.payload.event?.type === 'task_failed');
+    expect(failed?.payload.event).toMatchObject({ type: 'task_failed' });
+    expect((failed?.payload.event as { error: string }).error).toContain('boom');
+    expect(bridge.activeRunCount()).toBe(0);
+  });
+});

--- a/apps/desktop/src/main/runtimeBridge.test.ts
+++ b/apps/desktop/src/main/runtimeBridge.test.ts
@@ -135,6 +135,30 @@ describe('createRuntimeBridge', () => {
     expect(bridge.activeRunCount()).toBe(0);
   });
 
+  it('releases an in-flight approval wait on cancelTask so the run can unwind', async () => {
+    let approved: boolean | undefined;
+    // Runtime blocks on the approval promise — exactly the case where only
+    // aborting the signal would leave the run (and its cleanup) hanging.
+    const { bridge } = harness(async ({ onApprovalRequest }) => {
+      approved = await onApprovalRequest?.(approval('apv-1'));
+    });
+
+    bridge.runTask({ task: 't', workspacePath: '/w' });
+    await tick();
+    expect(bridge.activeRunCount()).toBe(1);
+
+    bridge.cancelTask('R1');
+    await tick();
+
+    expect(approved).toBe(false); // approval wait was released as denied
+    expect(bridge.activeRunCount()).toBe(0); // run unwound and was dropped
+
+    // A decision arriving after cancel is ignored (no late resolution).
+    bridge.respondApproval({ runId: 'R1', approvalId: 'apv-1', approved: true });
+    await tick();
+    expect(approved).toBe(false);
+  });
+
   it('forwards a task_failed event when the runtime throws', async () => {
     const { bridge, sent } = harness(async () => {
       throw new Error('boom');

--- a/apps/desktop/src/main/runtimeBridge.test.ts
+++ b/apps/desktop/src/main/runtimeBridge.test.ts
@@ -172,4 +172,37 @@ describe('createRuntimeBridge', () => {
     expect((failed?.payload.event as { error: string }).error).toContain('boom');
     expect(bridge.activeRunCount()).toBe(0);
   });
+
+  it('forwards task_failed when the runtime throws synchronously', async () => {
+    // Runner throws before returning a promise — must still be surfaced.
+    const { bridge, sent } = harness((() => {
+      throw new Error('sync boom');
+    }) as RuntimeRunner);
+
+    bridge.runTask({ task: 't', workspacePath: '/w' });
+    await tick();
+
+    const failed = sent.find((s) => s.payload.event?.type === 'task_failed');
+    expect((failed?.payload.event as { error: string } | undefined)?.error).toContain('sync boom');
+    expect(bridge.activeRunCount()).toBe(0);
+  });
+
+  it('does not report a cancellation (abort rejection) as task_failed', async () => {
+    const { bridge, sent } = harness(
+      ({ signal }) =>
+        new Promise<void>((_, reject) => {
+          signal?.addEventListener('abort', () =>
+            reject(new DOMException('The operation was aborted', 'AbortError')),
+          );
+        }),
+    );
+
+    bridge.runTask({ task: 't', workspacePath: '/w' });
+    await tick();
+    bridge.cancelTask('R1');
+    await tick();
+
+    expect(sent.some((s) => s.payload.event?.type === 'task_failed')).toBe(false);
+    expect(bridge.activeRunCount()).toBe(0); // still cleaned up
+  });
 });

--- a/apps/desktop/src/main/runtimeBridge.ts
+++ b/apps/desktop/src/main/runtimeBridge.ts
@@ -111,7 +111,15 @@ export function createRuntimeBridge(deps: RuntimeBridgeDeps): RuntimeBridge {
     },
 
     cancelTask(runId) {
-      runs.get(runId)?.controller.abort();
+      const active = runs.get(runId);
+      if (!active) return;
+      active.controller.abort();
+      // Release any in-flight approval wait so the runtime can unwind from its
+      // `await onApprovalRequest(...)` and observe the abort. Without this the
+      // run promise would hang on the unresolved approval and its `.finally`
+      // cleanup (which drops the run) would never execute.
+      for (const resolve of active.pendingApprovals.values()) resolve(false);
+      active.pendingApprovals.clear();
     },
 
     activeRunCount: () => runs.size,

--- a/apps/desktop/src/main/runtimeBridge.ts
+++ b/apps/desktop/src/main/runtimeBridge.ts
@@ -68,21 +68,29 @@ export function createRuntimeBridge(deps: RuntimeBridgeDeps): RuntimeBridge {
       // before any event is forwarded — the FrontAgentBridge.runTask timing
       // contract the renderer store relies on (see contract.ts).
       queueMicrotask(() => {
-        void deps
-          .run({
-            task: req.task,
-            projectRoot: req.workspacePath,
-            files: req.relevantFiles,
-            url: req.browserUrl,
-            signal: active.controller.signal,
-            onEvent: (event) => deps.send(IpcPush.AgentEvent, { runId, event }),
-            onApprovalRequest: (request) =>
-              new Promise<boolean>((resolve) => {
-                active.pendingApprovals.set(request.approvalId, resolve);
-                deps.send(IpcPush.ApprovalRequested, { runId, request });
-              }),
-          })
+        // `Promise.resolve().then(run)` so a runner that throws *synchronously*
+        // (before returning its promise) still becomes a rejection we handle,
+        // rather than escaping the microtask uncaught.
+        Promise.resolve()
+          .then(() =>
+            deps.run({
+              task: req.task,
+              projectRoot: req.workspacePath,
+              files: req.relevantFiles,
+              url: req.browserUrl,
+              signal: active.controller.signal,
+              onEvent: (event) => deps.send(IpcPush.AgentEvent, { runId, event }),
+              onApprovalRequest: (request) =>
+                new Promise<boolean>((resolve) => {
+                  active.pendingApprovals.set(request.approvalId, resolve);
+                  deps.send(IpcPush.ApprovalRequested, { runId, request });
+                }),
+            }),
+          )
           .catch((error) => {
+            // A rejection from user cancellation is not a task failure — the
+            // runtime commonly rejects with an AbortError once the signal fires.
+            if (active.controller.signal.aborted || isAbortError(error)) return;
             deps.send(IpcPush.AgentEvent, {
               runId,
               event: {
@@ -124,4 +132,8 @@ export function createRuntimeBridge(deps: RuntimeBridgeDeps): RuntimeBridge {
 
     activeRunCount: () => runs.size,
   };
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
 }

--- a/apps/desktop/src/main/runtimeBridge.ts
+++ b/apps/desktop/src/main/runtimeBridge.ts
@@ -1,0 +1,119 @@
+/**
+ * Main-process runtime bridge core. Drives `@frontagent/runtime-node`'s
+ * `runFrontAgentTask` and maps its callbacks onto the IPC envelopes the
+ * renderer consumes. Kept dependency-injected and Electron-free so it is fully
+ * unit-testable; PR4 wires it to `ipcMain` / `BrowserWindow` / preload.
+ */
+import type { AgentEvent } from '@frontagent/core';
+import type { ApprovalRequest } from '@frontagent/shared';
+import {
+  type AgentEventEnvelope,
+  type ApprovalDecisionInput,
+  type ApprovalRequestEnvelope,
+  IpcPush,
+  type RunTaskRequest,
+  type RunTaskResponse,
+} from '../ipc/contract.js';
+
+/** The subset of `RunFrontAgentTaskOptions` the bridge drives (injected for testing). */
+export interface RuntimeRunOptions {
+  task: string;
+  projectRoot: string;
+  files?: string[];
+  url?: string;
+  signal?: AbortSignal;
+  onEvent?: (event: AgentEvent) => void;
+  onApprovalRequest?: (request: ApprovalRequest) => Promise<boolean>;
+}
+
+export type RuntimeRunner = (options: RuntimeRunOptions) => Promise<unknown>;
+
+export interface RuntimeBridgeDeps {
+  /** Injectable `runFrontAgentTask`. */
+  run: RuntimeRunner;
+  /** Posts an envelope to the renderer (PR4: `webContents.send`). */
+  send: (channel: string, payload: AgentEventEnvelope | ApprovalRequestEnvelope) => void;
+  /** Overridable run-id generator (tests pass a deterministic one). */
+  generateRunId?: () => string;
+}
+
+export interface RuntimeBridge {
+  runTask(req: RunTaskRequest): RunTaskResponse;
+  respondApproval(input: ApprovalDecisionInput): void;
+  cancelTask(runId: string): void;
+  /** Number of runs currently in flight — for diagnostics/tests. */
+  activeRunCount(): number;
+}
+
+interface ActiveRun {
+  controller: AbortController;
+  pendingApprovals: Map<string, (approved: boolean) => void>;
+}
+
+export function createRuntimeBridge(deps: RuntimeBridgeDeps): RuntimeBridge {
+  const runs = new Map<string, ActiveRun>();
+  let counter = 0;
+  const genId = deps.generateRunId ?? (() => `run-${Date.now()}-${(counter += 1)}`);
+
+  return {
+    runTask(req) {
+      const runId = genId();
+      const active: ActiveRun = {
+        controller: new AbortController(),
+        pendingApprovals: new Map(),
+      };
+      runs.set(runId, active);
+
+      // Start the run on the next microtask so `runTask` returns the runId
+      // before any event is forwarded — the FrontAgentBridge.runTask timing
+      // contract the renderer store relies on (see contract.ts).
+      queueMicrotask(() => {
+        void deps
+          .run({
+            task: req.task,
+            projectRoot: req.workspacePath,
+            files: req.relevantFiles,
+            url: req.browserUrl,
+            signal: active.controller.signal,
+            onEvent: (event) => deps.send(IpcPush.AgentEvent, { runId, event }),
+            onApprovalRequest: (request) =>
+              new Promise<boolean>((resolve) => {
+                active.pendingApprovals.set(request.approvalId, resolve);
+                deps.send(IpcPush.ApprovalRequested, { runId, request });
+              }),
+          })
+          .catch((error) => {
+            deps.send(IpcPush.AgentEvent, {
+              runId,
+              event: {
+                type: 'task_failed',
+                error: error instanceof Error ? error.message : String(error),
+              },
+            });
+          })
+          .finally(() => {
+            // Resolve any approvals still pending (run ended) as denied so the
+            // runtime promise never hangs, then drop the run.
+            for (const resolve of active.pendingApprovals.values()) resolve(false);
+            runs.delete(runId);
+          });
+      });
+
+      return { runId };
+    },
+
+    respondApproval(input) {
+      const active = runs.get(input.runId);
+      const resolve = active?.pendingApprovals.get(input.approvalId);
+      if (!active || !resolve) return; // unknown run or stale/already-handled approval
+      active.pendingApprovals.delete(input.approvalId);
+      resolve(input.approved);
+    },
+
+    cancelTask(runId) {
+      runs.get(runId)?.controller.abort();
+    },
+
+    activeRunCount: () => runs.size,
+  };
+}

--- a/apps/desktop/src/main/settingsStore.test.ts
+++ b/apps/desktop/src/main/settingsStore.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { defaultSettings, loadSettings, type SettingsIO, saveSettings } from './settingsStore.js';
+
+function memoryIO(initial: string | null = null): SettingsIO & { contents: string | null } {
+  return {
+    contents: initial,
+    read() {
+      return this.contents;
+    },
+    write(contents) {
+      this.contents = contents;
+    },
+  };
+}
+
+describe('settingsStore', () => {
+  it('returns defaults when nothing is stored', () => {
+    expect(loadSettings(memoryIO(null))).toEqual(defaultSettings);
+  });
+
+  it('returns defaults when the stored blob is corrupt JSON', () => {
+    expect(loadSettings(memoryIO('{not json'))).toEqual(defaultSettings);
+  });
+
+  it('returns defaults when reading throws', () => {
+    const io: SettingsIO = {
+      read() {
+        throw new Error('EACCES');
+      },
+      write() {},
+    };
+    expect(loadSettings(io)).toEqual(defaultSettings);
+  });
+
+  it('round-trips settings through save and load', () => {
+    const io = memoryIO();
+    const settings = {
+      provider: 'openai',
+      model: 'gpt-x',
+      baseUrl: 'https://api.example.com',
+      defaultWorkspacePath: '/home/me/proj',
+    };
+    expect(saveSettings(io, settings)).toBe(true);
+    expect(loadSettings(io)).toEqual(settings);
+  });
+
+  it('ignores unknown and non-string fields in the stored blob', () => {
+    const io = memoryIO(
+      JSON.stringify({ provider: 'openai', model: 123, secret: 'x', defaultWorkspacePath: '/p' }),
+    );
+    const loaded = loadSettings(io);
+    expect(loaded.provider).toBe('openai');
+    expect(loaded.model).toBe(defaultSettings.model); // non-string model ignored
+    expect(loaded.defaultWorkspacePath).toBe('/p');
+    expect((loaded as unknown as Record<string, unknown>).secret).toBeUndefined();
+  });
+
+  it('returns false when writing fails instead of throwing', () => {
+    const io: SettingsIO = {
+      read: () => null,
+      write() {
+        throw new Error('ENOSPC');
+      },
+    };
+    expect(saveSettings(io, defaultSettings)).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/settingsStore.ts
+++ b/apps/desktop/src/main/settingsStore.ts
@@ -1,0 +1,62 @@
+/**
+ * Desktop settings persistence. Pure logic over an injected {@link SettingsIO}
+ * (PR4 backs it with a JSON file under `app.getPath('userData')`), so it is
+ * unit-testable and degrades safely on missing/corrupt/unwritable storage.
+ */
+import type { DesktopSettings } from '../ipc/contract.js';
+
+export const defaultSettings: DesktopSettings = {
+  provider: 'anthropic',
+  model: 'claude-opus-4-8',
+  baseUrl: '',
+  defaultWorkspacePath: '',
+};
+
+export interface SettingsIO {
+  /** Returns the stored contents, or null when nothing is stored yet. */
+  read(): string | null;
+  write(contents: string): void;
+}
+
+const STRING_KEYS: (keyof DesktopSettings)[] = [
+  'provider',
+  'model',
+  'baseUrl',
+  'defaultWorkspacePath',
+];
+
+/** Keep only known string fields; ignore anything else in the stored blob. */
+function sanitize(value: unknown): Partial<DesktopSettings> {
+  if (!value || typeof value !== 'object') return {};
+  const record = value as Record<string, unknown>;
+  const out: Partial<DesktopSettings> = {};
+  for (const key of STRING_KEYS) {
+    if (typeof record[key] === 'string') out[key] = record[key] as string;
+  }
+  return out;
+}
+
+export function loadSettings(io: SettingsIO): DesktopSettings {
+  let raw: string | null;
+  try {
+    raw = io.read();
+  } catch {
+    return { ...defaultSettings }; // unreadable storage → defaults
+  }
+  if (!raw) return { ...defaultSettings };
+  try {
+    return { ...defaultSettings, ...sanitize(JSON.parse(raw)) };
+  } catch {
+    return { ...defaultSettings }; // corrupt JSON → defaults
+  }
+}
+
+/** Persist settings. Returns true on success; never throws on write failure. */
+export function saveSettings(io: SettingsIO, settings: DesktopSettings): boolean {
+  try {
+    io.write(JSON.stringify({ ...defaultSettings, ...sanitize(settings) }, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Closes #330. Incremental slice 3/4 of the desktop app (follows #326 foundation, #329 renderer).

## What this adds

The **Electron-free, dependency-injected** main-process core that PR4's thin `main.ts` / `preload.ts` glue will wrap — so the meaty logic is fully unit-tested now.

- **`src/main/runtimeBridge.ts`** — `createRuntimeBridge({ run, send })`:
  - `runTask(req)` mints a `runId` and returns it **before** any event is forwarded (honours the `FrontAgentBridge.runTask` timing contract from #329 via `queueMicrotask`), then drives the injected `runFrontAgentTask`, forwarding `onEvent` → `AgentEventEnvelope` and `onApprovalRequest` → `ApprovalRequestEnvelope` + a promise resolved by the renderer's decision.
  - `respondApproval` resolves the matching pending approval (stale/unknown ignored); `cancelTask` aborts via `AbortSignal`; a thrown run is surfaced as `task_failed`; runs are dropped on completion (pending approvals resolved as denied so the runtime promise can't hang).
- **`src/main/settingsStore.ts`** — load/save `DesktopSettings` over an injected `SettingsIO`, degrading to defaults on missing/corrupt/unreadable storage and returning `false` (never throwing) on write failure.

## Incremental roadmap

1. ✅ #326 foundation (contract + reducer).
2. ✅ #329 renderer UI on the mock bridge.
3. **This PR** — main-process runtime bridge core + settings store (DI, tested, no electron).
4. Electron shell: `main.ts` window + `preload.ts` (real `FrontAgentBridge` over `ipcMain`/`ipcRenderer`) + packaging; swap the renderer's mock bridge for the preload bridge; SettingsPanel IPC-failure degradation (residual note from #329).

## Non-goals (PR4)

No `electron` dependency, `BrowserWindow`, real `ipcMain`/preload, or packaging in this slice.

## GitNexus Impact Summary

- **Risk level:** Low.
- **Critical skeleton changes:** None — additive `apps/desktop/src/main/*`; no existing symbol or execution flow modified, no new dependency.
- **GitNexus impact:** `detect_changes` (scope=staged, repo=FrontAgent) → `changed_count: 0`, `affected_count: 0`, `risk_level: low`, `changed_files: 4`.
- **Verification:** `pnpm lint` (1 pre-existing info), `pnpm typecheck` (23/23), `pnpm test` (23/23; desktop suite 62 incl. bridge + settings), `vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)