### PR TITLE
fix(desktop): only auto-scroll telemetry log when the user is at the bottom

### DIFF
--- a/apps/desktop/src/renderer/components/EventStream.tsx
+++ b/apps/desktop/src/renderer/components/EventStream.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef } from 'react';
 import type { ConsoleState } from '../../state/executionReducer.js';
 import { ApprovalDrawer } from './ApprovalDrawer.js';
 
+const SCROLL_BOTTOM_THRESHOLD = 32;
+
 export function EventStream({
   state,
   onApproval,
@@ -10,10 +12,19 @@ export function EventStream({
   onApproval: (approvalId: string, approved: boolean) => void;
 }) {
   const logRef = useRef<HTMLDivElement>(null);
+  const stickToBottomRef = useRef(true);
   const activeTokens = state.activeStepId ? state.tokensByStep[state.activeStepId] : undefined;
+
+  const handleLogScroll = (event: React.UIEvent<HTMLDivElement>) => {
+    const { scrollHeight, scrollTop, clientHeight } = event.currentTarget;
+    stickToBottomRef.current = scrollHeight - scrollTop - clientHeight <= SCROLL_BOTTOM_THRESHOLD;
+  };
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-scroll on every appended log line
   useEffect(() => {
+    if (!stickToBottomRef.current) {
+      return;
+    }
     logRef.current?.scrollTo({ top: logRef.current.scrollHeight });
   }, [state.log.length, activeTokens]);
 
@@ -39,6 +50,7 @@ export function EventStream({
         aria-live="polite"
         aria-relevant="additions"
         aria-label="遥测流"
+        onScroll={handleLogScroll}
       >
         {state.log.length === 0 ? (
           <div className="log-line" data-l="info">


### PR DESCRIPTION
## Linked Issue Or Context

Closes #351

## Summary

The EventStream telemetry log force-scrolled to the bottom on every appended line and streamed token, so a user who scrolled up to read history during a run was yanked back down. Now it tails only when the user is already at/near the bottom — standard log-tail behavior.

Implementation (single file, `apps/desktop/src/renderer/components/EventStream.tsx`):
- `stickToBottomRef` (default `true`, so a fresh log tails).
- An `onScroll` handler marks "at bottom" when `scrollHeight - scrollTop - clientHeight <= 32px`.
- The existing scroll effect early-returns when the user has scrolled away.

A ref (not state) is used so scroll tracking causes no re-renders. Appending content doesn't fire a scroll event (scrollTop unchanged), so the ref reflects the user's last *manual* scroll; the programmatic tail re-marks at-bottom, so tailing resumes once the user scrolls back down. The `role`/`aria-*` attributes added in #348 are preserved.

## Impact Scope

Renderer-only, single leaf component. No store/IPC/contract changes.

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: none
- GitNexus impact: `detect_changes` → only `EventStream` touched, 0 affected processes. `impact(EventStream, upstream)` → LOW, 1 direct caller (`App`).
- Verification: see below.

## Verification

- `biome check` on the file — clean.
- `pnpm --filter @frontagent/desktop typecheck` — clean.
- `pnpm --filter @frontagent/desktop test` — 13 files, 96 tests passing.

Manual verification (per repo-guard note): during a run, scroll up into history → new lines/tokens no longer pull the view to the bottom; scroll back to the bottom → auto-follow resumes.

Note on tests: `apps/desktop` follows an established no-DOM-test architecture (no `@testing-library`/jsdom). Verification relies on typecheck + biome + the contained diff + the manual steps above rather than a new component test, consistent with #349/#350.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [ ] I have run `pnpm quality:local` for critical skeleton changes — N/A, not critical skeleton.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed — no API/contract change; test convention noted.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary — filled despite being non-critical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)