### PR TITLE
build(desktop): publish multi-platform zip archives to GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release Desktop
+
+# Builds the desktop client into downloadable, unsigned zip archives for each OS
+# and attaches them to the GitHub Release on version tags (Issue #341).
+#
+# Triggers:
+#   - push tag `v*`     → build all 3 OS zips AND attach them to the tag's Release
+#   - pull_request      → build all 3 OS zips as workflow artifacts (no publish),
+#                         so the release path is verified on the PR that changes it
+#   - workflow_dispatch → manual build (artifacts only), for ad-hoc verification
+on:
+  push:
+    tags: ['v*']
+  pull_request:
+    branches: [develop]
+    paths:
+      - 'apps/desktop/**'
+      - '.github/workflows/release.yml'
+      - 'pnpm-lock.yaml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # electron-builder produces the per-platform zip (see electron-builder.yml
+      # target: zip). --publish never: assets are attached below, not by builder.
+      - name: Build desktop zip
+        run: pnpm --filter @frontagent/desktop run release
+
+      - name: Upload zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-${{ matrix.os }}
+          path: apps/desktop/release/*.zip
+          if-no-files-found: error
+
+      # Only real version tags publish to the GitHub Release.
+      - name: Attach zip to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: apps/desktop/release/*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,8 @@ name: Release Desktop
 # and attaches them to the GitHub Release on version tags (Issue #341).
 #
 # Triggers:
-#   - push tag `v*`     → build all 3 OS zips AND attach them to the tag's Release
+#   - push tag `v*`     → build all 3 OS zips, then a single publish job attaches
+#                         them to the tag's GitHub Release
 #   - pull_request      → build all 3 OS zips as workflow artifacts (no publish),
 #                         so the release path is verified on the PR that changes it
 #   - workflow_dispatch → manual build (artifacts only), for ad-hoc verification
@@ -18,6 +19,10 @@ on:
       - '.github/workflows/release.yml'
       - 'pnpm-lock.yaml'
   workflow_dispatch:
+
+# Least privilege by default; only the publish job widens to write Releases.
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -38,8 +43,14 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # electron-builder produces the per-platform zip (see electron-builder.yml
-      # target: zip). --publish never: assets are attached below, not by builder.
+      # Build the desktop package AND its workspace deps (core/shared/runtime-node)
+      # via turbo's dependency graph, so the desktop tsc build resolves their
+      # types — a desktop-only build can't, since the spine isn't prebuilt on CI.
+      - name: Build desktop and workspace deps
+        run: pnpm exec turbo build --filter=@frontagent/desktop
+
+      # electron-builder produces the per-platform zip (electron-builder.yml
+      # target: zip). --publish never: assets are attached by the publish job.
       - name: Build desktop zip
         run: pnpm --filter @frontagent/desktop run release
 
@@ -50,9 +61,22 @@ jobs:
           path: apps/desktop/release/*.zip
           if-no-files-found: error
 
-      # Only real version tags publish to the GitHub Release.
-      - name: Attach zip to GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
+  publish:
+    # A single job attaches every platform's zip to the Release, so the three
+    # matrix builds never race to create/update the same Release. Tags only.
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all platform zips
+        uses: actions/download-artifact@v4
+        with:
+          path: dist-zips
+          merge-multiple: true
+
+      - name: Attach zips to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: apps/desktop/release/*.zip
+          files: dist-zips/*.zip

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -17,6 +17,8 @@ productName: FrontAgent
 executableName: frontagent
 directories:
   output: release
+# Downloadable archive naming for GitHub Release assets (Issue #341).
+artifactName: frontagent-desktop-${version}-${os}-${arch}.${ext}
 # Built by `pnpm --filter @frontagent/desktop build` before packaging:
 #   dist/renderer      → vite renderer bundle (index.html + assets, base './')
 #   dist/electron      → esbuilt main.mjs (ESM) + preload.cjs (CJS)
@@ -34,9 +36,12 @@ npmRebuild: false
 # `node --check`, and an unpacked tree is trivially inspectable. asar packing is
 # part of the deferred maintainer-led release hardening (with installers/signing).
 asar: false
+# Each platform ships an unsigned downloadable zip (Issue #341). Installers
+# (AppImage / dmg / nsis) and signing/notarization are the deferred maintainer-led
+# release-hardening follow-up; zip needs no secrets and builds on all 3 runners.
 linux:
-  target: AppImage
+  target: zip
 mac:
-  target: dmg
+  target: zip
 win:
-  target: nsis
+  target: zip

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,6 +12,7 @@
     "build": "tsc --noEmit && vite build && node electron.build.mjs",
     "build:electron": "node electron.build.mjs",
     "package": "pnpm run clean && pnpm run build && electron-builder --dir",
+    "release": "pnpm run build && electron-builder --publish never",
     "start": "electron .",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",

--- a/scripts/tests/workflow-rules.test.mjs
+++ b/scripts/tests/workflow-rules.test.mjs
@@ -408,11 +408,16 @@ test('desktop release workflow publishes per-platform zips on version tags', () 
   assert.match(release, /tags:\s*\['v\*'\]/u);
   assert.match(release, /pull_request:/u);
   assert.match(release, /workflow_dispatch:/u);
-  // Build the zip on all three desktop OSes.
+  // Build the zip on all three desktop OSes, building the workspace spine first.
   assert.match(release, /os:\s*\[ubuntu-latest,\s*macos-latest,\s*windows-latest\]/u);
+  assert.match(release, /pnpm exec turbo build --filter=@frontagent\/desktop/u);
   assert.match(release, /pnpm --filter @frontagent\/desktop run release/u);
   assert.match(release, /actions\/upload-artifact/u);
-  // Attach to the GitHub Release only on real version tags.
+  // A single publish job (needs: build) attaches all zips on tags, with explicit
+  // write permission — the matrix builds never race to write the same Release.
+  assert.match(release, /permissions:\s*\n\s*contents:\s*write/u);
+  assert.match(release, /needs:\s*build/u);
+  assert.match(release, /actions\/download-artifact/u);
   assert.match(release, /softprops\/action-gh-release/u);
   assert.match(release, /if:\s*startsWith\(github\.ref,\s*'refs\/tags\/'\)/u);
 

--- a/scripts/tests/workflow-rules.test.mjs
+++ b/scripts/tests/workflow-rules.test.mjs
@@ -399,6 +399,34 @@ test('desktop app has an unsigned electron-builder packaging path', () => {
   assert.match(config, /dist\/\*\*/u);
 });
 
