### PR TITLE
feat(desktop): add ARIA live-region & navigation semantics to the console UI

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -24,22 +24,24 @@ export function App({ bridge }: { bridge: FrontAgentBridge }) {
             <small>Console</small>
           </div>
         </div>
-        <nav className="nav">
+        <nav className="nav" aria-label="主导航">
           <button
             type="button"
             className="nav-item"
             data-active={view === 'console'}
+            aria-current={view === 'console' ? 'page' : undefined}
             onClick={() => setView('console')}
           >
-            <span className="nav-dot" /> 任务控制台
+            <span className="nav-dot" aria-hidden="true" /> 任务控制台
           </button>
           <button
             type="button"
             className="nav-item"
             data-active={view === 'settings'}
+            aria-current={view === 'settings' ? 'page' : undefined}
             onClick={() => setView('settings')}
           >
-            <span className="nav-dot" /> 设置
+            <span className="nav-dot" aria-hidden="true" /> 设置
           </button>
         </nav>
         <div className="rail-foot">

--- a/apps/desktop/src/renderer/components/ApprovalDrawer.tsx
+++ b/apps/desktop/src/renderer/components/ApprovalDrawer.tsx
@@ -8,7 +8,7 @@ export function ApprovalDrawer({
   onDecide: (approvalId: string, approved: boolean) => void;
 }) {
   return (
-    <div className="approval">
+    <section className="approval" aria-label={`需要审批：${request.toolName}`}>
       <div className="approval-head">
         ⚠ 需要审批 · {request.toolName}
         <span className="risk">{request.riskLevel}</span>
@@ -31,6 +31,6 @@ export function ApprovalDrawer({
           批准
         </button>
       </div>
-    </div>
+    </section>
   );
 }

--- a/apps/desktop/src/renderer/components/EventStream.tsx
+++ b/apps/desktop/src/renderer/components/EventStream.tsx
@@ -32,7 +32,14 @@ export function EventStream({
         </div>
       ) : null}
 
-      <div className="stream-log" ref={logRef}>
+      <div
+        className="stream-log"
+        ref={logRef}
+        role="log"
+        aria-live="polite"
+        aria-relevant="additions"
+        aria-label="遥测流"
+      >
         {state.log.length === 0 ? (
           <div className="log-line" data-l="info">
             <span className="log-text" style={{ color: 'var(--ink-faint)' }}>

--- a/apps/desktop/src/renderer/components/StatusPill.tsx
+++ b/apps/desktop/src/renderer/components/StatusPill.tsx
@@ -10,8 +10,8 @@ const LABELS: Record<RunStatus, string> = {
 
 export function StatusPill({ status }: { status: RunStatus }) {
   return (
-    <span className="status-pill" data-status={status}>
-      <span className="beacon" />
+    <span className="status-pill" data-status={status} role="status" aria-live="polite">
+      <span className="beacon" aria-hidden="true" />
       {LABELS[status]}
     </span>
   );


### PR DESCRIPTION
## Linked Issue Or Context

Closes #348

## Summary

Assistive technology could not perceive the console's dynamic surfaces. #344 added visual keyboard-focus rings and reduced-motion, but AT semantics were still missing. This PR adds **purely-additive** ARIA semantics — no behavior, layout, text, or styling changes:

- **StatusPill** — `role="status"` + `aria-live="polite"` so run-status transitions (planning → running → completed/failed) are announced; decorative beacon marked `aria-hidden`.
- **EventStream log** — `role="log"` + `aria-live="polite"` + `aria-relevant="additions"` + `aria-label="遥测流"` so streamed telemetry lines are announced as they append.
- **App nav** — `aria-label="主导航"` on the nav, `aria-current="page"` on the active item, decorative nav-dots marked `aria-hidden`.
- **ApprovalDrawer** — rendered as a labelled `<section>` (`aria-label` naming the pending tool) so the approve/reject surface is a named group.

## Impact Scope

Renderer-only, leaf/near-leaf components. No store, IPC, or contract changes.

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: none (renderer presentational components)
- GitNexus impact: `detect_changes` → exactly the 4 expected symbols touched (`App`, `StatusPill`, `EventStream`, `ApprovalDrawer`); 1 affected process `App → Submit` (step 1, `App`) — additive attributes only, no behavioral change. `impact(upstream)` on each = LOW (single parent caller, all flow into `App`).
- Verification: see below.

## Verification

- `biome check` on all 4 files — clean.
- `pnpm --filter @frontagent/desktop typecheck` — clean.
- `pnpm --filter @frontagent/desktop test` — 13 files, 96 tests passing.

### Design note on the ApprovalDrawer element

The issue suggested `role="group"` on the drawer, but biome's `a11y/useSemanticElements` rule (correctly) prefers a native semantic element over a `role` on a generic `<div>`, and `aria-label` is unsupported on a bare `<span>`. So the drawer is a native `<section aria-label=…>` (semantic, label-supported, no layout impact since `.approval` owns all styling, no `biome-ignore` needed), and the risk badge keeps its visible text (already announced inline) rather than an unsupported `aria-label`.

### Note on tests

`apps/desktop` follows an established no-DOM-test architecture (no `@testing-library`/jsdom installed; logic lives in the store layer, components are not unit-tested). Per the repo-guard issue note, rather than introduce a DOM-testing stack (a much larger, convention-breaking change) for attribute assertions, verification relies on typecheck + biome's a11y ruleset + the contained additive diff. Happy to add a lightweight render assertion if maintainers want to adopt that stack.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [ ] I have run `pnpm quality:local` for critical skeleton changes — N/A, not a critical skeleton change.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed — purely-additive ARIA, no behavior/API/contract change; test convention noted above.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results — filled despite being non-critical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)