### PR TITLE
docs: document the desktop client (three usage paths + download/build)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,24 @@ The repository is currently aligned on `frontagent@2.1.1` for both the npm CLI p
 - Quality gates: `pnpm quality:predev`, `pnpm quality:precommit`, `pnpm quality:ci`, and `pnpm quality:local` combine contract checks, linting, typechecking, tests, workflow tests, and build verification.
 - v2.1.1 focus: smaller agent/executor/context/Filesense/memory/runtime/webview modules, hardened VS Code webview nonce generation, restored GitNexus contract checks, and expanded focused tests.
 
-## Two Ways to Use FrontAgent
+## Three Ways to Use FrontAgent
 
-FrontAgent now supports both terminal-first and VS Code desktop workflows:
+FrontAgent supports terminal, VS Code, and standalone desktop workflows:
 
 - **CLI**: use `fa init`, `fa run`, RAG commands, Skill Lab, and automation-friendly workflows directly from your terminal.
 - **VS Code Extension**: use the FrontAgent sidebar task console to run tasks, attach the current file or selection, provide a browser URL, review phase/step progress, approve sensitive actions, initialize/validate SDD, and open run logs from inside VS Code.
+- **Desktop App**: a standalone Electron GUI (`apps/desktop`) that reuses the same Node runtime spine — a Task Console for launching tasks, watching live phase/step telemetry, and approving sensitive actions, plus a Settings panel for the LLM provider/model.
 
 Install the VS Code extension from the Marketplace by searching for `FrontAgent` or the extension id `ceilf6.frontagent`.
