### PR TITLE
fix(desktop): announce successful settings save to assistive tech

### DIFF
--- a/apps/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/SettingsPanel.tsx
@@ -56,7 +56,9 @@ export function SettingsPanel({ bridge }: { bridge: FrontAgentBridge }) {
       ) : null}
       <button type="button" className="btn btn-primary" onClick={save} disabled={saving}>
         {saving ? '保存中…' : status === 'save-error' ? '重试保存' : '保存设置'}
-        {saved ? <span className="settings-saved">✓ 已保存</span> : null}
+        <span className="settings-saved" role="status" aria-live="polite">
+          {saved ? '✓ 已保存' : ''}
+        </span>
       </button>
     </div>
   );

--- a/apps/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/SettingsPanel.tsx
@@ -56,10 +56,10 @@ export function SettingsPanel({ bridge }: { bridge: FrontAgentBridge }) {
       ) : null}
       <button type="button" className="btn btn-primary" onClick={save} disabled={saving}>
         {saving ? '保存中…' : status === 'save-error' ? '重试保存' : '保存设置'}
-        <span className="settings-saved" role="status" aria-live="polite">
-          {saved ? '✓ 已保存' : ''}
-        </span>
       </button>
+      <span className="settings-saved" role="status" aria-live="polite">
+        {saved ? '✓ 已保存' : ''}
+      </span>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/theme.css
+++ b/apps/desktop/src/renderer/theme.css
@@ -738,6 +738,8 @@ body::before {
   font-family: var(--font-mono);
   font-size: 11.5px;
   color: var(--teal);
+}
+.settings-saved:not(:empty) {
   margin-left: 12px;
 }
 .settings-error {


### PR DESCRIPTION
## What & why

`SettingsPanel` announces a save **failure** to assistive tech via `role="alert"`, but a save **success** ("✓ 已保存") was a plain conditionally-mounted `<span>` with no live-region — so screen-reader users got no confirmation the save actually worked. This is a WCAG 2.1 SC 4.1.3 (Status Messages) parity gap.

Closes #355

## Change (single component + minimal CSS)

- `SettingsPanel.tsx`: render the success confirmation as an **always-present** polite status live-region (`role="status" aria-live="polite"`) whose text toggles on the existing `saved` flag. A live region must exist in the DOM before content is inserted to be announced reliably, so the container is always rendered and its text is empty until `saved`. The failure `role="alert"` paths are untouched.
- `theme.css`: guard `.settings-saved`'s `margin-left` with `:not(:empty)` so the now-always-rendered (empty when unsaved) span introduces **no layout gap**. Visual affordance is otherwise identical.

No change to `settingsController`, the IPC contract, or any other file. Live-region text is kept equivalent to the existing "✓ 已保存" visual cue (per repo-guard's optional issue-review note).

## Verification

- `pnpm --filter @frontagent/desktop typecheck` — clean
- `pnpm --filter @frontagent/desktop test` — 96/96 pass
- root `biome check .` — clean (only the pre-existing `useTemplate` info in hallucination-guard, unrelated)
- `quality:precommit` pre-commit hook — green (lint/typecheck/test/test:workflows 32/32)
- Manual a11y check: with `saved=false` the status region is empty and adds no visible gap; on a successful save it receives "✓ 已保存" and a polite-live screen reader announces it without moving focus.

Follows the desktop **no-DOM-test** architecture (no `@testing-library/jsdom`); semantics verified via typecheck + biome a11y rules + controlled diff + this manual note, consistent with #348/#350.

## GitNexus Impact Summary

- **Risk level**: LOW
- **Critical skeleton changes**: None — presentational a11y markup + scoped CSS only; no exported signature, IPC contract, or store change.
- **GitNexus impact**: `impact(SettingsPanel, upstream)` → risk LOW, d=1 `App` (renders it), d=2 `main.tsx`; 1 process (`App → Submit`, step 1), module `Components`. `detect_changes(all)` → 1 changed symbol (`SettingsPanel`, touched), **0 affected processes**, risk low. theme.css is non-symbol CSS.
- **Verification**: desktop typecheck clean, 96/96 tests, biome clean, precommit green (see above).