### PR TITLE
fix(desktop): stop shipping demo content as TaskComposer initial values

### DIFF
--- a/apps/desktop/src/renderer/components/TaskComposer.tsx
+++ b/apps/desktop/src/renderer/components/TaskComposer.tsx
@@ -8,12 +8,14 @@ export function TaskComposer({
   disabled: boolean;
   onRun: (req: RunTaskRequest) => void;
 }) {
-  const [task, setTask] = useState('为登录页添加深色模式切换');
-  const [workspacePath, setWorkspacePath] = useState('~/projects/login-page');
-  const [browserUrl, setBrowserUrl] = useState('http://localhost:5173');
+  const [task, setTask] = useState('');
+  const [workspacePath, setWorkspacePath] = useState('');
+  const [browserUrl, setBrowserUrl] = useState('');
+
+  const canRun = task.trim().length > 0 && workspacePath.trim().length > 0;
 
   const submit = () => {
-    if (disabled || task.trim().length === 0) return;
+    if (disabled || !canRun) return;
     onRun({ task: task.trim(), workspacePath, browserUrl: browserUrl || undefined });
   };
 
@@ -30,13 +32,28 @@ export function TaskComposer({
       <div className="composer-row">
         <div className="field">
           <label htmlFor="ws">工作区</label>
-          <input id="ws" value={workspacePath} onChange={(e) => setWorkspacePath(e.target.value)} />
+          <input
+            id="ws"
+            value={workspacePath}
+            onChange={(e) => setWorkspacePath(e.target.value)}
+            placeholder="~/projects/your-app"
+          />
         </div>
         <div className="field">
           <label htmlFor="url">URL</label>
-          <input id="url" value={browserUrl} onChange={(e) => setBrowserUrl(e.target.value)} />
+          <input
+            id="url"
+            value={browserUrl}
+            onChange={(e) => setBrowserUrl(e.target.value)}
+            placeholder="http://localhost:5173（可选）"
+          />
         </div>
-        <button type="button" className="btn btn-primary" disabled={disabled} onClick={submit}>
+        <button
+          type="button"
+          className="btn btn-primary"
+          disabled={disabled || !canRun}
+          onClick={submit}
+        >
           {disabled ? '执行中…' : '运行任务 ⌘↵'}
         </button>
       </div>


### PR DESCRIPTION
## Linked Issue Or Context

Closes #347

## Summary

`TaskComposer` seeded its React state with hardcoded demo content (a fake task `为登录页添加深色模式切换` plus `~/projects/login-page` / `http://localhost:5173`), so a freshly launched desktop app greeted users with pre-filled fake content and the textarea's placeholder never showed. This is the same class of leftover as the #344 footer cleanup, missed in the composer.

Changes (single file, `apps/desktop/src/renderer/components/TaskComposer.tsx`):
- Default `task`, `workspacePath`, `browserUrl` to empty strings so placeholders show on first launch.
- Add placeholders to the workspace (`~/projects/your-app`) and URL (`http://localhost:5173（可选）`) inputs, which previously had none.
- Add a `canRun` guard (task **and** workspace both non-empty) used by both `submit()` and the run button's `disabled` state, so the now-empty workspace default cannot launch an invalid run. `browserUrl` stays optional.

## Impact Scope

Renderer-only, leaf component. No store, IPC, or contract changes.

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: none (leaf renderer component)
- GitNexus impact: `detect_changes` → changed symbols `TaskComposer` + `submit` (same file), 1 affected process `App → Submit` (steps 2–3) — exactly the expected scope. `impact(TaskComposer, upstream)` → LOW, 1 direct caller (`App`), 1 process, 1 module (`Components`).
- Verification: see below.

## Verification

- `pnpm --filter @frontagent/desktop typecheck` — clean.
- `pnpm --filter @frontagent/desktop test` — 13 files, 96 tests passing.
- `biome check` on the file — clean (formatted).
- `pnpm quality:precommit` ran via pre-commit hook — lint shows only the pre-existing `useTemplate` **info** in `hallucination-guard` (unrelated), typecheck/test green.

Note on tests: `apps/desktop` follows an established no-DOM-test architecture (logic lives in the store layer; components are not unit-tested). Per the repo-guard issue note, the verification intent (empty initial values + placeholders) is covered by the typecheck + the contained diff rather than a new component test, to avoid breaking that convention. Happy to add a lightweight render assertion if maintainers prefer.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [ ] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run. — N/A, not a critical skeleton change.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed. — no public API/contract change; test convention noted above.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results. — filled despite being non-critical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)