+
+### Desktop App
+
+The desktop client is a sandboxed Electron window wired to the real runtime (`window.frontagent` → IPC → `runFrontAgentTask`); it persists settings under your OS user-data directory and degrades gracefully if the runtime is unavailable.
+
+- **Download**: grab the unsigned per-platform archive `frontagent-desktop-${version}-${os}-${arch}.zip` from the [GitHub Releases](https://github.com/FrontAgent/FrontAgent/releases) page (published automatically for each `v*` tag), unzip, and launch the `frontagent` executable. The LLM API key is read from the environment (`PROVIDER_API_KEY` / `API_KEY`); set provider/model/base URL in the in-app Settings panel.
+- **Build locally**: `pnpm --filter @frontagent/desktop package` produces an unpacked app under `apps/desktop/release/`, and `pnpm --filter @frontagent/desktop dev` runs it against the Vite dev server. The `release` script (`pnpm --filter @frontagent/desktop run release`) produces the distributable zip.
+
+> Desktop archives are currently unsigned; code signing, notarization, and native installers (dmg/nsis/AppImage) are planned follow-ups.
 
 ## CLI Quick Start
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,0 +1,51 @@
+# @frontagent/desktop
+
+Standalone Electron desktop client for FrontAgent. It reuses the same Node
+runtime spine as the CLI (`runFrontAgentTask`) behind a sandboxed React UI:
+a Task Console (launch tasks, live phase/step telemetry, approvals) and a
+Settings panel (LLM provider/model/base URL).
+
+See the root [README](../../README.md#desktop-app) for the user-facing download
+and usage overview.
+
+## Architecture
+
+```
+renderer (React, sandboxed)
+  window.frontagent              ← exposed by the preload via contextBridge
+    → IPC (typed channels)       ← src/ipc/contract.ts
+      → main process bridge      ← src/main/runtimeBridge.ts + ipcHandlers.ts
+        → runFrontAgentTask      ← @frontagent/runtime-node
+```
+
+- `sandbox: true`, `contextIsolation: true`, `nodeIntegration: false`. The
+  renderer reaches the main process only through the typed `window.frontagent`
+  bridge.
+- Build is esbuild (`electron.build.mjs`): ESM main (`main.mjs`) + CommonJS
+  preload (`preload.cjs`), with node_modules kept external. The renderer is a
+  Vite build (`dist/renderer`).
+- Logic lives in dependency-injected, unit-tested modules (stores, reducer,
+  bridge, settings, smoke probe); `main.ts` is pure assembly. There is no
+  DOM/testing-library layer by design — UI logic is tested at the store layer.
+
+## Scripts
+
+| Script | What it does |
+|--------|--------------|
+| `dev` | Vite dev server + Electron against it |
+| `dev:renderer` | renderer only, in a browser (mock bridge) |
+| `build` | typecheck + Vite renderer build + esbuild main/preload |
+| `package` | unsigned, host-platform unpacked app (`electron-builder --dir`) |
+| `release` | unsigned per-platform distributable zip (`electron-builder`) |
+| `test` / `typecheck` | Vitest / `tsc --noEmit` |
+
+## Packaging & release
+
+- `pnpm --filter @frontagent/desktop package` → `release/<os>-unpacked/` (used by
+  CI's launch smoke).
+- `pnpm --filter @frontagent/desktop run release` → `release/frontagent-desktop-${version}-${os}-${arch}.zip`.
+- CI (`.github/workflows/release.yml`) builds the zip on ubuntu/macOS/windows and,
+  on `v*` tags, attaches them to the GitHub Release.
+
+Code signing, notarization, and native installers (dmg/nsis/AppImage) are planned
+follow-ups; current archives are unsigned.

--- a/docs/README-CN.md
+++ b/docs/README-CN.md
@@ -49,14 +49,24 @@ FrontAgent 是一个专为前端工程设计的 AI Agent 系统，解决了在�
 - 质量门禁：`pnpm quality:predev`、`pnpm quality:precommit`、`pnpm quality:ci` 和 `pnpm quality:local` 会组合执行 contract 检查、lint、typecheck、测试、workflow 测试与构建验证。
 - v2.1.1 重点：拆小 agent/executor/context/Filesense/memory/runtime/webview 模块，加固 VS Code webview nonce 生成，恢复 GitNexus contract checks，并扩展 focused tests。
 
-## 两种使用方式
+## 三种使用方式
 
-FrontAgent 现在同时支持命令行和 VS Code 桌面插件两种使用方式：
+FrontAgent 支持终端、VS Code 与独立桌面三种使用方式：
 
 - **CLI**：在终端里使用 `fa init`、`fa run`、RAG 命令、Skill Lab，以及适合自动化脚本的工作流。
 - **VS Code 插件**：在 Activity Bar 打开 FrontAgent 侧边栏任务台，直接运行任务、附加当前文件或选区、填写浏览器 URL、查看阶段/步骤进度、审批敏感操作、初始化/校验 SDD，并在 VS Code 内打开运行日志。
+- **桌面客户端**：独立的 Electron GUI（`apps/desktop`），复用同一套 Node 运行时脊柱——任务控制台用于发起任务、实时查看阶段/步骤遥测、审批敏感操作，并提供设置面板配置 LLM provider/model。
 
 你可以在 VS Code Marketplace 搜索 `FrontAgent`，或使用插件 ID `ceilf6.frontagent` 安装。
+
+### 桌面客户端
+
+桌面客户端是一个 sandboxed Electron 窗口，接到真实运行时（`window.frontagent` → IPC → `runFrontAgentTask`）；设置持久化到本机用户数据目录，运行时不可用时优雅降级。
+
+- **下载**：在 [GitHub Releases](https://github.com/FrontAgent/FrontAgent/releases) 页面下载对应平台的未签名压缩包 `frontagent-desktop-${version}-${os}-${arch}.zip`（每个 `v*` tag 自动发布），解压后运行 `frontagent` 可执行文件。LLM API Key 从环境变量读取（`PROVIDER_API_KEY` / `API_KEY`）；provider/model/base URL 在应用内设置面板配置。
+- **本地构建**：`pnpm --filter @frontagent/desktop package` 在 `apps/desktop/release/` 下产出未打包的应用；`pnpm --filter @frontagent/desktop dev` 对接 Vite 开发服务器运行；`pnpm --filter @frontagent/desktop run release` 产出可分发 zip。
+
+> 桌面压缩包目前未签名；代码签名、公证与原生安装器（dmg/nsis/AppImage）为后续计划。
 
 ## CLI 快速开始
 

--- a/scripts/tests/workflow-rules.test.mjs
+++ b/scripts/tests/workflow-rules.test.mjs
@@ -463,6 +463,20 @@ test('README links the current FrontAgent planner Hugging Face collection', () =
   assert.doesNotMatch(readme, /https:\/\/huggingface\.co\/ceilf6\/frontagent-planner-7B-lora/u);
 });
 
+test('README documents the desktop client as a supported usage path', () => {
+  const readme = readFileSync('README.md', 'utf8');
+  const readmeCn = readFileSync('docs/README-CN.md', 'utf8');
+
+  // Three usage paths (CLI / VS Code / Desktop), not two.
+  assert.match(readme, /## Three Ways to Use FrontAgent/u);
+  assert.match(readme, /\*\*Desktop App\*\*/u);
+  assert.match(readmeCn, /## 三种使用方式/u);
+  // Both downloadable-release and local-build paths are documented.
+  assert.match(readme, /frontagent-desktop-\$\{version\}-\$\{os\}-\$\{arch\}\.zip/u);
+  assert.match(readme, /pnpm --filter @frontagent\/desktop package/u);
+  assert.match(readmeCn, /pnpm --filter @frontagent\/desktop package/u);
+});
+
 test('local Claude state markdown remains ignored', () => {
   assert.doesNotThrow(() =>
     execFileSync('git', ['check-ignore', '-q', '.claude/repo-evolver.local.md']),


### PR DESCRIPTION
## Summary

Closes #345. The desktop client (Electron GUI, now with downloadable per-platform release zips from #341/#343) was undocumented — the README listed only CLI + VS Code.

### Changes
- **README.md / docs/README-CN.md**: "Two Ways to Use FrontAgent" → "Three Ways", adding a **Desktop App** entry and a Desktop App section covering both acquisition paths — download the unsigned `frontagent-desktop-${version}-${os}-${arch}.zip` from GitHub Releases, or build locally (`pnpm --filter @frontagent/desktop package` / `run release`). Unsigned-archive caveat noted.
- **apps/desktop/README.md** (new): one-page architecture (sandboxed renderer → IPC → runtime spine), scripts table, and packaging/release notes.
- **scripts/tests/workflow-rules.test.mjs**: authority-docs contract test asserting README/README-CN document the desktop client (both download and local-build paths).

Docs only — no code or build behavior changes.

## Verification
- `pnpm lint` clean (1 pre-existing unrelated info); `node --test scripts/tests/workflow-rules.test.mjs` 32/32; pre-commit gate (lint/typecheck/test/test:workflows) passed.

## GitNexus Impact Summary
- Risk level: LOW
- Critical skeleton changes: None — documentation only (README, README-CN, new apps/desktop/README, contract test). No source symbols.
- GitNexus impact: `detect_changes` reported 0 affected processes; the 25 "changed symbols" are all markdown section headings (risk low). `context` on the authority-docs contract rule confirms `scripts/tests/workflow-rules.test.mjs` gates README changes, updated here.
- Verification: `pnpm lint && pnpm typecheck && pnpm test && pnpm test:workflows` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
