### PR TITLE
feat(desktop): Electron bootstrap — main/preload entry + build wiring + renderer swap

### DIFF
--- a/apps/desktop/electron.build.mjs
+++ b/apps/desktop/electron.build.mjs
@@ -2,26 +2,38 @@
  * Builds the Electron main + preload bundles with esbuild.
  *
  * Raw `tsc` fights this package's `"type": "module"` + workspace `exports` +
- * Electron's preload module-format rules; esbuild sidesteps all of it: it emits
- * `.mjs` (ESM, the format Electron 42 loads for both main and an `.mjs` preload),
- * bundles only our own source, and keeps every node_modules package external so
- * the heavy runtime tree is resolved by Node at launch rather than inlined.
+ * Electron's module-format rules; esbuild sidesteps all of it: it bundles only
+ * our own source and keeps every node_modules package external so the heavy
+ * runtime tree is resolved by Node at launch rather than inlined.
+ *
+ * The two bundles use different formats deliberately:
+ * - main → ESM (`.mjs`): Electron 42 loads an ESM main, which gives us
+ *   `import.meta.dirname` and native `import` of the ESM runtime spine.
+ * - preload → CommonJS (`.cjs`): a *sandboxed* renderer (`sandbox: true`, the
+ *   security posture the app requires) loads only a CJS preload. Bundled with
+ *   deps external, the preload requires nothing but `electron` at runtime,
+ *   which the sandbox preload loader allows.
  */
 import { build } from 'esbuild';
 
 const shared = {
   bundle: true,
   platform: 'node',
-  format: 'esm',
   target: 'node20',
   packages: 'external',
   sourcemap: true,
   logLevel: 'info',
 };
 
-await build({ ...shared, entryPoints: ['src/main/main.ts'], outfile: 'dist/electron/main.mjs' });
 await build({
   ...shared,
+  format: 'esm',
+  entryPoints: ['src/main/main.ts'],
+  outfile: 'dist/electron/main.mjs',
+});
+await build({
+  ...shared,
+  format: 'cjs',
   entryPoints: ['src/preload/preload.ts'],
-  outfile: 'dist/electron/preload.mjs',
+  outfile: 'dist/electron/preload.cjs',
 });

