### PR TITLE
feat(desktop): IPC seam — main handler registration + preload bridge (Electron-free)

### DIFF
--- a/apps/desktop/src/main/ipcHandlers.test.ts
+++ b/apps/desktop/src/main/ipcHandlers.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type ApprovalDecisionInput,
+  type DesktopSettings,
+  IpcChannel,
+  type RunTaskRequest,
+} from '../ipc/contract.js';
+import { type IpcInvokeListener, registerIpcHandlers } from './ipcHandlers.js';
+import type { RuntimeBridge } from './runtimeBridge.js';
+
+const settings: DesktopSettings = { provider: 'anthropic', model: 'claude-opus-4-8' };
+
+function harness(opts: { saveOk?: boolean } = {}) {
+  const handlers = new Map<string, IpcInvokeListener>();
+  const calls = {
+    runTask: [] as RunTaskRequest[],
+    cancelTask: [] as string[],
+    respondApproval: [] as ApprovalDecisionInput[],
+    saved: [] as DesktopSettings[],
+  };
+  const bridge: RuntimeBridge = {
+    runTask: (req) => {
+      calls.runTask.push(req);
+      return { runId: 'R1' };
+    },
+    respondApproval: (input) => {
+      calls.respondApproval.push(input);
+    },
+    cancelTask: (runId) => {
+      calls.cancelTask.push(runId);
+    },
+    activeRunCount: () => 0,
+  };
+  registerIpcHandlers({
+    handle: (channel, listener) => handlers.set(channel, listener),
+    bridge,
+    loadSettings: () => settings,
+    saveSettings: (s) => {
+      calls.saved.push(s);
+      return opts.saveOk ?? true;
+    },
+  });
+  // Invoke a channel as `ipcMain` would (event arg unused by handlers).
+  const invoke = (channel: string, payload?: unknown) => handlers.get(channel)?.(null, payload);
+  return { calls, invoke };
+}
+
+describe('registerIpcHandlers', () => {
+  it('registers exactly the five invoke channels', () => {
+    const handlers = new Map<string, IpcInvokeListener>();
+    const bridge = {
+      runTask: () => ({ runId: 'R1' }),
+      respondApproval: () => {},
+      cancelTask: () => {},
+      activeRunCount: () => 0,
+    } satisfies RuntimeBridge;
+    registerIpcHandlers({
+      handle: (channel, listener) => handlers.set(channel, listener),
+      bridge,
+      loadSettings: () => settings,
+      saveSettings: () => true,
+    });
+    expect([...handlers.keys()].sort()).toEqual(
+      [
+        IpcChannel.RunTask,
+        IpcChannel.CancelTask,
+        IpcChannel.RespondApproval,
+        IpcChannel.GetSettings,
+        IpcChannel.SaveSettings,
+      ].sort(),
+    );
+  });
+
+  it('routes RunTask to the bridge and returns the runId', () => {
+    const { calls, invoke } = harness();
+    const req: RunTaskRequest = { task: 't', workspacePath: '/w' };
+    const res = invoke(IpcChannel.RunTask, req);
+    expect(res).toEqual({ runId: 'R1' });
+    expect(calls.runTask).toEqual([req]);
+  });
+
+  it('routes CancelTask and RespondApproval to the bridge', () => {
+    const { calls, invoke } = harness();
+    invoke(IpcChannel.CancelTask, 'R1');
+    const decision: ApprovalDecisionInput = { runId: 'R1', approvalId: 'apv-1', approved: true };
+    invoke(IpcChannel.RespondApproval, decision);
+    expect(calls.cancelTask).toEqual(['R1']);
+    expect(calls.respondApproval).toEqual([decision]);
+  });
+
+  it('returns stored settings from GetSettings', () => {
+    const { invoke } = harness();
+    expect(invoke(IpcChannel.GetSettings)).toEqual(settings);
+  });
+
+  it('persists settings on SaveSettings success', () => {
+    const { calls, invoke } = harness({ saveOk: true });
+    expect(() => invoke(IpcChannel.SaveSettings, settings)).not.toThrow();
+    expect(calls.saved).toEqual([settings]);
+  });
+
+  it('rejects (throws) SaveSettings when the write fails', () => {
+    const { invoke } = harness({ saveOk: false });
+    // Throwing here makes `ipcRenderer.invoke` reject so the renderer can degrade.
+    expect(() => invoke(IpcChannel.SaveSettings, settings)).toThrow(/persist settings/);
+  });
+});

