### PR TITLE
feat(desktop): UI polish — real version, focus-visible, reduced-motion

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -43,11 +43,9 @@ export function App({ bridge }: { bridge: FrontAgentBridge }) {
           </button>
         </nav>
         <div className="rail-foot">
-          v2.1.1 · electron
+          v{__APP_VERSION__} · electron
           <br />
           spine · runtime-node
-          <br />
-          mock bridge · PR2
         </div>
       </aside>
 

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -5,4 +5,6 @@ declare global {
     /** Exposed by the Electron preload (`preload.ts`); absent under plain `vite dev`. */
     frontagent?: FrontAgentBridge;
   }
+  /** Package version injected at build time by Vite `define` (see vite.config.ts). */
+  const __APP_VERSION__: string;
 }

--- a/apps/desktop/src/renderer/theme.css
+++ b/apps/desktop/src/renderer/theme.css
@@ -783,10 +783,12 @@ button:focus-visible {
   outline-offset: 2px;
 }
 
-/* These inputs reset the default outline on :focus with no replacement; restore
-   a visible ring for keyboard focus (equal specificity, declared later wins). */
-.field input:focus-visible,
-.setting-group input:focus-visible {
+/* Field controls reset the default outline on :focus with no replacement; restore
+   a visible ring for keyboard focus (equal specificity, declared later wins).
+   :is(input, textarea, select) so any control inside a field is covered, not just
+   today's text inputs. (The main composer textarea keeps its amber border/glow.) */
+.field :is(input, textarea, select):focus-visible,
+.setting-group :is(input, textarea, select):focus-visible {
   outline: 2px solid var(--amber);
   outline-offset: 1px;
 }

--- a/apps/desktop/src/renderer/theme.css
+++ b/apps/desktop/src/renderer/theme.css
@@ -769,3 +769,41 @@ body::before {
 ::-webkit-scrollbar-track {
   background: transparent;
 }
+
+/* ---------------------------------------------------------------------------
+   Accessibility — keyboard focus visibility + reduced motion
+   ------------------------------------------------------------------------ */
+
+/* A clear amber ring for keyboard users on interactive controls that otherwise
+   have no visible focus state. :focus-visible keeps pointer clicks quiet. */
+.nav-item:focus-visible,
+.btn:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 2px;
+}
+
+/* These inputs reset the default outline on :focus with no replacement; restore
+   a visible ring for keyboard focus (equal specificity, declared later wins). */
+.field input:focus-visible,
+.setting-group input:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 1px;
+}
+
+/* Honor users who prefer reduced motion: drop looping/entrance animations
+   (pulse, rise, spin, fade) and collapse transitions to near-instant. The
+   universal reset must win over the specific per-element animation rules, so
+   !important is required here (canonical reduced-motion pattern). */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    /* biome-ignore lint/complexity/noImportantStyles: reduced-motion reset must override specific animation rules */
+    animation-duration: 0.001ms !important;
+    /* biome-ignore lint/complexity/noImportantStyles: stop infinite loops (pulse/spin) for reduced-motion users */
+    animation-iteration-count: 1 !important;
+    /* biome-ignore lint/complexity/noImportantStyles: reduced-motion reset must override specific transition rules */
+    transition-duration: 0.001ms !important;
+  }
+}

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,13 +1,21 @@
+import { readFileSync } from 'node:fs';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
-// Renderer-only build for the desktop app. The Electron main/preload bundle
-// is wired in a later PR; for now the renderer runs in a browser against the
-// mock bridge so the UI is reviewable on its own.
+// Renderer build for the desktop app. In the packaged app the renderer is loaded
+// from disk by the Electron main process; under plain `vite dev` it runs in a
+// browser against the mock bridge so the UI is reviewable on its own.
+const { version } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
+
 export default defineConfig({
   root: __dirname,
   base: './',
   plugins: [react()],
+  // Surface the real package version to the renderer (App.tsx footer) instead of
+  // a hardcoded string that drifts.
+  define: {
+    __APP_VERSION__: JSON.stringify(version),
+  },
   build: {
     outDir: 'dist/renderer',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary

Closes #342. A focused UI-polish pass on the desktop renderer (not a redesign).

### Changes
- **Stale dev text** — `App.tsx` footer dropped the dev-era breadcrumb `mock bridge · PR2` (the app uses the real bridge now) and the hardcoded `v2.1.1`. The real package version is injected at build time via Vite `define` (`__APP_VERSION__`, sourced from `apps/desktop/package.json`), declared in `global.d.ts`.
- **Keyboard focus (a11y)** — `theme.css` adds `:focus-visible` amber rings to `.nav-item` / `.btn` / `button` (which had no focus state) and to `.field` / `.setting-group` inputs (which reset the default outline with no replacement). Verified specificity so the input rules win over the existing `:focus { outline: none }`.
- **Reduced motion (a11y)** — a `prefers-reduced-motion: reduce` block neutralizes the looping/entrance animations (pulse/spin/rise/fade). `!important` is required (canonical pattern) and carries `biome-ignore` rationale.

Empty states already exist (`ExecutionTimeline` "等待任务编排", `EventStream` "空 · 暂无事件"), so they were left as-is — that part of the issue was already satisfied.

## Verification
- `pnpm --filter @frontagent/desktop typecheck` clean; `test` 96/96; `pnpm lint` clean (1 pre-existing unrelated info, 0 new warnings); `build` confirms the version string is baked into the renderer bundle.
- Renderer/CSS only, no source symbols (GitNexus `detect_changes`: 0 changed symbols / 0 affected processes, risk low). Guarded by typecheck + the existing store tests, per the repo's deliberate no-DOM-test architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