+test('desktop release workflow publishes per-platform zips on version tags', () => {
+  const release = readFileSync('.github/workflows/release.yml', 'utf8');
+  const pkg = JSON.parse(readFileSync('apps/desktop/package.json', 'utf8'));
+  const config = readFileSync('apps/desktop/electron-builder.yml', 'utf8');
+
+  // Triggers: version tags publish; pull_request/dispatch build artifacts only.
+  assert.match(release, /tags:\s*\['v\*'\]/u);
+  assert.match(release, /pull_request:/u);
+  assert.match(release, /workflow_dispatch:/u);
+  // Build the zip on all three desktop OSes.
+  assert.match(release, /os:\s*\[ubuntu-latest,\s*macos-latest,\s*windows-latest\]/u);
+  assert.match(release, /pnpm --filter @frontagent\/desktop run release/u);
+  assert.match(release, /actions\/upload-artifact/u);
+  // Attach to the GitHub Release only on real version tags.
+  assert.match(release, /softprops\/action-gh-release/u);
+  assert.match(release, /if:\s*startsWith\(github\.ref,\s*'refs\/tags\/'\)/u);
+
+  // The release build emits unsigned per-platform zips with stable asset names.
+  assert.equal(pkg.scripts.release, 'pnpm run build && electron-builder --publish never');
+  assert.match(
+    config,
+    /artifactName:\s*frontagent-desktop-\$\{version\}-\$\{os\}-\$\{arch\}\.\$\{ext\}/u,
+  );
+  assert.match(config, /linux:\s*\n\s*target:\s*zip/u);
+  assert.match(config, /mac:\s*\n\s*target:\s*zip/u);
+  assert.match(config, /win:\s*\n\s*target:\s*zip/u);
+});
+
 test('PR template contains enforced GitNexus summary fields', () => {
   const template = readFileSync('.github/PULL_REQUEST_TEMPLATE.md', 'utf8');
 


### PR DESCRIPTION
## Summary

Closes #341. The desktop client had a build/package path (#340) but no way for users to **download** it. This adds an automated release pipeline producing unsigned, per-platform zip archives attached to the GitHub Release.

### Changes
- `.github/workflows/release.yml` — matrix build (ubuntu/macos/windows):
  - **push `v*` tag** → build all 3 zips **and** attach them to the tag's GitHub Release (`softprops/action-gh-release`, guarded by `startsWith(github.ref, 'refs/tags/')`).
  - **pull_request** (paths-filtered to `apps/desktop/**` / this workflow / lockfile) and **workflow_dispatch** → build the same zips as workflow artifacts, no publish — so the release path is exercised on the PR that changes it.
- `apps/desktop/electron-builder.yml` — per-platform `target: zip`; `artifactName: frontagent-desktop-${version}-${os}-${arch}.${ext}` (repo-guard's naming suggestion).
- `apps/desktop/package.json` — `release` script (`build && electron-builder --publish never`); no `clean` (CI runners are fresh; avoids a Windows `rm -rf` landmine — `package`'s ubuntu-only clean is unchanged).
- `scripts/tests/workflow-rules.test.mjs` — contract test for the release workflow + zip config (repo-harness gate).

### Scope boundary (deferred maintainer-led release hardening)
Code signing / notarization (need cert secrets) and installer formats (dmg/nsis/AppImage). zip needs no secrets and builds on all three runners, so it's the right first distributable.

## Verification
- `pnpm --filter @frontagent/desktop typecheck` clean; `test` 96/96; `pnpm lint` clean (1 pre-existing unrelated info); `node --test scripts/tests/workflow-rules.test.mjs` 31/31.
- The release workflow's matrix runs on **this PR** (pull_request trigger) — the authoritative verification that all 3 OS produce a zip. Local packaging can't run in the sandbox (no electron binary), as with #340.

## GitNexus Impact Summary
- Risk level: LOW
- Critical skeleton changes: None — CI/release wiring + packaging config only (release.yml, electron-builder.yml zip targets, release script, contract test). No source symbols.
- GitNexus impact: `detect_changes` reported 0 changed symbols / 0 affected processes (risk low); `context` on the repo-harness contract rule confirms `scripts/tests/workflow-rules.test.mjs` gates `.github/workflows/` changes, updated here for `release.yml`.
- Verification: `pnpm lint && pnpm typecheck && pnpm test && pnpm test:workflows` pass; the release matrix builds zips on all 3 OS via this PR's pull_request trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