--- a/apps/desktop/electron.build.mjs
+++ b/apps/desktop/electron.build.mjs
@@ -1,0 +1,27 @@
+/**
+ * Builds the Electron main + preload bundles with esbuild.
+ *
+ * Raw `tsc` fights this package's `"type": "module"` + workspace `exports` +
+ * Electron's preload module-format rules; esbuild sidesteps all of it: it emits
+ * `.mjs` (ESM, the format Electron 42 loads for both main and an `.mjs` preload),
+ * bundles only our own source, and keeps every node_modules package external so
+ * the heavy runtime tree is resolved by Node at launch rather than inlined.
+ */
+import { build } from 'esbuild';
+
+const shared = {
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  target: 'node20',
+  packages: 'external',
+  sourcemap: true,
+  logLevel: 'info',
+};
+
+await build({ ...shared, entryPoints: ['src/main/main.ts'], outfile: 'dist/electron/main.mjs' });
+await build({
+  ...shared,
+  entryPoints: ['src/preload/preload.ts'],
+  outfile: 'dist/electron/preload.mjs',
+});

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "main": "./dist/electron/main.mjs",
   "scripts": {
-    "dev": "vite",
-    "dev:app": "concurrently -k -n VITE,ELECTRON -c blue,green \"vite --port 5173 --strictPort\" \"node electron.build.mjs && cross-env ELECTRON_RENDERER_URL=http://localhost:5173 electron .\"",
+    "dev": "concurrently -k -n VITE,ELECTRON -c blue,green \"vite --port 5173 --strictPort\" \"node electron.build.mjs && cross-env ELECTRON_RENDERER_URL=http://localhost:5173 electron .\"",
+    "dev:renderer": "vite",
     "build": "tsc --noEmit && vite build && node electron.build.mjs",
     "build:electron": "node electron.build.mjs",
     "start": "electron .",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,7 +7,7 @@
   "main": "./dist/electron/main.mjs",
   "scripts": {
     "dev": "vite",
-    "dev:app": "concurrently -k -n VITE,ELECTRON -c blue,green \"vite --port 5173 --strictPort\" \"node electron.build.mjs && ELECTRON_RENDERER_URL=http://localhost:5173 electron .\"",
+    "dev:app": "concurrently -k -n VITE,ELECTRON -c blue,green \"vite --port 5173 --strictPort\" \"node electron.build.mjs && cross-env ELECTRON_RENDERER_URL=http://localhost:5173 electron .\"",
     "build": "tsc --noEmit && vite build && node electron.build.mjs",
     "build:electron": "node electron.build.mjs",
     "start": "electron .",
@@ -30,6 +30,7 @@
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^5.1.0",
     "concurrently": "^9.2.0",
+    "cross-env": "^7.0.3",
     "electron": "^42.4.0",
     "esbuild": "^0.25.0",
     "typescript": "^6.0.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -4,10 +4,13 @@
   "description": "FrontAgent desktop app (Electron) — standalone GUI entry point reusing the Node runtime spine",
   "private": true,
   "type": "module",
-  "main": "./dist/electron/main.js",
+  "main": "./dist/electron/main.mjs",
   "scripts": {
     "dev": "vite",
-    "build": "tsc --noEmit && vite build",
+    "dev:app": "concurrently -k -n VITE,ELECTRON -c blue,green \"vite --port 5173 --strictPort\" \"node electron.build.mjs && ELECTRON_RENDERER_URL=http://localhost:5173 electron .\"",
+    "build": "tsc --noEmit && vite build && node electron.build.mjs",
+    "build:electron": "node electron.build.mjs",
+    "start": "electron .",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
@@ -17,6 +20,7 @@
     "@fontsource/ibm-plex-mono": "^5.2.0",
     "@fontsource/ibm-plex-sans": "^5.2.0",
     "@frontagent/core": "workspace:*",
+    "@frontagent/runtime-node": "workspace:*",
     "@frontagent/shared": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
@@ -25,6 +29,9 @@
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^5.1.0",
+    "concurrently": "^9.2.0",
+    "electron": "^42.4.0",
+    "esbuild": "^0.25.0",
     "typescript": "^6.0.3",
     "vite": "^7.1.0",
     "vitest": "^4.1.7"

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -43,13 +43,13 @@ function createMainWindow(): BrowserWindow {
     backgroundColor: '#0e1014',
     show: false,
     webPreferences: {
-      preload: join(import.meta.dirname, 'preload.mjs'),
+      // CommonJS preload (see electron.build.mjs) so the renderer stays
+      // sandboxed; it reaches the main process only through the typed
+      // `window.frontagent` bridge the preload exposes.
+      preload: join(import.meta.dirname, 'preload.cjs'),
+      sandbox: true,
       contextIsolation: true,
       nodeIntegration: false,
-      // ESM (.mjs) preload requires the sandbox disabled; the renderer still has
-      // no Node access (contextIsolation + nodeIntegration:false) and reaches the
-      // main process only through the typed `window.frontagent` bridge.
-      sandbox: false,
     },
   });
   win.once('ready-to-show', () => win.show());

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1,0 +1,103 @@
+/**
+ * Electron main-process entry. Pure assembly (keel grade: wiring): it composes
+ * the already-built, unit-tested pieces and owns no logic of its own —
+ *
+ *   runFrontAgentTask (the Node runtime spine)
+ *     → createRuntimeBridge  (runtime → IPC envelopes, #330)
+ *       → registerIpcHandlers (invoke channels → bridge + settings, #333)
+ *         → createPreloadBridge on the renderer (exposed by preload.ts, #333)
+ *
+ * Everything testable lives in those modules; this file just starts the window
+ * and connects them, so it carries no tests (it cannot run without Electron).
+ */
+import { join } from 'node:path';
+import { runFrontAgentTask } from '@frontagent/runtime-node';
+import { app, BrowserWindow, ipcMain } from 'electron';
+import { registerIpcHandlers } from './ipcHandlers.js';
+import { createRuntimeBridge, type RuntimeRunOptions } from './runtimeBridge.js';
+import { createFileSettingsIO } from './runtimeIO.js';
+import { loadSettings, saveSettings } from './settingsStore.js';
+
+/** Set by `pnpm dev:app` so the window loads the live Vite server in development. */
+const RENDERER_DEV_URL = process.env.ELECTRON_RENDERER_URL;
+
+let mainWindow: BrowserWindow | null = null;
+
+function loadRenderer(win: BrowserWindow): void {
+  if (RENDERER_DEV_URL) {
+    // Vite may not be listening yet on first launch; retry until it is.
+    win.loadURL(RENDERER_DEV_URL).catch(() => {
+      setTimeout(() => loadRenderer(win), 400);
+    });
+    return;
+  }
+  win.loadFile(join(import.meta.dirname, '../renderer/index.html'));
+}
+
+function createMainWindow(): BrowserWindow {
+  const win = new BrowserWindow({
+    width: 1280,
+    height: 860,
+    minWidth: 960,
+    minHeight: 640,
+    backgroundColor: '#0e1014',
+    show: false,
+    webPreferences: {
+      preload: join(import.meta.dirname, 'preload.mjs'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      // ESM (.mjs) preload requires the sandbox disabled; the renderer still has
+      // no Node access (contextIsolation + nodeIntegration:false) and reaches the
+      // main process only through the typed `window.frontagent` bridge.
+      sandbox: false,
+    },
+  });
+  win.once('ready-to-show', () => win.show());
+  win.on('closed', () => {
+    if (mainWindow === win) mainWindow = null;
+  });
+  loadRenderer(win);
+  mainWindow = win;
+  return win;
+}
+
+app.whenReady().then(() => {
+  const io = createFileSettingsIO(join(app.getPath('userData'), 'settings.json'));
+
+  const bridge = createRuntimeBridge({
+    run: (opts: RuntimeRunOptions) => {
+      // Merge the persisted LLM settings into each run; the API key resolves
+      // from the environment inside the runtime (PROVIDER_API_KEY / API_KEY).
+      const s = loadSettings(io);
+      return runFrontAgentTask({
+        ...opts,
+        provider: s.provider,
+        model: s.model,
+        baseUrl: s.baseUrl || undefined,
+      });
+    },
+    send: (channel, payload) => {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send(channel, payload);
+      }
+    },
+  });
+
+  registerIpcHandlers({
+    handle: (channel, listener) => ipcMain.handle(channel, listener),
+    bridge,
+    loadSettings: () => loadSettings(io),
+    saveSettings: (settings) => saveSettings(io, settings),
+  });
+
+  createMainWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createMainWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  // macOS apps conventionally stay alive until Cmd+Q.
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/apps/desktop/src/main/runtimeIO.test.ts
+++ b/apps/desktop/src/main/runtimeIO.test.ts
@@ -1,0 +1,35 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createFileSettingsIO } from './runtimeIO.js';
+
+describe('createFileSettingsIO', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'fa-settings-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns null when the file does not exist', () => {
+    const io = createFileSettingsIO(join(dir, 'missing', 'settings.json'));
+    expect(io.read()).toBeNull();
+  });
+
+  it('round-trips contents and creates the parent directory', () => {
+    const path = join(dir, 'nested', 'settings.json');
+    const io = createFileSettingsIO(path);
+    io.write('{"provider":"anthropic"}');
+    expect(io.read()).toBe('{"provider":"anthropic"}');
+    // The parent dir was created on write.
+    expect(readFileSync(path, 'utf8')).toContain('anthropic');
+  });
+
+  it('reads contents written out of band', () => {
+    const path = join(dir, 'settings.json');
+    writeFileSync(path, 'raw', 'utf8');
+    expect(createFileSettingsIO(path).read()).toBe('raw');
+  });
+});

--- a/apps/desktop/src/main/runtimeIO.ts
+++ b/apps/desktop/src/main/runtimeIO.ts
@@ -1,0 +1,19 @@
+/**
+ * File-backed {@link SettingsIO} for the Electron main process. Kept separate
+ * from `main.ts` (which is Electron assembly) so the read/write/parent-dir
+ * behaviour stays unit-testable against a real temp directory. `main.ts` points
+ * it at `app.getPath('userData')`.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import type { SettingsIO } from './settingsStore.js';
+
+export function createFileSettingsIO(filePath: string): SettingsIO {
+  return {
+    read: () => (existsSync(filePath) ? readFileSync(filePath, 'utf8') : null),
+    write: (contents) => {
+      mkdirSync(dirname(filePath), { recursive: true });
+      writeFileSync(filePath, contents, 'utf8');
+    },
+  };
+}

--- a/apps/desktop/src/preload/install.test.ts
+++ b/apps/desktop/src/preload/install.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { FrontAgentBridge } from '../ipc/contract.js';
+import { IpcChannel } from '../ipc/contract.js';
+import type { PreloadIpc } from './bridge.js';
+import { FRONTAGENT_BRIDGE_KEY, installPreloadBridge } from './install.js';
+
+function fakeIpc() {
+  const invokes: { channel: string; payload?: unknown }[] = [];
+  const ipc: PreloadIpc = {
+    invoke: (channel, payload) => {
+      invokes.push({ channel, payload });
+      return Promise.resolve({ runId: 'R1' });
+    },
+    on: () => {},
+    removeListener: () => {},
+  };
+  return { ipc, invokes };
+}
+
+describe('installPreloadBridge', () => {
+  it('exposes a FrontAgentBridge under the frontagent key', () => {
+    const { ipc } = fakeIpc();
+    const exposed = new Map<string, unknown>();
+    installPreloadBridge({ expose: (key, api) => exposed.set(key, api), ipc });
+
+    expect(FRONTAGENT_BRIDGE_KEY).toBe('frontagent'); // the key the renderer reads
+    expect(exposed.has(FRONTAGENT_BRIDGE_KEY)).toBe(true);
+
+    const bridge = exposed.get(FRONTAGENT_BRIDGE_KEY) as FrontAgentBridge;
+    expect(typeof bridge.runTask).toBe('function');
+    expect(typeof bridge.cancelTask).toBe('function');
+    expect(typeof bridge.respondApproval).toBe('function');
+    expect(typeof bridge.getSettings).toBe('function');
+    expect(typeof bridge.saveSettings).toBe('function');
+    expect(typeof bridge.onAgentEvent).toBe('function');
+    expect(typeof bridge.onApprovalRequested).toBe('function');
+  });
+
+  it('exposes a bridge wired to IPC, not a stub', async () => {
+    const { ipc, invokes } = fakeIpc();
+    const exposed = new Map<string, unknown>();
+    installPreloadBridge({ expose: (key, api) => exposed.set(key, api), ipc });
+
+    const bridge = exposed.get(FRONTAGENT_BRIDGE_KEY) as FrontAgentBridge;
+    const res = await bridge.runTask({ task: 't', workspacePath: '/w' });
+    expect(res).toEqual({ runId: 'R1' });
+    expect(invokes[0].channel).toBe(IpcChannel.RunTask);
+  });
+});

--- a/apps/desktop/src/preload/install.ts
+++ b/apps/desktop/src/preload/install.ts
@@ -1,0 +1,21 @@
+/**
+ * The preload's one job, made testable: expose a working {@link FrontAgentBridge}
+ * on the renderer global under a fixed key. Kept separate from `preload.ts` (which
+ * can only import the real `electron` at runtime) so a unit test can assert the
+ * bridge is actually injected — and wired to IPC, not a stub — without launching
+ * Electron.
+ */
+import { createPreloadBridge, type PreloadIpc } from './bridge.js';
+
+/** The global key the renderer reads as `window.frontagent`. */
+export const FRONTAGENT_BRIDGE_KEY = 'frontagent';
+
+export interface PreloadHost {
+  /** `contextBridge.exposeInMainWorld` in `preload.ts`. */
+  expose: (key: string, api: unknown) => void;
+  ipc: PreloadIpc;
+}
+
+export function installPreloadBridge(host: PreloadHost): void {
+  host.expose(FRONTAGENT_BRIDGE_KEY, createPreloadBridge(host.ipc));
+}

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1,11 +1,12 @@
 /**
  * Electron preload. The thin glue the IPC seam (#333) was designed for: it
  * exposes the {@link FrontAgentBridge} on `window.frontagent` via `contextBridge`
- * by handing `createPreloadBridge` a minimal `ipcRenderer` slice. No logic lives
- * here — all behaviour is in `createPreloadBridge`, which is unit-tested.
+ * by handing the IPC slice to `installPreloadBridge`. No logic lives here — all
+ * behaviour is in `createPreloadBridge` / `installPreloadBridge`, both unit-tested.
  */
 import { contextBridge, type IpcRendererEvent, ipcRenderer } from 'electron';
-import { createPreloadBridge, type PreloadIpc } from './bridge.js';
+import type { PreloadIpc } from './bridge.js';
+import { installPreloadBridge } from './install.js';
 
 const ipc: PreloadIpc = {
   invoke: (channel, payload) => ipcRenderer.invoke(channel, payload),
@@ -20,4 +21,7 @@ const ipc: PreloadIpc = {
   },
 };
 
-contextBridge.exposeInMainWorld('frontagent', createPreloadBridge(ipc));
+installPreloadBridge({
+  expose: (key, api) => contextBridge.exposeInMainWorld(key, api),
+  ipc,
+});

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1,0 +1,23 @@
+/**
+ * Electron preload. The thin glue the IPC seam (#333) was designed for: it
+ * exposes the {@link FrontAgentBridge} on `window.frontagent` via `contextBridge`
+ * by handing `createPreloadBridge` a minimal `ipcRenderer` slice. No logic lives
+ * here — all behaviour is in `createPreloadBridge`, which is unit-tested.
+ */
+import { contextBridge, type IpcRendererEvent, ipcRenderer } from 'electron';
+import { createPreloadBridge, type PreloadIpc } from './bridge.js';
+
+const ipc: PreloadIpc = {
+  invoke: (channel, payload) => ipcRenderer.invoke(channel, payload),
+  on: (channel, listener) => {
+    ipcRenderer.on(channel, listener as (event: IpcRendererEvent, ...args: unknown[]) => void);
+  },
+  removeListener: (channel, listener) => {
+    ipcRenderer.removeListener(
+      channel,
+      listener as (event: IpcRendererEvent, ...args: unknown[]) => void,
+    );
+  },
+};
+
+contextBridge.exposeInMainWorld('frontagent', createPreloadBridge(ipc));

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -1,0 +1,8 @@
+import type { FrontAgentBridge } from '../ipc/contract.js';
+
+declare global {
+  interface Window {
+    /** Exposed by the Electron preload (`preload.ts`); absent under plain `vite dev`. */
+    frontagent?: FrontAgentBridge;
+  }
+}

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -16,9 +16,10 @@ import { App } from './App.js';
 import { createMockBridge } from './mock/mockBridge.js';
 import './theme.css';
 
-// PR 2 runs the renderer against the in-browser mock bridge. PR 3 swaps this
-// for the preload bridge exposed by the Electron main process over IPC.
-const bridge = createMockBridge();
+// Use the real preload bridge (`window.frontagent`) when running inside Electron;
+// fall back to the in-browser mock under plain `vite dev` so the UI stays
+// reviewable on its own.
+const bridge = window.frontagent ?? createMockBridge();
 
 const root = document.getElementById('root');
 if (!root) throw new Error('missing #root');

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -12,17 +12,31 @@ import '@fontsource/ibm-plex-sans/700.css';
 import '@fontsource/ibm-plex-mono/400.css';
 import '@fontsource/ibm-plex-mono/500.css';
 import '@fontsource/ibm-plex-mono/600.css';
+import type { FrontAgentBridge } from '../ipc/contract.js';
 import { App } from './App.js';
 import { createMockBridge } from './mock/mockBridge.js';
+import { selectBridge } from './selectBridge.js';
 import './theme.css';
-
-// Use the real preload bridge (`window.frontagent`) when running inside Electron;
-// fall back to the in-browser mock under plain `vite dev` so the UI stays
-// reviewable on its own.
-const bridge = window.frontagent ?? createMockBridge();
 
 const root = document.getElementById('root');
 if (!root) throw new Error('missing #root');
+
+// Prefer the real preload bridge (`window.frontagent`); fall back to the mock
+// only in a plain browser. A missing bridge *inside Electron* is a hard failure
+// (the real runtime wiring broke) — surfaced as a visible startup error rather
+// than a silent downgrade to the mock. See selectBridge.ts.
+let bridge: FrontAgentBridge;
+try {
+  bridge = selectBridge({
+    frontagent: window.frontagent,
+    userAgent: navigator.userAgent,
+    createMock: createMockBridge,
+  });
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  root.innerHTML = `<div role="alert" style="font-family:'IBM Plex Mono',monospace;color:#ff6b6b;background:#0e1014;padding:2rem;min-height:100vh;box-sizing:border-box"><h1 style="font-family:'Chakra Petch',sans-serif;letter-spacing:.04em">启动失败 · STARTUP FAILED</h1><p style="color:#c9d1d9;max-width:60ch;line-height:1.6">${message}</p></div>`;
+  throw error;
+}
 
 createRoot(root).render(
   <StrictMode>

--- a/apps/desktop/src/renderer/selectBridge.test.ts
+++ b/apps/desktop/src/renderer/selectBridge.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { FrontAgentBridge } from '../ipc/contract.js';
+import { isElectronRuntime, MissingPreloadBridgeError, selectBridge } from './selectBridge.js';
+
+const ELECTRON_UA =
+  'Mozilla/5.0 (Macintosh) AppleWebKit/537.36 FrontAgent/2.1.1 Chrome/130 Electron/42.4.0 Safari/537.36';
+const BROWSER_UA = 'Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/130 Safari/537.36';
+
+const realBridge = {} as FrontAgentBridge;
+
+describe('isElectronRuntime', () => {
+  it('detects an Electron user-agent', () => {
+    expect(isElectronRuntime(ELECTRON_UA)).toBe(true);
+  });
+  it('rejects a plain browser user-agent', () => {
+    expect(isElectronRuntime(BROWSER_UA)).toBe(false);
+  });
+});
+
+describe('selectBridge', () => {
+  it('uses the preload bridge when present (Electron)', () => {
+    const createMock = vi.fn();
+    expect(selectBridge({ frontagent: realBridge, userAgent: ELECTRON_UA, createMock })).toBe(
+      realBridge,
+    );
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it('throws in Electron when the preload bridge is missing (no silent mock)', () => {
+    const createMock = vi.fn();
+    expect(() =>
+      selectBridge({ frontagent: undefined, userAgent: ELECTRON_UA, createMock }),
+    ).toThrow(MissingPreloadBridgeError);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the mock only in a plain browser', () => {
+    const mock = {} as FrontAgentBridge;
+    const createMock = vi.fn(() => mock);
+    expect(selectBridge({ frontagent: undefined, userAgent: BROWSER_UA, createMock })).toBe(mock);
+    expect(createMock).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/renderer/selectBridge.ts
+++ b/apps/desktop/src/renderer/selectBridge.ts
@@ -1,0 +1,34 @@
+/**
+ * Decides which {@link FrontAgentBridge} the renderer runs against. Pure and
+ * unit-tested so the browser-review vs. Electron-runtime distinction is explicit
+ * rather than an implicit `?? mock`: a missing preload bridge inside Electron is
+ * a hard failure (the real runtime wiring broke), not a silent downgrade to the
+ * mock. Only a plain browser (`vite dev`, no Electron) may use the mock.
+ */
+import type { FrontAgentBridge } from '../ipc/contract.js';
+
+/** Electron stamps `Electron/<version>` into the renderer's user-agent. */
+export function isElectronRuntime(userAgent: string): boolean {
+  return /\bElectron\//i.test(userAgent);
+}
+
+export class MissingPreloadBridgeError extends Error {
+  constructor() {
+    super(
+      'FrontAgent preload bridge unavailable: the Electron preload did not expose ' +
+        'window.frontagent. Refusing to fall back to the mock bridge in a desktop ' +
+        'runtime — check the preload build/path and contextBridge wiring.',
+    );
+    this.name = 'MissingPreloadBridgeError';
+  }
+}
+
+export function selectBridge(opts: {
+  frontagent: FrontAgentBridge | undefined;
+  userAgent: string;
+  createMock: () => FrontAgentBridge;
+}): FrontAgentBridge {
+  if (opts.frontagent) return opts.frontagent;
+  if (isElectronRuntime(opts.userAgent)) throw new MissingPreloadBridgeError();
+  return opts.createMock();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@frontagent/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@frontagent/runtime-node':
+        specifier: workspace:*
+        version: link:../../packages/runtime-node
       '@frontagent/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -139,6 +142,15 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.1.0
         version: 5.2.0(vite@7.3.2(@types/node@25.9.1)(yaml@2.9.0))
+      concurrently:
+        specifier: ^9.2.0
+        version: 9.2.1
+      electron:
+        specifier: ^42.4.0
+        version: 42.4.0
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -570,8 +582,22 @@ packages:
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
+  '@electron-internal/extract-zip@1.0.3':
+    resolution: {integrity: sha512-OjKpjB7gohtEjZiq6nDx1egqjZJhGPN1iFOIED+NFhB/MMkXw/XRcHjh1DGXKT5z2W9eW7Jy2UKU3gpjvusFTQ==}
+    engines: {node: '>=22.12.0'}
+
+  '@electron/get@5.0.0':
+    resolution: {integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==}
+    engines: {node: '>=22.12.0'}
+
   '@emnapi/runtime@1.11.0':
     resolution: {integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -585,6 +611,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
@@ -595,6 +627,12 @@ packages:
     resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -609,6 +647,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
@@ -621,6 +665,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
@@ -631,6 +681,12 @@ packages:
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -645,6 +701,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
@@ -655,6 +717,12 @@ packages:
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -669,6 +737,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
@@ -679,6 +753,12 @@ packages:
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -693,6 +773,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
@@ -703,6 +789,12 @@ packages:
     resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -717,6 +809,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
@@ -727,6 +825,12 @@ packages:
     resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -741,6 +845,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
@@ -751,6 +861,12 @@ packages:
     resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.7':
@@ -765,6 +881,12 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
@@ -777,6 +899,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
@@ -787,6 +915,12 @@ packages:
     resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -801,6 +935,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
@@ -811,6 +951,12 @@ packages:
     resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -825,6 +971,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
@@ -836,6 +988,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
@@ -849,6 +1007,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
@@ -861,6 +1025,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
@@ -871,6 +1041,12 @@ packages:
     resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -1668,6 +1844,11 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
     engines: {node: '>=18'}
@@ -1761,6 +1942,11 @@ packages:
   electron-to-chromium@1.5.372:
     resolution: {integrity: sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==}
 
+  electron@42.4.0:
+    resolution: {integrity: sha512-OXXqh9LD9KxXPv2Fe25EfU9N9AvWTuV6V81sfhQaNvTAXCd9ONA+Q4OWvMe+CmYD6xIwjFxGGtG/ZphDYYC5OQ==}
+    engines: {node: '>= 22.12.0'}
+    hasBin: true
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -1776,6 +1962,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -1801,6 +1991,11 @@ packages:
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -2506,6 +2701,10 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   protobufjs@7.6.2:
     resolution: {integrity: sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==}
     engines: {node: '>=12.0.0'}
@@ -2603,6 +2802,9 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -2667,6 +2869,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
@@ -2765,9 +2971,17 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
+  sumchecker@3.0.1:
+    resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
+    engines: {node: '>= 8.0'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
 
   table-layout@4.1.1:
     resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==}
@@ -2799,6 +3013,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   tree-sitter-c-sharp@0.23.1:
     resolution: {integrity: sha512-9zZ4FlcTRWWfRf6f4PgGhG8saPls6qOOt75tDfX7un9vQZJmARjPrAC6yBNCX2T/VKcCjIDbgq0evFaB3iGhQw==}
@@ -2941,6 +3159,10 @@ packages:
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  undici@7.27.2:
+    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+    engines: {node: '>=20.18.1'}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -3325,9 +3547,27 @@ snapshots:
 
   '@cfworker/json-schema@4.1.1': {}
 
+  '@electron-internal/extract-zip@1.0.3': {}
+
+  '@electron/get@5.0.0':
+    dependencies:
+      debug: 4.4.3
+      env-paths: 3.0.0
+      graceful-fs: 4.2.11
+      progress: 2.0.3
+      semver: 7.8.0
+      sumchecker: 3.0.1
+    optionalDependencies:
+      undici: 7.27.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@emnapi/runtime@1.11.0':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
@@ -3336,10 +3576,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.28.0':
     optional: true
 
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
     optional: true
 
   '@esbuild/android-arm@0.27.7':
@@ -3348,10 +3594,16 @@ snapshots:
   '@esbuild/android-arm@0.28.0':
     optional: true
 
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
   '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.7':
@@ -3360,10 +3612,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.28.0':
     optional: true
 
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.7':
@@ -3372,10 +3630,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.28.0':
     optional: true
 
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
     optional: true
 
   '@esbuild/linux-arm64@0.27.7':
@@ -3384,10 +3648,16 @@ snapshots:
   '@esbuild/linux-arm64@0.28.0':
     optional: true
 
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
     optional: true
 
   '@esbuild/linux-ia32@0.27.7':
@@ -3396,10 +3666,16 @@ snapshots:
   '@esbuild/linux-ia32@0.28.0':
     optional: true
 
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.7':
@@ -3408,10 +3684,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.28.0':
     optional: true
 
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.7':
@@ -3420,10 +3702,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.28.0':
     optional: true
 
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
     optional: true
 
   '@esbuild/linux-x64@0.27.7':
@@ -3432,10 +3720,16 @@ snapshots:
   '@esbuild/linux-x64@0.28.0':
     optional: true
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -3444,10 +3738,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.28.0':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -3456,10 +3756,16 @@ snapshots:
   '@esbuild/openbsd-x64@0.28.0':
     optional: true
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.27.7':
@@ -3468,16 +3774,25 @@ snapshots:
   '@esbuild/sunos-x64@0.28.0':
     optional: true
 
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.28.0':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -4234,6 +4549,15 @@ snapshots:
 
   commander@14.0.3: {}
 
+  concurrently@9.2.1:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
@@ -4303,6 +4627,14 @@ snapshots:
 
   electron-to-chromium@1.5.372: {}
 
+  electron@42.4.0:
+    dependencies:
+      '@electron-internal/extract-zip': 1.0.3
+      '@electron/get': 5.0.0
+      '@types/node': 24.13.1
+    transitivePeerDependencies:
+      - supports-color
+
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
@@ -4314,6 +4646,8 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  env-paths@3.0.0: {}
 
   environment@1.1.0: {}
 
@@ -4330,6 +4664,35 @@ snapshots:
   es-toolkit@1.46.1: {}
 
   es6-error@4.1.1: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -5089,6 +5452,8 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  progress@2.0.3: {}
+
   protobufjs@7.6.2:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -5239,6 +5604,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safe-buffer@5.1.2: {}
 
   safe-stable-stringify@2.5.0: {}
@@ -5332,6 +5701,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.3: {}
 
   side-channel-list@1.0.1:
     dependencies:
@@ -5433,7 +5804,17 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
+  sumchecker@3.0.1:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
 
@@ -5466,6 +5847,8 @@ snapshots:
   tinyrainbow@3.1.0: {}
 
   toidentifier@1.0.1: {}
+
+  tree-kill@1.2.2: {}
 
   tree-sitter-c-sharp@0.23.1(tree-sitter@0.21.1):
     dependencies:
@@ -5591,6 +5974,9 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici-types@7.24.6: {}
+
+  undici@7.27.2:
+    optional: true
 
   universalify@2.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       concurrently:
         specifier: ^9.2.0
         version: 9.2.1
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       electron:
         specifier: ^42.4.0
         version: 42.4.0
@@ -1882,6 +1885,11 @@ packages:
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
+
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -4578,6 +4586,10 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:


### PR DESCRIPTION
Closes #335. Slice 5 of the desktop app (follows #325 foundation, #327 renderer, #330 runtime-bridge core, #334 IPC seam). First slice that pulls in `electron` and makes the app **launch as a desktop window wired to the real Node runtime spine**.

## What

Pure **assembly** (keel grade: wiring) — composes the already-built, unit-tested pieces; owns no logic of its own:

```
runFrontAgentTask (Node runtime spine)
  → createRuntimeBridge   (runtime → IPC envelopes, #330)
    → registerIpcHandlers (invoke channels → bridge + settings, #334)
      → createPreloadBridge on the renderer (exposed by preload.ts, #334)
```

- **`src/main/main.ts`** — `app`/`BrowserWindow` lifecycle (`contextIsolation: true`, `nodeIntegration: false`, `sandbox: false` for the `.mjs` preload). Builds `createRuntimeBridge({ run: <runFrontAgentTask adapter merging persisted provider/model/baseUrl>, send: webContents.send })` and registers handlers via `registerIpcHandlers` over `ipcMain.handle`, backing `settingsStore` with a JSON file under `app.getPath('userData')`. Loads the Vite dev URL in dev (with retry), built `index.html` in production.
- **`src/preload/preload.ts`** — thin: `contextBridge.exposeInMainWorld('frontagent', createPreloadBridge(ipcRendererSlice))`. No logic — the glue the seam was designed for.
- **`src/main/runtimeIO.ts`** — file-backed `SettingsIO`, kept out of `main.ts` so it stays unit-testable; **3 tests** against a real temp dir.
- **Build** — `electron` + `esbuild` + `concurrently` devDeps; `electron.build.mjs` emits `dist/electron/{main,preload}.mjs` (ESM, deps external — raw `tsc` fights `type:module` + workspace `exports` + preload module-format rules); scripts `build` / `build:electron` / `dev:app` / `start`; `main` → `dist/electron/main.mjs`.
- **Renderer swap** — `main.tsx` uses `window.frontagent` when present, else the mock bridge (so plain `vite dev` review still works); typed `window.frontagent`.

## Why esbuild (build decision)

`tsc` can't cleanly emit what Electron 42 wants here: this package is `"type": "module"`, the runtime spine is resolved through workspace `exports`, and Electron's preload loads ESM only from `.mjs`. esbuild emits `.mjs` directly, bundles only our own `src`, and keeps every node_modules package external (`packages: 'external'`) so the heavy runtime tree is resolved by Node at launch, not inlined. Verified: `main.mjs` keeps `electron`, `@frontagent/runtime-node`, and `node:*` as imports.

## Non-goals (follow-up slices)

- **Packaging/distribution** (electron-builder, signed installers) — release engineering, deferred.
- **SettingsPanel IPC-failure degraded UI** — the failure semantic already exists (#334 `SaveSettings` rejects); the renderer degraded state + tests land in the final slice.

## GitNexus impact summary

- `detect_changes` (staged): **risk_level low**, 0 changed symbols, 0 affected processes — assembly + the renderer-entry swap; nothing else imports these, so no upstream blast radius.
- No existing symbol edited apart from the `main.tsx` mock→bridge swap (renderer entry, no external callers).

## Verification

- `pnpm --filter @frontagent/desktop typecheck` clean; `test` → **79 passed** (76 prior + 3 new `runtimeIO`); `biome check` clean.
- `pnpm --filter @frontagent/desktop build:electron` emits `dist/electron/{main,preload}.mjs`; `vite build` still produces `dist/renderer`.
- Launching a real Electron window + end-to-end agent run is manual (not part of CI; needs a display + provider API key in env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)