--- a/apps/desktop/src/main/ipcHandlers.ts
+++ b/apps/desktop/src/main/ipcHandlers.ts
@@ -1,0 +1,60 @@
+/**
+ * Main-process IPC handler registration. Maps the renderer's invoke channels
+ * (see {@link IpcChannel}) onto the {@link RuntimeBridge} core and the settings
+ * store. Dependency-injected and Electron-free — `handle` is a minimal slice of
+ * `ipcMain.handle`, so the wiring is fully unit-testable; the thin Electron
+ * `main.ts` that calls this with the real `ipcMain` lands in the next slice.
+ */
+import {
+  type ApprovalDecisionInput,
+  type DesktopSettings,
+  IpcChannel,
+  type RunTaskRequest,
+  type RunTaskResponse,
+} from '../ipc/contract.js';
+import type { RuntimeBridge } from './runtimeBridge.js';
+
+/** A registered invoke listener. The first arg is Electron's event (unused here). */
+export type IpcInvokeListener = (event: unknown, payload?: unknown) => unknown;
+
+/** The minimal slice of `ipcMain.handle` the registration depends on. */
+export type IpcHandle = (channel: string, listener: IpcInvokeListener) => void;
+
+export interface IpcHandlerDeps {
+  handle: IpcHandle;
+  bridge: RuntimeBridge;
+  loadSettings: () => DesktopSettings;
+  /** Persists settings; returns false on write failure (never throws). */
+  saveSettings: (settings: DesktopSettings) => boolean;
+}
+
+export function registerIpcHandlers(deps: IpcHandlerDeps): void {
+  const { handle, bridge, loadSettings, saveSettings } = deps;
+
+  // RunTask returns the runId synchronously; `ipcMain.handle` resolves it to the
+  // renderer as a promise before any pushed envelope — the timing contract the
+  // store relies on (see contract.ts / runtimeBridge.ts).
+  handle(
+    IpcChannel.RunTask,
+    (_event, payload): RunTaskResponse => bridge.runTask(payload as RunTaskRequest),
+  );
+
+  handle(IpcChannel.CancelTask, (_event, payload) => {
+    bridge.cancelTask(payload as string);
+  });
+
+  handle(IpcChannel.RespondApproval, (_event, payload) => {
+    bridge.respondApproval(payload as ApprovalDecisionInput);
+  });
+
+  handle(IpcChannel.GetSettings, (): DesktopSettings => loadSettings());
+
+  // Reject on write failure so the renderer's `saveSettings` promise rejects and
+  // the SettingsPanel can show a degraded state (the UI lands with the renderer
+  // swap). A silent false here would strand the renderer believing it persisted.
+  handle(IpcChannel.SaveSettings, (_event, payload) => {
+    if (!saveSettings(payload as DesktopSettings)) {
+      throw new Error('Failed to persist settings');
+    }
+  });
+}

