### PR TITLE
feat(desktop): SettingsPanel IPC-failure degraded states (load/save error + retry)

### DIFF
--- a/apps/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/SettingsPanel.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
 import type { DesktopSettings, FrontAgentBridge } from '../../ipc/contract.js';
+import { useSettings } from '../store/useSettings.js';
 
 const FIELDS: { key: keyof DesktopSettings; label: string; placeholder: string }[] = [
   { key: 'provider', label: 'Provider', placeholder: 'anthropic' },
@@ -9,31 +9,33 @@ const FIELDS: { key: keyof DesktopSettings; label: string; placeholder: string }
 ];
 
 export function SettingsPanel({ bridge }: { bridge: FrontAgentBridge }) {
-  const [settings, setSettings] = useState<DesktopSettings | null>(null);
-  const [saved, setSaved] = useState(false);
+  const { state, update, save, retryLoad } = useSettings(bridge);
 
-  useEffect(() => {
-    bridge.getSettings().then(setSettings);
-  }, [bridge]);
+  if (state.status === 'loading') return <div className="settings">加载中…</div>;
 
-  if (!settings) return <div className="settings">加载中…</div>;
+  if (state.status === 'load-error' || !state.settings) {
+    return (
+      <div className="settings">
+        <h2>设置</h2>
+        <div className="settings-error" role="alert">
+          无法加载设置：{state.error ?? '未知错误'}
+        </div>
+        <button type="button" className="btn btn-primary" onClick={retryLoad}>
+          重试
+        </button>
+      </div>
+    );
+  }
 
-  const update = (key: keyof DesktopSettings, value: string) => {
-    setSettings({ ...settings, [key]: value });
-    setSaved(false);
-  };
-
-  const save = async () => {
-    await bridge.saveSettings(settings);
-    setSaved(true);
-  };
+  const { settings, status, saved, error } = state;
+  const saving = status === 'saving';
 
   return (
     <div className="settings">
       <h2>设置</h2>
       <p className="hint">
-        设置仅在本会话内保存（刷新后不保留）；本机安全存储与持久化在 PR3 接入。Base URL 留空使用
-        provider 默认。
+        设置持久化到本机用户目录（app.getPath('userData')/settings.json）。Base URL 留空使用
+        provider 默认；API Key 从环境变量读取。
       </p>
       {FIELDS.map((field) => (
         <div className="setting-group" key={field.key}>
@@ -42,12 +44,18 @@ export function SettingsPanel({ bridge }: { bridge: FrontAgentBridge }) {
             id={field.key}
             value={settings[field.key] ?? ''}
             placeholder={field.placeholder}
+            disabled={saving}
             onChange={(e) => update(field.key, e.target.value)}
           />
         </div>
       ))}
-      <button type="button" className="btn btn-primary" onClick={save}>
-        保存设置
+      {status === 'save-error' ? (
+        <div className="settings-error" role="alert">
+          保存失败：{error ?? '未知错误'}
+        </div>
+      ) : null}
+      <button type="button" className="btn btn-primary" onClick={save} disabled={saving}>
+        {saving ? '保存中…' : status === 'save-error' ? '重试保存' : '保存设置'}
         {saved ? <span className="settings-saved">✓ 已保存</span> : null}
       </button>
     </div>

--- a/apps/desktop/src/renderer/store/settingsController.test.ts
+++ b/apps/desktop/src/renderer/store/settingsController.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { DesktopSettings, FrontAgentBridge } from '../../ipc/contract.js';
+import { createSettingsController } from './settingsController.js';
+
+const stored: DesktopSettings = { provider: 'openai', model: 'gpt-x', baseUrl: '' };
+
+/** Minimal bridge with overridable getSettings/saveSettings; rest unused here. */
+function fakeBridge(over: Partial<FrontAgentBridge> = {}): FrontAgentBridge {
+  return {
+    runTask: vi.fn(),
+    cancelTask: vi.fn(),
+    respondApproval: vi.fn(),
+    getSettings: vi.fn(async () => stored),
+    saveSettings: vi.fn(async () => {}),
+    onAgentEvent: vi.fn(() => () => {}),
+    onApprovalRequested: vi.fn(() => () => {}),
+    ...over,
+  } as FrontAgentBridge;
+}
+
+describe('settingsController', () => {
+  it('loads settings into the ready state', async () => {
+    const c = createSettingsController(fakeBridge());
+    expect(c.getState().status).toBe('loading');
+    await c.load();
+    expect(c.getState()).toMatchObject({ status: 'ready', settings: stored, error: null });
+  });
+
+  it('surfaces a retryable load-error when getSettings rejects', async () => {
+    let calls = 0;
+    const bridge = fakeBridge({
+      getSettings: vi.fn(async () => {
+        calls += 1;
+        if (calls === 1) throw new Error('IPC down');
+        return stored;
+      }),
+    });
+    const c = createSettingsController(bridge);
+    await c.load();
+    expect(c.getState()).toMatchObject({ status: 'load-error', settings: null, error: 'IPC down' });
+
+    await c.load(); // retry succeeds
+    expect(c.getState()).toMatchObject({ status: 'ready', settings: stored });
+  });
+
+  it('clears the saved flag on edit', async () => {
+    const c = createSettingsController(fakeBridge());
+    await c.load();
+    await c.save();
+    expect(c.getState().saved).toBe(true);
+    c.update('model', 'gpt-y');
+    expect(c.getState()).toMatchObject({ status: 'ready', saved: false });
+    expect(c.getState().settings?.model).toBe('gpt-y');
+  });
+
+  it('marks saved on a successful save', async () => {
+    const save = vi.fn(async () => {});
+    const c = createSettingsController(fakeBridge({ saveSettings: save }));
+    await c.load();
+    await c.save();
+    expect(save).toHaveBeenCalledWith(stored);
+    expect(c.getState()).toMatchObject({ status: 'ready', saved: true });
+  });
+
+  it('surfaces a retryable save-error when saveSettings rejects, preserving edits', async () => {
+    let calls = 0;
+    const bridge = fakeBridge({
+      saveSettings: vi.fn(async () => {
+        calls += 1;
+        if (calls === 1) throw new Error('disk full');
+      }),
+    });
+    const c = createSettingsController(bridge);
+    await c.load();
+    c.update('model', 'gpt-y');
+    await c.save();
+    expect(c.getState()).toMatchObject({ status: 'save-error', saved: false, error: 'disk full' });
+    expect(c.getState().settings?.model).toBe('gpt-y'); // edits preserved for retry
+
+    await c.save(); // retry succeeds
+    expect(c.getState()).toMatchObject({ status: 'ready', saved: true });
+  });
+
+  it('notifies subscribers on state changes', async () => {
+    const c = createSettingsController(fakeBridge());
+    const listener = vi.fn();
+    const off = c.subscribe(listener);
+    await c.load();
+    expect(listener).toHaveBeenCalled();
+    off();
+    const before = listener.mock.calls.length;
+    c.update('provider', 'anthropic');
+    expect(listener.mock.calls.length).toBe(before); // no longer notified
+  });
+});

--- a/apps/desktop/src/renderer/store/settingsController.ts
+++ b/apps/desktop/src/renderer/store/settingsController.ts
@@ -1,0 +1,98 @@
+/**
+ * Framework-free settings store. Wraps the bridge's `getSettings`/`saveSettings`
+ * with an explicit status so the SettingsPanel degrades instead of breaking when
+ * the (now real, failable — see #333) IPC rejects: a failed load surfaces a
+ * retryable `load-error`, a failed save a retryable `save-error`, rather than a
+ * stuck "加载中…" or a silently swallowed rejection.
+ *
+ * Kept out of React (like `consoleStore`) so the transitions are unit-tested
+ * against a fake bridge with no DOM; the React layer consumes it via
+ * `useSyncExternalStore`.
+ */
+import type { DesktopSettings, FrontAgentBridge } from '../../ipc/contract.js';
+
+export type SettingsStatus = 'loading' | 'ready' | 'load-error' | 'saving' | 'save-error';
+
+export interface SettingsState {
+  status: SettingsStatus;
+  /** Present once loaded; preserved across save/save-error so a retry keeps edits. */
+  settings: DesktopSettings | null;
+  /** True after a successful save until the next edit. */
+  saved: boolean;
+  /** Message for `load-error` / `save-error`; null otherwise. */
+  error: string | null;
+}
+
+export const initialSettingsState: SettingsState = {
+  status: 'loading',
+  settings: null,
+  saved: false,
+  error: null,
+};
+
+export interface SettingsController {
+  getState(): SettingsState;
+  subscribe(listener: () => void): () => void;
+  /** Load (or retry loading) settings from the bridge. */
+  load(): Promise<void>;
+  /** Edit a field; clears any prior saved/error flag. */
+  update(key: keyof DesktopSettings, value: string): void;
+  /** Persist the current settings; surfaces a retryable `save-error` on failure. */
+  save(): Promise<void>;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function createSettingsController(bridge: FrontAgentBridge): SettingsController {
+  let state = initialSettingsState;
+  const listeners = new Set<() => void>();
+
+  const set = (next: SettingsState) => {
+    if (next === state) return;
+    state = next;
+    for (const listener of listeners) listener();
+  };
+
+  return {
+    getState: () => state,
+
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+
+    async load() {
+      set({ status: 'loading', settings: state.settings, saved: false, error: null });
+      try {
+        const settings = await bridge.getSettings();
+        set({ status: 'ready', settings, saved: false, error: null });
+      } catch (error) {
+        set({ status: 'load-error', settings: null, saved: false, error: errorMessage(error) });
+      }
+    },
+
+    update(key, value) {
+      if (!state.settings) return;
+      set({
+        status: 'ready',
+        settings: { ...state.settings, [key]: value },
+        saved: false,
+        error: null,
+      });
+    },
+
+    async save() {
+      if (!state.settings) return;
+      const settings = state.settings;
+      set({ status: 'saving', settings, saved: false, error: null });
+      try {
+        await bridge.saveSettings(settings);
+        set({ status: 'ready', settings, saved: true, error: null });
+      } catch (error) {
+        set({ status: 'save-error', settings, saved: false, error: errorMessage(error) });
+      }
+    },
+  };
+}

--- a/apps/desktop/src/renderer/store/useSettings.ts
+++ b/apps/desktop/src/renderer/store/useSettings.ts
@@ -1,0 +1,24 @@
+import { useEffect, useMemo, useSyncExternalStore } from 'react';
+import type { DesktopSettings, FrontAgentBridge } from '../../ipc/contract.js';
+import { createSettingsController, type SettingsState } from './settingsController.js';
+
+/** React binding over {@link createSettingsController}; loads on mount. */
+export function useSettings(bridge: FrontAgentBridge): {
+  state: SettingsState;
+  update: (key: keyof DesktopSettings, value: string) => void;
+  save: () => Promise<void>;
+  retryLoad: () => Promise<void>;
+} {
+  const controller = useMemo(() => createSettingsController(bridge), [bridge]);
+  useEffect(() => {
+    controller.load();
+  }, [controller]);
+
+  const state = useSyncExternalStore(
+    controller.subscribe,
+    controller.getState,
+    controller.getState,
+  );
+
+  return { state, update: controller.update, save: controller.save, retryLoad: controller.load };
+}

--- a/apps/desktop/src/renderer/theme.css
+++ b/apps/desktop/src/renderer/theme.css
@@ -740,6 +740,22 @@ body::before {
   color: var(--teal);
   margin-left: 12px;
 }
+.settings-error {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--coral);
+  background: var(--coral-glow);
+  border: 1px solid var(--coral);
+  border-radius: var(--radius);
+  padding: 11px 13px;
+  margin-bottom: 20px;
+}
+.settings input:disabled,
+.settings .btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
 
 /* scrollbars */
 ::-webkit-scrollbar {


### PR DESCRIPTION
Closes #337. Final slice of the desktop app (follows #325 foundation, #327 renderer, #330 runtime-bridge core, #333 IPC seam, #335 Electron bootstrap).

## What

Now that the renderer talks to a **real, failable** IPC bridge (#335), the SettingsPanel degrades gracefully instead of breaking. Implemented with the repo's framework-free-store pattern (like `consoleStore`) — no new DOM/component test infra.

- **`store/settingsController.ts`** — framework-free, subscribable store with an explicit status: `loading | ready | load-error | saving | save-error`.
  - `load()` catches a rejected `getSettings` → retryable **load-error** (instead of the panel being stuck on "加载中…" forever).
  - `save()` catches the rejection #333 made `saveSettings` throw on write failure → retryable **save-error**, preserving edits (instead of an unhandled throw with no UI feedback).
  - `update()` clears the saved flag.
- **`store/useSettings.ts`** — `useSyncExternalStore` binding; loads on mount.
- **`components/SettingsPanel.tsx`** — thin shell rendering the load-error (Retry button), saving (disabled inputs/button), and save-error (message + Retry) states; refreshes the stale hint copy (persistence is real as of #335, was "PR3 接入").
- **`store/settingsController.test.ts`** — 6 tests: load success/failure→retry, edit clears saved, save success, save failure→retry succeeds (edits preserved), subscriber notify/unsubscribe.
- **`theme.css`** — `.settings-error` + disabled input/button styling (reuses the existing `--coral` error palette).

## Non-goals

- No new component-render test infra (jsdom / testing-library); logic is tested at the framework-free store layer, consistent with the rest of the app.
- No change to the IPC contract or main-process handlers (the reject-on-failure semantic already exists in #333).

## GitNexus impact summary

- `detect_changes` (staged): **risk_level low**, 0 changed symbols, 0 affected processes — `SettingsPanel` is a leaf component (no indexed callers), the store files are net-new.

## Verification

- `pnpm --filter @frontagent/desktop typecheck` clean; `test` → **92 passed** (86 prior + 6 new); `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)