--- a/apps/desktop/src/preload/bridge.test.ts
+++ b/apps/desktop/src/preload/bridge.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type AgentEventEnvelope,
+  type ApprovalRequestEnvelope,
+  IpcChannel,
+  IpcPush,
+} from '../ipc/contract.js';
+import { createPreloadBridge, type PreloadIpc } from './bridge.js';
+
+type PushListener = (event: unknown, payload: unknown) => void;
+
+function fakeIpc(invoke?: (channel: string, payload?: unknown) => Promise<unknown>) {
+  const invokes: { channel: string; payload?: unknown }[] = [];
+  const listeners = new Map<string, Set<PushListener>>();
+  const ipc: PreloadIpc = {
+    invoke: (channel, payload) => {
+      invokes.push({ channel, payload });
+      return invoke ? invoke(channel, payload) : Promise.resolve(undefined);
+    },
+    on: (channel, listener) => {
+      (listeners.get(channel) ?? listeners.set(channel, new Set()).get(channel)!).add(listener);
+    },
+    removeListener: (channel, listener) => {
+      listeners.get(channel)?.delete(listener);
+    },
+  };
+  const emit = (channel: string, payload: unknown) => {
+    for (const l of listeners.get(channel) ?? []) l(null, payload);
+  };
+  const listenerCount = (channel: string) => listeners.get(channel)?.size ?? 0;
+  return { ipc, invokes, emit, listenerCount };
+}
+
+describe('createPreloadBridge', () => {
+  it('maps each request method onto its invoke channel', async () => {
+    const { ipc, invokes } = fakeIpc(async () => ({ runId: 'R1' }));
+    const bridge = createPreloadBridge(ipc);
+
+    const res = await bridge.runTask({ task: 't', workspacePath: '/w' });
+    expect(res).toEqual({ runId: 'R1' });
+
+    await bridge.cancelTask('R1');
+    await bridge.respondApproval({ runId: 'R1', approvalId: 'apv-1', approved: true });
+    await bridge.getSettings();
+    await bridge.saveSettings({ provider: 'anthropic', model: 'm' });
+
+    expect(invokes.map((i) => i.channel)).toEqual([
+      IpcChannel.RunTask,
+      IpcChannel.CancelTask,
+      IpcChannel.RespondApproval,
+      IpcChannel.GetSettings,
+      IpcChannel.SaveSettings,
+    ]);
+    expect(invokes[0].payload).toEqual({ task: 't', workspacePath: '/w' });
+    expect(invokes[1].payload).toBe('R1');
+  });
+
+  it('propagates a rejected saveSettings invoke (write failure → degrade)', async () => {
+    const { ipc } = fakeIpc(async () => {
+      throw new Error('Failed to persist settings');
+    });
+    const bridge = createPreloadBridge(ipc);
+    await expect(bridge.saveSettings({ provider: 'anthropic', model: 'm' })).rejects.toThrow(
+      /persist settings/,
+    );
+  });
+
+  it('delivers pushed agent events to the subscriber', () => {
+    const { ipc, emit } = fakeIpc();
+    const bridge = createPreloadBridge(ipc);
+    const seen: AgentEventEnvelope[] = [];
+    bridge.onAgentEvent((env) => seen.push(env));
+
+    const env: AgentEventEnvelope = { runId: 'R1', event: { type: 'planning_started' } };
+    emit(IpcPush.AgentEvent, env);
+    expect(seen).toEqual([env]);
+  });
+
+  it('delivers pushed approval requests to the subscriber', () => {
+    const { ipc, emit } = fakeIpc();
+    const bridge = createPreloadBridge(ipc);
+    const seen: ApprovalRequestEnvelope[] = [];
+    bridge.onApprovalRequested((env) => seen.push(env));
+
+    const env = { runId: 'R1', request: { approvalId: 'apv-1' } } as ApprovalRequestEnvelope;
+    emit(IpcPush.ApprovalRequested, env);
+    expect(seen).toEqual([env]);
+  });
+
+  it('unsubscribe stops further delivery and removes the listener', () => {
+    const { ipc, emit, listenerCount } = fakeIpc();
+    const bridge = createPreloadBridge(ipc);
+    const listener = vi.fn();
+    const off = bridge.onAgentEvent(listener);
+    expect(listenerCount(IpcPush.AgentEvent)).toBe(1);
+
+    off();
+    expect(listenerCount(IpcPush.AgentEvent)).toBe(0);
+    emit(IpcPush.AgentEvent, { runId: 'R1', event: { type: 'planning_started' } });
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/preload/bridge.ts
+++ b/apps/desktop/src/preload/bridge.ts
@@ -1,0 +1,59 @@
+/**
+ * Renderer-facing bridge factory. Builds the {@link FrontAgentBridge} contract
+ * surface (see contract.ts) over a minimal slice of `ipcRenderer`: request
+ * methods map onto `invoke`, push subscriptions onto `on`/`removeListener`.
+ *
+ * Dependency-injected and Electron-free so it is unit-testable; the thin
+ * `preload.ts` that exposes `createPreloadBridge(ipcRenderer)` on
+ * `window.frontagent` via `contextBridge` lands in the next slice.
+ */
+import {
+  type AgentEventEnvelope,
+  type ApprovalDecisionInput,
+  type ApprovalRequestEnvelope,
+  type DesktopSettings,
+  type FrontAgentBridge,
+  IpcChannel,
+  IpcPush,
+  type RunTaskRequest,
+  type RunTaskResponse,
+} from '../ipc/contract.js';
+
+/** A push listener as registered on `ipcRenderer` (first arg is Electron's event). */
+type PushListener = (event: unknown, payload: unknown) => void;
+
+/** The minimal slice of `ipcRenderer` the bridge depends on. */
+export interface PreloadIpc {
+  invoke(channel: string, payload?: unknown): Promise<unknown>;
+  on(channel: string, listener: PushListener): void;
+  removeListener(channel: string, listener: PushListener): void;
+}
+
+export function createPreloadBridge(ipc: PreloadIpc): FrontAgentBridge {
+  return {
+    runTask: (req: RunTaskRequest) =>
+      ipc.invoke(IpcChannel.RunTask, req) as Promise<RunTaskResponse>,
+    cancelTask: (runId: string) => ipc.invoke(IpcChannel.CancelTask, runId) as Promise<void>,
+    respondApproval: (input: ApprovalDecisionInput) =>
+      ipc.invoke(IpcChannel.RespondApproval, input) as Promise<void>,
+    getSettings: () => ipc.invoke(IpcChannel.GetSettings) as Promise<DesktopSettings>,
+    // Rejects when the main handler rejects (write failure) — the SettingsPanel
+    // relies on this to surface a degraded state.
+    saveSettings: (settings: DesktopSettings) =>
+      ipc.invoke(IpcChannel.SaveSettings, settings) as Promise<void>,
+    onAgentEvent: (listener) => subscribe<AgentEventEnvelope>(ipc, IpcPush.AgentEvent, listener),
+    onApprovalRequested: (listener) =>
+      subscribe<ApprovalRequestEnvelope>(ipc, IpcPush.ApprovalRequested, listener),
+  };
+}
+
+/** Wire a push channel to a typed listener; returns an unsubscribe function. */
+function subscribe<T>(
+  ipc: PreloadIpc,
+  channel: string,
+  listener: (envelope: T) => void,
+): () => void {
+  const handler: PushListener = (_event, payload) => listener(payload as T);
+  ipc.on(channel, handler);
+  return () => ipc.removeListener(channel, handler);
+}


### PR DESCRIPTION
Closes #333. Incremental slice 4 of the desktop app (follows #325 foundation, #327 renderer, #330 runtime-bridge core).

## What

Wires the existing pieces together with the seam's **two ends**, both kept **dependency-injected and Electron-free** (no `electron` import — `handle`/`invoke`/`on` are injected behind minimal interfaces), the same discipline as the runtime-bridge core, so the seam is fully unit-testable now.

- **`apps/desktop/src/main/ipcHandlers.ts`** — `registerIpcHandlers({ handle, bridge, loadSettings, saveSettings })` maps the five `IpcChannel` invoke channels onto the `createRuntimeBridge` core (#330) and the settings store:
  - `RunTask` → `bridge.runTask(req)` returning `{ runId }` (honours the #325 timing contract: invoke resolves before any pushed envelope).
  - `CancelTask` / `RespondApproval` → the matching bridge methods.
  - `GetSettings` → `loadSettings()`.
  - `SaveSettings` → **throws when the write fails**, so `ipcRenderer.invoke` rejects and the renderer can show a degraded state — the failure-semantic the #327/#329 SettingsPanel-degradation note depends on. A silent `false` would strand the renderer believing it persisted.
- **`apps/desktop/src/preload/bridge.ts`** — `createPreloadBridge(ipc)` builds the `FrontAgentBridge` contract surface (#325) over `ipc.invoke` + `ipc.on`/`removeListener`, so a later `preload.ts` can expose it on `window.frontagent` with **no renderer changes**.
- 11 unit tests (fake `handle` registry / fake `ipc`) covering: channel routing, the `runId` return, save-failure rejection, push delivery for both push channels, and unsubscribe removing the listener.

## Re-split note (for maintainer)

#330 framed the remaining work as one "PR4: Electron glue + packaging + swap + degradation". I split it into this **seam slice** (pure, testable) + a following **Electron-bootstrap slice**. Keeps each PR independently reviewable and isolates the heavy `electron` dependency + build/packaging tooling to its own focused PR.

## Non-goals (next slice — Electron bootstrap)

- No `electron` dependency, `app`/`BrowserWindow` lifecycle, real `ipcMain`/`contextBridge`, `main.ts`/`preload.ts` entry files, or packaging.
- Renderer still uses the mock bridge; swapping `main.tsx` to `window.frontagent` and the SettingsPanel IPC-failure degraded **UI** land there with the real failing bridge.

## GitNexus impact summary

- `detect_changes` (staged): **risk_level low**, 0 changed symbols, 0 affected processes — net-new additive files; nothing imports the new exports until the PR5 renderer swap, so no upstream blast radius.
- No existing symbol edited (both files are new exports), so no `impact` warning applies.

## Verification

- `pnpm --filter @frontagent/desktop test` → **76 passed** (65 prior + 11 new).
- `pnpm --filter @frontagent/desktop typecheck` clean; `biome check` clean on the four files.
- No new heavy dependency (no `electron`) in this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)