### PR TITLE
feat(mcp-web-fetch): add @frontagent/mcp-web-fetch adapter package (unwired)

### DIFF
--- a/packages/mcp-web-fetch/.gitignore
+++ b/packages/mcp-web-fetch/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/packages/mcp-web-fetch/package.json
+++ b/packages/mcp-web-fetch/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@frontagent/mcp-web-fetch",
+  "version": "2.1.1",
+  "description": "MCP Web-Fetch Adapter - Agent-friendly URL fetching (HTML→text) with SSRF guards for FrontAgent",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^25.9.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
+  }
+}

--- a/packages/mcp-web-fetch/package.json
+++ b/packages/mcp-web-fetch/package.json
@@ -18,7 +18,9 @@
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },
-  "dependencies": {},
+  "dependencies": {
+    "undici": "^6.21.0"
+  },
   "devDependencies": {
     "@types/node": "^25.9.1",
     "typescript": "^6.0.3",

--- a/packages/mcp-web-fetch/src/engine.lookup.test.ts
+++ b/packages/mcp-web-fetch/src/engine.lookup.test.ts
@@ -1,0 +1,49 @@
+import type { LookupAddress } from 'node:dns';
+import { describe, expect, it } from 'vitest';
+import { safeLookup } from './engine.js';
+
+/**
+ * These tests exercise `safeLookup` directly — the function undici's
+ * dispatcher actually calls at connection time. All cases use local-only
+ * resolution (loopback hostnames and IP literals), so no external network
+ * access is required:
+ *  - Literal IPs are returned by `dns.lookup` without a network query.
+ *  - 'localhost' is resolved via the hosts file (local).
+ */
+function runLookup(hostname: string): Promise<{
+  err: NodeJS.ErrnoException | null;
+  address: string | LookupAddress[];
+  family?: number;
+}> {
+  return new Promise((resolve) => {
+    safeLookup(hostname, {}, (err, address, family) => {
+      resolve({ err, address, family });
+    });
+  });
+}
+
+describe('safeLookup', () => {
+  it('blocks localhost (resolves to a loopback address)', async () => {
+    const { err } = await runLookup('localhost');
+    expect(err).not.toBeNull();
+    expect(err?.message).toMatch(/private|blocked/i);
+  });
+
+  it('blocks the literal IPv4 loopback address 127.0.0.1', async () => {
+    const { err } = await runLookup('127.0.0.1');
+    expect(err).not.toBeNull();
+    expect(err?.message).toMatch(/private|blocked/i);
+  });
+
+  it('blocks the literal IPv6 loopback address ::1', async () => {
+    const { err } = await runLookup('::1');
+    expect(err).not.toBeNull();
+    expect(err?.message).toMatch(/private|blocked/i);
+  });
+
+  it('allows a literal public IPv4 address', async () => {
+    const { err, address } = await runLookup('8.8.8.8');
+    expect(err).toBeNull();
+    expect(address).toBe('8.8.8.8');
+  });
+});

--- a/packages/mcp-web-fetch/src/engine.test.ts
+++ b/packages/mcp-web-fetch/src/engine.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchUrl } from './engine.js';
+
+describe('fetchUrl', () => {
+  it('rejects a redirect to a private address without following it', async () => {
+    const mock = vi.fn(
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: 'http://127.0.0.1/secret' },
+        }),
+    );
+
+    await expect(
+      fetchUrl('https://example.com/', { fetchImpl: mock as unknown as typeof fetch }),
+    ).rejects.toThrow();
+
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('truncates the body when it exceeds maxBytes', async () => {
+    const largeBody = 'x'.repeat(1000);
+    const mock = vi.fn(
+      async () =>
+        new Response(largeBody, {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        }),
+    );
+
+    const result = await fetchUrl('https://example.com/', {
+      fetchImpl: mock as unknown as typeof fetch,
+      maxBytes: 100,
+    });
+
+    expect(result.truncated).toBe(true);
+    expect(result.bytes).toBeLessThanOrEqual(100);
+  });
+
+  it('throws once the redirect count exceeds maxRedirects', async () => {
+    const mock = vi.fn(
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: 'http://example.org/next' },
+        }),
+    );
+
+    await expect(
+      fetchUrl('https://example.com/', {
+        fetchImpl: mock as unknown as typeof fetch,
+        maxRedirects: 2,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('returns text and title for a successful HTML response', async () => {
+    const mock = vi.fn(
+      async () =>
+        new Response('<title>Hi</title><p>Hello</p>', {
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+        }),
+    );
+
+    const result = await fetchUrl('https://example.com/', {
+      fetchImpl: mock as unknown as typeof fetch,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.title).toBe('Hi');
+    expect(result.text).toContain('Hello');
+  });
+});

--- a/packages/mcp-web-fetch/src/engine.ts
+++ b/packages/mcp-web-fetch/src/engine.ts
@@ -1,5 +1,7 @@
+import dns from 'node:dns';
+import { Agent } from 'undici';
 import { htmlToText } from './html-to-text.js';
-import { assertResolvedHostSafe, parseAndValidateUrl } from './url-safety.js';
+import { isConnectionAddressBlocked, parseAndValidateUrl, UrlSafetyError } from './url-safety.js';
 
 export interface FetchResult {
   url: string;
@@ -22,21 +24,66 @@ export interface FetchOptions {
   maxRedirects?: number;
 }
 
-const DEFAULT_TIMEOUT_MS = 15000;
-const DEFAULT_MAX_BYTES = 2_000_000;
+export const DEFAULT_TIMEOUT_MS = 15000;
+export const DEFAULT_MAX_BYTES = 2_000_000;
+export const HARD_MAX_TIMEOUT_MS = 60_000;
+export const HARD_MAX_BYTES = 5_000_000;
 const DEFAULT_MAX_REDIRECTS = 5;
+const HARD_MAX_REDIRECTS = 10;
 const DEFAULT_USER_AGENT = 'frontagent-mcp-web-fetch/2.1.1 (+https://github.com/frontagent)';
+
+/**
+ * Clamps a caller-supplied numeric limit to a safe, bounded integer.
+ *
+ * Returns `def` for any non-finite, non-numeric, zero, or negative input.
+ * Fractional values are floored. Values above `hardMax` are capped to
+ * `hardMax`, regardless of what the caller requested.
+ */
+export function clampLimit(value: unknown, def: number, hardMax: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return def;
+  return Math.min(Math.floor(value), hardMax);
+}
+
+/**
+ * Undici dispatcher whose DNS lookup validates the resolved address at
+ * connection time, closing the TOCTOU gap between SSRF pre-validation
+ * (parseAndValidateUrl) and the actual network connection.
+ */
+const safeDispatcher = new Agent({
+  connect: {
+    lookup: (hostname, options, callback) => {
+      dns.lookup(hostname, options, (err, address, family) => {
+        if (err) {
+          callback(err, address as string, family as number);
+          return;
+        }
+        const resolved = address as string;
+        if (isConnectionAddressBlocked(resolved)) {
+          callback(
+            new UrlSafetyError(`Blocked private address ${resolved} for host ${hostname}`),
+            resolved,
+            family as number,
+          );
+          return;
+        }
+        callback(null, resolved, family as number);
+      });
+    },
+  },
+});
 
 /**
  * Fetch a URL and return cleaned, readable text along with metadata.
  *
- * Performs SSRF-safety validation (URL shape + DNS resolution) on every
- * hop of the redirect chain before issuing any network request.
+ * Performs SSRF-safety validation (URL shape) on every hop of the
+ * redirect chain before issuing any network request, and routes all
+ * requests through a dispatcher that validates the resolved connection
+ * address at connect time (closing the DNS-rebinding TOCTOU gap).
  */
 export async function fetchUrl(rawUrl: string, opts: FetchOptions = {}): Promise<FetchResult> {
-  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
-  const maxRedirects = opts.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+  const timeoutMs = clampLimit(opts.timeoutMs, DEFAULT_TIMEOUT_MS, HARD_MAX_TIMEOUT_MS);
+  const maxBytes = clampLimit(opts.maxBytes, DEFAULT_MAX_BYTES, HARD_MAX_BYTES);
+  const maxRedirects = clampLimit(opts.maxRedirects, DEFAULT_MAX_REDIRECTS, HARD_MAX_REDIRECTS);
   const format = opts.format ?? 'text';
   const userAgent = opts.userAgent ?? DEFAULT_USER_AGENT;
 
@@ -53,15 +100,14 @@ export async function fetchUrl(rawUrl: string, opts: FetchOptions = {}): Promise
     let redirectCount = 0;
 
     for (;;) {
-      await assertResolvedHostSafe(currentUrl.hostname);
-
       let res: Response;
       try {
         res = await fetch(currentUrl, {
           redirect: 'manual',
           signal: controller.signal,
           headers: { 'user-agent': userAgent },
-        });
+          dispatcher: safeDispatcher,
+        } as RequestInit);
       } catch (err) {
         if (controller.signal.aborted) {
           throw new Error(`Request timed out after ${timeoutMs}ms: ${currentUrl}`);

--- a/packages/mcp-web-fetch/src/engine.ts
+++ b/packages/mcp-web-fetch/src/engine.ts
@@ -1,0 +1,176 @@
+import { htmlToText } from './html-to-text.js';
+import { assertResolvedHostSafe, parseAndValidateUrl } from './url-safety.js';
+
+export interface FetchResult {
+  url: string;
+  finalUrl: string;
+  status: number;
+  contentType: string | null;
+  title: string | null;
+  text: string;
+  bytes: number;
+  truncated: boolean;
+}
+
+export interface FetchOptions {
+  timeoutMs?: number;
+  maxBytes?: number;
+  userAgent?: string;
+  format?: 'text' | 'html';
+  allowHosts?: string[];
+  denyHosts?: string[];
+  maxRedirects?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 15000;
+const DEFAULT_MAX_BYTES = 2_000_000;
+const DEFAULT_MAX_REDIRECTS = 5;
+const DEFAULT_USER_AGENT = 'frontagent-mcp-web-fetch/2.1.1 (+https://github.com/frontagent)';
+
+/**
+ * Fetch a URL and return cleaned, readable text along with metadata.
+ *
+ * Performs SSRF-safety validation (URL shape + DNS resolution) on every
+ * hop of the redirect chain before issuing any network request.
+ */
+export async function fetchUrl(rawUrl: string, opts: FetchOptions = {}): Promise<FetchResult> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+  const maxRedirects = opts.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+  const format = opts.format ?? 'text';
+  const userAgent = opts.userAgent ?? DEFAULT_USER_AGENT;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    let currentUrl = parseAndValidateUrl(rawUrl, {
+      allowHosts: opts.allowHosts,
+      denyHosts: opts.denyHosts,
+    });
+
+    let response: Response | undefined;
+    let redirectCount = 0;
+
+    for (;;) {
+      await assertResolvedHostSafe(currentUrl.hostname);
+
+      let res: Response;
+      try {
+        res = await fetch(currentUrl, {
+          redirect: 'manual',
+          signal: controller.signal,
+          headers: { 'user-agent': userAgent },
+        });
+      } catch (err) {
+        if (controller.signal.aborted) {
+          throw new Error(`Request timed out after ${timeoutMs}ms: ${currentUrl}`);
+        }
+        throw err;
+      }
+
+      const isRedirect = res.status >= 300 && res.status < 400 && res.headers.has('location');
+      if (!isRedirect) {
+        response = res;
+        break;
+      }
+
+      redirectCount++;
+      if (redirectCount > maxRedirects) {
+        throw new Error(`Exceeded maximum redirects (${maxRedirects}) while fetching ${rawUrl}`);
+      }
+
+      const location = res.headers.get('location')!;
+      const nextUrl = new URL(location, currentUrl);
+      currentUrl = parseAndValidateUrl(nextUrl.toString(), {
+        allowHosts: opts.allowHosts,
+        denyHosts: opts.denyHosts,
+      });
+    }
+
+    const finalUrl = currentUrl.toString();
+    const contentType = response.headers.get('content-type');
+
+    const { bytes, truncated, text: rawText } = await readBody(response, maxBytes);
+
+    let title: string | null = null;
+    let text: string;
+
+    const looksHtml = (contentType ?? '').toLowerCase().includes('html');
+    const treatAsHtml = looksHtml || (format === 'text' && looksLikeHtml(rawText));
+
+    if (treatAsHtml) {
+      const converted = htmlToText(rawText);
+      title = converted.title;
+      text = format === 'html' ? rawText : converted.text;
+    } else {
+      text = rawText;
+    }
+
+    return {
+      url: rawUrl,
+      finalUrl,
+      status: response.status,
+      contentType,
+      title,
+      text,
+      bytes,
+      truncated,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function readBody(
+  response: Response,
+  maxBytes: number,
+): Promise<{ bytes: number; truncated: boolean; text: string }> {
+  if (!response.body) {
+    const buf = await response.arrayBuffer();
+    const truncated = buf.byteLength > maxBytes;
+    const slice = truncated ? buf.slice(0, maxBytes) : buf;
+    return { bytes: slice.byteLength, truncated, text: new TextDecoder().decode(slice) };
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  let truncated = false;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+
+    if (total + value.length > maxBytes) {
+      const remaining = maxBytes - total;
+      if (remaining > 0) {
+        chunks.push(value.subarray(0, remaining));
+        total += remaining;
+      }
+      truncated = true;
+      await reader.cancel().catch(() => {});
+      break;
+    }
+
+    chunks.push(value);
+    total += value.length;
+  }
+
+  const combined = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return { bytes: total, truncated, text: new TextDecoder().decode(combined) };
+}
+
+function looksLikeHtml(text: string): boolean {
+  const sample = text.slice(0, 1024).trimStart().toLowerCase();
+  return (
+    sample.startsWith('<!doctype html') || sample.startsWith('<html') || sample.includes('<body')
+  );
+}

--- a/packages/mcp-web-fetch/src/engine.ts
+++ b/packages/mcp-web-fetch/src/engine.ts
@@ -22,6 +22,13 @@ export interface FetchOptions {
   allowHosts?: string[];
   denyHosts?: string[];
   maxRedirects?: number;
+  /**
+   * Test-only injection seam: overrides the `fetch` implementation used to
+   * issue requests. Defaults to the global `fetch`. Not intended for
+   * production use — when supplied, the `dispatcher: safeDispatcher` option
+   * is still passed but a mock implementation may ignore it.
+   */
+  fetchImpl?: typeof fetch;
 }
 
 export const DEFAULT_TIMEOUT_MS = 15000;
@@ -52,7 +59,7 @@ export function clampLimit(value: unknown, def: number, hardMax: number): number
 const safeDispatcher = new Agent({
   connect: {
     lookup: (hostname, options, callback) => {
-      dns.lookup(hostname, options, (err, address, family) => {
+      dns.lookup(hostname, { ...options, all: false }, (err, address, family) => {
         if (err) {
           callback(err, address as string, family as number);
           return;
@@ -89,6 +96,7 @@ export async function fetchUrl(rawUrl: string, opts: FetchOptions = {}): Promise
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const doFetch = opts.fetchImpl ?? fetch;
 
   try {
     let currentUrl = parseAndValidateUrl(rawUrl, {
@@ -102,7 +110,7 @@ export async function fetchUrl(rawUrl: string, opts: FetchOptions = {}): Promise
     for (;;) {
       let res: Response;
       try {
-        res = await fetch(currentUrl, {
+        res = await doFetch(currentUrl, {
           redirect: 'manual',
           signal: controller.signal,
           headers: { 'user-agent': userAgent },

--- a/packages/mcp-web-fetch/src/engine.ts
+++ b/packages/mcp-web-fetch/src/engine.ts
@@ -1,3 +1,4 @@
+import type { LookupAddress, LookupOptions } from 'node:dns';
 import dns from 'node:dns';
 import { Agent } from 'undici';
 import { htmlToText } from './html-to-text.js';
@@ -52,30 +53,46 @@ export function clampLimit(value: unknown, def: number, hardMax: number): number
 }
 
 /**
+ * DNS lookup used by the safe undici dispatcher. Resolves the hostname and
+ * rejects (via UrlSafetyError) if the resolved address is private/loopback/
+ * link-local — enforced at CONNECTION time so the validated address is the
+ * one actually connected to (DNS-rebinding-safe). Exported for direct testing.
+ */
+export function safeLookup(
+  hostname: string,
+  options: LookupOptions,
+  callback: (
+    err: NodeJS.ErrnoException | null,
+    address: string | LookupAddress[],
+    family?: number,
+  ) => void,
+): void {
+  dns.lookup(hostname, { ...options, all: false }, (err, address, family) => {
+    if (err) {
+      callback(err, address, family);
+      return;
+    }
+    const resolved = address as string;
+    if (isConnectionAddressBlocked(resolved)) {
+      callback(
+        new UrlSafetyError(`Blocked private address ${resolved} for host ${hostname}`),
+        resolved,
+        family,
+      );
+      return;
+    }
+    callback(null, resolved, family);
+  });
+}
+
+/**
  * Undici dispatcher whose DNS lookup validates the resolved address at
  * connection time, closing the TOCTOU gap between SSRF pre-validation
  * (parseAndValidateUrl) and the actual network connection.
  */
 const safeDispatcher = new Agent({
   connect: {
-    lookup: (hostname, options, callback) => {
-      dns.lookup(hostname, { ...options, all: false }, (err, address, family) => {
-        if (err) {
-          callback(err, address as string, family as number);
-          return;
-        }
-        const resolved = address as string;
-        if (isConnectionAddressBlocked(resolved)) {
-          callback(
-            new UrlSafetyError(`Blocked private address ${resolved} for host ${hostname}`),
-            resolved,
-            family as number,
-          );
-          return;
-        }
-        callback(null, resolved, family as number);
-      });
-    },
+    lookup: safeLookup,
   },
 });
 

--- a/packages/mcp-web-fetch/src/html-to-text.test.ts
+++ b/packages/mcp-web-fetch/src/html-to-text.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { htmlToText } from './html-to-text.js';
+
+describe('htmlToText', () => {
+  it('extracts the title', () => {
+    const { title } = htmlToText(
+      '<html><head><title>Hello World</title></head><body></body></html>',
+    );
+    expect(title).toBe('Hello World');
+  });
+
+  it('returns null title when missing', () => {
+    const { title } = htmlToText('<html><body><p>No title here</p></body></html>');
+    expect(title).toBeNull();
+  });
+
+  it('removes script and style content', () => {
+    const html =
+      '<html><head><style>body{color:red}</style></head><body><script>alert(1)</script><p>Hi</p></body></html>';
+    const { text } = htmlToText(html);
+    expect(text).not.toContain('alert');
+    expect(text).not.toContain('color:red');
+    expect(text).toContain('Hi');
+  });
+
+  it('converts <p> and <br> to newlines', () => {
+    const html = '<p>Line one</p><p>Line two<br>Line three</p>';
+    const { text } = htmlToText(html);
+    const lines = text.split('\n');
+    expect(lines).toEqual(['Line one', 'Line two', 'Line three']);
+  });
+
+  it('decodes common entities', () => {
+    const html = '<p>Tom &amp; Jerry&#39;s&nbsp;place</p>';
+    const { text } = htmlToText(html);
+    expect(text).toBe("Tom & Jerry's place");
+  });
+
+  it('handles a combined snippet', () => {
+    const html = `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>My &amp; Page</title>
+          <style>.x { display: none; }</style>
+          <script>console.log('hi');</script>
+        </head>
+        <body>
+          <!-- a comment -->
+          <h1>Welcome</h1>
+          <p>This is a paragraph with &quot;quotes&quot;.</p>
+          <ul>
+            <li>Item one</li>
+            <li>Item two</li>
+          </ul>
+        </body>
+      </html>
+    `;
+    const { title, text } = htmlToText(html);
+    expect(title).toBe('My & Page');
+    expect(text).toContain('Welcome');
+    expect(text).toContain('This is a paragraph with "quotes".');
+    expect(text).toContain('Item one');
+    expect(text).toContain('Item two');
+    expect(text).not.toContain('console.log');
+    expect(text).not.toContain('display: none');
+    expect(text).not.toContain('a comment');
+    expect(/\n{3,}/.test(text)).toBe(false);
+  });
+});

--- a/packages/mcp-web-fetch/src/html-to-text.ts
+++ b/packages/mcp-web-fetch/src/html-to-text.ts
@@ -1,0 +1,66 @@
+/**
+ * Convert HTML to plain, readable text, extracting the page title.
+ */
+export function htmlToText(html: string): { title: string | null; text: string } {
+  // Extract <title>...</title>
+  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const title = titleMatch ? decodeEntities(titleMatch[1]).trim() || null : null;
+
+  let body = html;
+
+  // Remove script, style, noscript blocks (including their contents)
+  body = body.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '');
+  body = body.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '');
+  body = body.replace(/<noscript[^>]*>[\s\S]*?<\/noscript>/gi, '');
+
+  // Remove HTML comments
+  body = body.replace(/<!--[\s\S]*?-->/g, '');
+
+  // Convert block-ish tags to newlines
+  body = body.replace(/<\/p\s*>/gi, '\n');
+  body = body.replace(/<br\s*\/?>/gi, '\n');
+  body = body.replace(/<\/div\s*>/gi, '\n');
+  body = body.replace(/<\/h[1-6]\s*>/gi, '\n');
+  body = body.replace(/<\/li\s*>/gi, '\n');
+  body = body.replace(/<\/tr\s*>/gi, '\n');
+
+  // Strip all remaining tags
+  body = body.replace(/<[^>]+>/g, '');
+
+  // Decode entities
+  body = decodeEntities(body);
+
+  // Collapse 3+ blank lines to 2, trim trailing spaces per line, trim overall
+  body = body
+    .split('\n')
+    .map((line) => line.replace(/[ \t]+$/g, ''))
+    .join('\n');
+  body = body.replace(/\n{3,}/g, '\n\n');
+  body = body.trim();
+
+  return { title, text: body };
+}
+
+function decodeEntities(input: string): string {
+  return input
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex: string) => {
+      try {
+        return String.fromCodePoint(parseInt(hex, 16));
+      } catch {
+        return '';
+      }
+    })
+    .replace(/&#(\d+);/g, (_, dec: string) => {
+      try {
+        return String.fromCodePoint(parseInt(dec, 10));
+      } catch {
+        return '';
+      }
+    });
+}

--- a/packages/mcp-web-fetch/src/index.ts
+++ b/packages/mcp-web-fetch/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @frontagent/mcp-web-fetch - Agent-friendly URL fetching for FrontAgent
+ *
+ * Provides:
+ * - SSRF-safe URL validation and DNS resolution checks
+ * - HTML-to-text conversion for readable page content
+ * - A fetch engine with per-hop redirect re-validation, timeouts, and byte limits
+ * - MCP tool schemas and handlers for integration with FrontAgent's MCP server
+ */
+
+export * from './engine.js';
+export {
+  allWebFetchSchemas,
+  handleWebFetchTool,
+  type WebFetchToolResult,
+  webFetchSchema,
+} from './tools.js';
+export { VERSION } from './types.js';

--- a/packages/mcp-web-fetch/src/limits.test.ts
+++ b/packages/mcp-web-fetch/src/limits.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clampLimit,
+  DEFAULT_MAX_BYTES,
+  DEFAULT_TIMEOUT_MS,
+  HARD_MAX_BYTES,
+  HARD_MAX_TIMEOUT_MS,
+} from './engine.js';
+import { isConnectionAddressBlocked } from './url-safety.js';
+
+describe('clampLimit', () => {
+  it('returns the default for non-number values', () => {
+    expect(clampLimit('15000', DEFAULT_TIMEOUT_MS, HARD_MAX_TIMEOUT_MS)).toBe(DEFAULT_TIMEOUT_MS);
+    expect(clampLimit(undefined, DEFAULT_TIMEOUT_MS, HARD_MAX_TIMEOUT_MS)).toBe(DEFAULT_TIMEOUT_MS);
+    expect(clampLimit(null, DEFAULT_TIMEOUT_MS, HARD_MAX_TIMEOUT_MS)).toBe(DEFAULT_TIMEOUT_MS);
+  });
+
+  it('returns the default for NaN, zero, negative, and non-finite values', () => {
+    expect(clampLimit(Number.NaN, DEFAULT_MAX_BYTES, HARD_MAX_BYTES)).toBe(DEFAULT_MAX_BYTES);
+    expect(clampLimit(0, DEFAULT_MAX_BYTES, HARD_MAX_BYTES)).toBe(DEFAULT_MAX_BYTES);
+    expect(clampLimit(-1, DEFAULT_MAX_BYTES, HARD_MAX_BYTES)).toBe(DEFAULT_MAX_BYTES);
+    expect(clampLimit(Number.POSITIVE_INFINITY, DEFAULT_MAX_BYTES, HARD_MAX_BYTES)).toBe(
+      DEFAULT_MAX_BYTES,
+    );
+    expect(clampLimit(Number.NEGATIVE_INFINITY, DEFAULT_MAX_BYTES, HARD_MAX_BYTES)).toBe(
+      DEFAULT_MAX_BYTES,
+    );
+  });
+
+  it('floors fractional values', () => {
+    expect(clampLimit(10.7, DEFAULT_TIMEOUT_MS, HARD_MAX_TIMEOUT_MS)).toBe(10);
+  });
+
+  it('caps values above the hard maximum', () => {
+    expect(clampLimit(100_000, DEFAULT_TIMEOUT_MS, HARD_MAX_TIMEOUT_MS)).toBe(HARD_MAX_TIMEOUT_MS);
+    expect(clampLimit(10_000_000, DEFAULT_MAX_BYTES, HARD_MAX_BYTES)).toBe(HARD_MAX_BYTES);
+  });
+
+  it('passes through valid in-range values', () => {
+    expect(clampLimit(5000, DEFAULT_TIMEOUT_MS, HARD_MAX_TIMEOUT_MS)).toBe(5000);
+    expect(clampLimit(1_000_000, DEFAULT_MAX_BYTES, HARD_MAX_BYTES)).toBe(1_000_000);
+  });
+});
+
+describe('isConnectionAddressBlocked', () => {
+  it('blocks private/loopback/link-local IPv4 addresses', () => {
+    expect(isConnectionAddressBlocked('127.0.0.1')).toBe(true);
+    expect(isConnectionAddressBlocked('10.0.0.1')).toBe(true);
+    expect(isConnectionAddressBlocked('169.254.169.254')).toBe(true);
+    expect(isConnectionAddressBlocked('192.168.1.1')).toBe(true);
+  });
+
+  it('blocks private/loopback/link-local IPv6 addresses', () => {
+    expect(isConnectionAddressBlocked('::1')).toBe(true);
+    expect(isConnectionAddressBlocked('fe80::1')).toBe(true);
+    expect(isConnectionAddressBlocked('fc00::1')).toBe(true);
+  });
+
+  it('allows public addresses', () => {
+    expect(isConnectionAddressBlocked('8.8.8.8')).toBe(false);
+    expect(isConnectionAddressBlocked('2606:4700::1')).toBe(false);
+  });
+});

--- a/packages/mcp-web-fetch/src/tools.security.test.ts
+++ b/packages/mcp-web-fetch/src/tools.security.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { handleWebFetchTool } from './tools.js';
+
+describe('mcp-web-fetch SSRF guards (no network)', () => {
+  it('rejects loopback IPv4 addresses', async () => {
+    const result = await handleWebFetchTool('web_fetch', { url: 'http://127.0.0.1/' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/private|blocked|loopback|safety|denied/i);
+  });
+
+  it('rejects localhost', async () => {
+    const result = await handleWebFetchTool('web_fetch', { url: 'http://localhost/' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/private|blocked|loopback|safety|denied/i);
+  });
+
+  it('rejects cloud metadata addresses', async () => {
+    const result = await handleWebFetchTool('web_fetch', {
+      url: 'http://169.254.169.254/latest/meta-data/',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/private|blocked|loopback|safety|denied/i);
+  });
+
+  it('rejects file: URLs', async () => {
+    const result = await handleWebFetchTool('web_fetch', { url: 'file:///etc/passwd' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/private|blocked|loopback|safety|denied|protocol/i);
+  });
+
+  it('rejects ftp: URLs', async () => {
+    const result = await handleWebFetchTool('web_fetch', { url: 'ftp://example.com' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/private|blocked|loopback|safety|denied|protocol/i);
+  });
+
+  it('rejects URLs with embedded credentials', async () => {
+    const result = await handleWebFetchTool('web_fetch', {
+      url: 'http://user:pass@example.com/',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/private|blocked|loopback|safety|denied|credentials/i);
+  });
+
+  it('rejects unknown tool names', async () => {
+    const result = await handleWebFetchTool('not_a_real_tool', { url: 'https://example.com' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/unknown/i);
+  });
+});

--- a/packages/mcp-web-fetch/src/tools.ts
+++ b/packages/mcp-web-fetch/src/tools.ts
@@ -1,0 +1,71 @@
+/**
+ * MCP Tool definitions for Web-Fetch
+ * Exposes the web-fetch operation as an MCP-compatible tool for FrontAgent
+ */
+
+import { fetchUrl } from './engine.js';
+import type { WebFetchToolResult } from './types.js';
+
+export type { WebFetchToolResult } from './types.js';
+
+// ─── Tool Schemas ──────────────────────────────────────────────────────────────
+
+export const webFetchSchema = {
+  name: 'web_fetch',
+  description:
+    '抓取指定 URL 的网页内容并返回清洗后的可读文本（HTML→纯文本）。用于查阅库/框架文档、API 参考、错误信息等外部资料。内置 SSRF 防护：拒绝私网/环回/链路本地/云元数据地址。',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      url: {
+        type: 'string',
+        description: '要抓取的 URL（仅支持 http/https）',
+      },
+      format: {
+        type: 'string',
+        enum: ['text', 'html'],
+        description: '返回格式：text（默认，HTML 转纯文本）或 html（原始 HTML）',
+      },
+      timeoutMs: {
+        type: 'number',
+        description: '请求超时时间（毫秒），默认 15000',
+      },
+      maxBytes: {
+        type: 'number',
+        description: '响应体最大字节数，超出后截断，默认 2000000',
+      },
+    },
+    required: ['url'],
+  },
+};
+
+// ─── All schemas for registration ─────────────────────────────────────────────
+
+export const allWebFetchSchemas = [webFetchSchema];
+
+// ─── Tool Handlers ─────────────────────────────────────────────────────────────
+
+export async function handleWebFetchTool(
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<WebFetchToolResult> {
+  try {
+    switch (toolName) {
+      case 'web_fetch': {
+        const data = await fetchUrl(args.url as string, {
+          format: args.format as 'text' | 'html' | undefined,
+          timeoutMs: args.timeoutMs as number | undefined,
+          maxBytes: args.maxBytes as number | undefined,
+        });
+        return { success: true, data };
+      }
+      default:
+        return { success: false, error: `Unknown web-fetch tool: ${toolName}` };
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/packages/mcp-web-fetch/src/tools.ts
+++ b/packages/mcp-web-fetch/src/tools.ts
@@ -28,11 +28,15 @@ export const webFetchSchema = {
       },
       timeoutMs: {
         type: 'number',
-        description: '请求超时时间（毫秒），默认 15000',
+        minimum: 1,
+        maximum: 60000,
+        description: '请求超时时间（毫秒），默认 15000，硬上限 60000',
       },
       maxBytes: {
         type: 'number',
-        description: '响应体最大字节数，超出后截断，默认 2000000',
+        minimum: 1,
+        maximum: 5000000,
+        description: '响应体最大字节数，超出后截断，默认 2000000，硬上限 5000000',
       },
     },
     required: ['url'],

--- a/packages/mcp-web-fetch/src/types.ts
+++ b/packages/mcp-web-fetch/src/types.ts
@@ -1,0 +1,11 @@
+import type { FetchResult } from './engine.js';
+
+export type { FetchOptions, FetchResult } from './engine.js';
+
+export const VERSION = '2.1.1';
+
+export interface WebFetchToolResult {
+  success: boolean;
+  data?: FetchResult;
+  error?: string;
+}

--- a/packages/mcp-web-fetch/src/url-safety.test.ts
+++ b/packages/mcp-web-fetch/src/url-safety.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isBlockedHostname,
+  isPrivateIpv4,
+  isPrivateIpv6,
+  parseAndValidateUrl,
+  UrlSafetyError,
+} from './url-safety.js';
+
+describe('isPrivateIpv4', () => {
+  it('returns true for private/loopback/link-local addresses', () => {
+    expect(isPrivateIpv4('127.0.0.1')).toBe(true);
+    expect(isPrivateIpv4('10.0.0.1')).toBe(true);
+    expect(isPrivateIpv4('192.168.1.1')).toBe(true);
+    expect(isPrivateIpv4('172.16.0.1')).toBe(true);
+    expect(isPrivateIpv4('169.254.169.254')).toBe(true);
+  });
+
+  it('returns false for public addresses', () => {
+    expect(isPrivateIpv4('8.8.8.8')).toBe(false);
+    expect(isPrivateIpv4('1.1.1.1')).toBe(false);
+  });
+});
+
+describe('isPrivateIpv6', () => {
+  it('returns true for loopback/ULA/link-local addresses', () => {
+    expect(isPrivateIpv6('::1')).toBe(true);
+    expect(isPrivateIpv6('fe80::1')).toBe(true);
+    expect(isPrivateIpv6('fc00::1')).toBe(true);
+  });
+
+  it('returns false for public addresses', () => {
+    expect(isPrivateIpv6('2606:4700::1')).toBe(false);
+  });
+});
+
+describe('isBlockedHostname', () => {
+  it('returns true for localhost and private IP literals', () => {
+    expect(isBlockedHostname('localhost')).toBe(true);
+    expect(isBlockedHostname('127.0.0.1')).toBe(true);
+    expect(isBlockedHostname('foo.localhost')).toBe(true);
+    expect(isBlockedHostname('printer.local')).toBe(true);
+  });
+
+  it('returns false for normal public hostnames', () => {
+    expect(isBlockedHostname('example.com')).toBe(false);
+  });
+});
+
+describe('parseAndValidateUrl', () => {
+  it('throws for unsupported protocols', () => {
+    expect(() => parseAndValidateUrl('ftp://x')).toThrow(UrlSafetyError);
+    expect(() => parseAndValidateUrl('file:///etc/passwd')).toThrow(UrlSafetyError);
+  });
+
+  it('throws for embedded credentials', () => {
+    expect(() => parseAndValidateUrl('http://user:pass@example.com')).toThrow(UrlSafetyError);
+  });
+
+  it('throws for blocked hosts', () => {
+    expect(() => parseAndValidateUrl('http://localhost/')).toThrow(UrlSafetyError);
+    expect(() => parseAndValidateUrl('http://127.0.0.1/')).toThrow(UrlSafetyError);
+  });
+
+  it('returns a URL for valid public addresses', () => {
+    const url = parseAndValidateUrl('https://example.com/docs');
+    expect(url).toBeInstanceOf(URL);
+    expect(url.hostname).toBe('example.com');
+  });
+
+  it('denyHosts blocks specified hosts', () => {
+    expect(() =>
+      parseAndValidateUrl('https://example.com/', { denyHosts: ['example.com'] }),
+    ).toThrow(UrlSafetyError);
+  });
+
+  it('allowHosts restricts to specified hosts', () => {
+    expect(() =>
+      parseAndValidateUrl('https://example.com/', { allowHosts: ['other.com'] }),
+    ).toThrow(UrlSafetyError);
+    const url = parseAndValidateUrl('https://example.com/', { allowHosts: ['example.com'] });
+    expect(url.hostname).toBe('example.com');
+  });
+});

--- a/packages/mcp-web-fetch/src/url-safety.test.ts
+++ b/packages/mcp-web-fetch/src/url-safety.test.ts
@@ -27,10 +27,22 @@ describe('isPrivateIpv6', () => {
     expect(isPrivateIpv6('::1')).toBe(true);
     expect(isPrivateIpv6('fe80::1')).toBe(true);
     expect(isPrivateIpv6('fc00::1')).toBe(true);
+    expect(isPrivateIpv6('::')).toBe(true);
+  });
+
+  it('returns true for IPv4-mapped/compatible addresses with private embedded IPv4, in dotted and hex hextet forms', () => {
+    expect(isPrivateIpv6('::ffff:127.0.0.1')).toBe(true);
+    expect(isPrivateIpv6('::ffff:7f00:1')).toBe(true);
+    expect(isPrivateIpv6('::ffff:0a00:1')).toBe(true);
+    expect(isPrivateIpv6('::ffff:192.168.1.1')).toBe(true);
+    expect(isPrivateIpv6('0:0:0:0:0:ffff:127.0.0.1')).toBe(true);
+    expect(isPrivateIpv6('0:0:0:0:0:ffff:7f00:1')).toBe(true);
   });
 
   it('returns false for public addresses', () => {
     expect(isPrivateIpv6('2606:4700::1')).toBe(false);
+    expect(isPrivateIpv6('2606:4700:4700::1111')).toBe(false);
+    expect(isPrivateIpv6('2001:4860:4860::8888')).toBe(false);
   });
 });
 
@@ -80,5 +92,15 @@ describe('parseAndValidateUrl', () => {
     ).toThrow(UrlSafetyError);
     const url = parseAndValidateUrl('https://example.com/', { allowHosts: ['example.com'] });
     expect(url.hostname).toBe('example.com');
+  });
+
+  it('rejects IPv4-mapped IPv6 literals that resolve to private addresses', () => {
+    expect(() => parseAndValidateUrl('http://[::ffff:7f00:1]/')).toThrow(UrlSafetyError);
+    expect(() => parseAndValidateUrl('http://[::ffff:0a00:1]/')).toThrow(UrlSafetyError);
+  });
+
+  it('accepts a public IPv6 literal', () => {
+    const url = parseAndValidateUrl('https://[2606:4700:4700::1111]/');
+    expect(url).toBeInstanceOf(URL);
   });
 });

--- a/packages/mcp-web-fetch/src/url-safety.ts
+++ b/packages/mcp-web-fetch/src/url-safety.ts
@@ -1,0 +1,190 @@
+import dns from 'node:dns';
+
+export class UrlSafetyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UrlSafetyError';
+  }
+}
+
+/**
+ * Returns true if the given dotted-quad IPv4 address falls within a
+ * private, loopback, link-local, unspecified, or CGNAT range.
+ */
+export function isPrivateIpv4(ip: string): boolean {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return false;
+
+  const octets: number[] = [];
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return false;
+    const n = Number(part);
+    if (n < 0 || n > 255) return false;
+    octets.push(n);
+  }
+  const [a, b] = octets;
+
+  // 0.0.0.0/8
+  if (a === 0) return true;
+  // 10.0.0.0/8
+  if (a === 10) return true;
+  // 100.64.0.0/10 (CGNAT)
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  // 127.0.0.0/8 (loopback)
+  if (a === 127) return true;
+  // 169.254.0.0/16 (link-local, incl. 169.254.169.254 metadata)
+  if (a === 169 && b === 254) return true;
+  // 172.16.0.0/12
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.168.0.0/16
+  if (a === 192 && b === 168) return true;
+
+  return false;
+}
+
+/**
+ * Returns true if the given IPv6 address is loopback, unique-local,
+ * link-local, unspecified, or an IPv4-mapped address whose embedded
+ * IPv4 address is private.
+ */
+export function isPrivateIpv6(ip: string): boolean {
+  const normalized = ip.toLowerCase().trim();
+
+  // Unspecified
+  if (normalized === '::') return true;
+  // Loopback
+  if (normalized === '::1') return true;
+
+  // IPv4-mapped: ::ffff:x.x.x.x
+  const v4MappedMatch = normalized.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (v4MappedMatch) {
+    return isPrivateIpv4(v4MappedMatch[1]);
+  }
+
+  // fc00::/7 (Unique Local Address) -> first 7 bits are 1111 110x
+  // i.e. first hex group's value, when masked, falls in 0xfc00-0xfdff
+  const firstGroup = normalized.split(':')[0];
+  if (/^[0-9a-f]{1,4}$/.test(firstGroup)) {
+    const value = parseInt(firstGroup, 16);
+    // fc00::/7 => top 7 bits of first 16-bit group are 1111110
+    if ((value & 0xfe00) === 0xfc00) return true;
+    // fe80::/10 (link-local) => top 10 bits are 1111111010
+    if ((value & 0xffc0) === 0xfe80) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Returns true if the host should be blocked outright: localhost,
+ * *.localhost, *.local, or a literal IP address that is private.
+ */
+export function isBlockedHostname(host: string): boolean {
+  const h = host.toLowerCase().trim();
+
+  if (h === 'localhost') return true;
+  if (h.endsWith('.localhost')) return true;
+  if (h.endsWith('.local')) return true;
+
+  // Strip brackets from literal IPv6 hosts, e.g. "[::1]"
+  const bare = h.startsWith('[') && h.endsWith(']') ? h.slice(1, -1) : h;
+
+  // IPv4 literal
+  if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(bare)) {
+    return isPrivateIpv4(bare);
+  }
+
+  // IPv6 literal (contains a colon)
+  if (bare.includes(':')) {
+    return isPrivateIpv6(bare);
+  }
+
+  return false;
+}
+
+/**
+ * Parses and validates a URL for safe outbound fetching.
+ *
+ * Throws UrlSafetyError unless:
+ *  - protocol is http: or https:
+ *  - there are no embedded credentials (username/password)
+ *  - a host is present
+ *  - the host is not in opts.denyHosts
+ *  - if opts.allowHosts is given, the host must be in it
+ *  - the host is not blocked per isBlockedHostname
+ */
+export function parseAndValidateUrl(
+  rawUrl: string,
+  opts?: { allowHosts?: string[]; denyHosts?: string[] },
+): URL {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new UrlSafetyError(`Invalid URL: ${rawUrl}`);
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new UrlSafetyError(`Unsupported protocol: ${url.protocol}`);
+  }
+
+  if (url.username || url.password) {
+    throw new UrlSafetyError('URLs with embedded credentials are not allowed');
+  }
+
+  const host = url.hostname;
+  if (!host) {
+    throw new UrlSafetyError('URL has no host');
+  }
+
+  const lowerHost = host.toLowerCase();
+
+  if (opts?.denyHosts?.some((h) => h.toLowerCase() === lowerHost)) {
+    throw new UrlSafetyError(`Host is denied: ${host}`);
+  }
+
+  if (opts?.allowHosts && opts.allowHosts.length > 0) {
+    if (!opts.allowHosts.some((h) => h.toLowerCase() === lowerHost)) {
+      throw new UrlSafetyError(`Host is not in allow list: ${host}`);
+    }
+  }
+
+  if (isBlockedHostname(host)) {
+    throw new UrlSafetyError(`Host is blocked: ${host}`);
+  }
+
+  return url;
+}
+
+/**
+ * Resolves the given hostname via DNS and throws UrlSafetyError if any
+ * resolved address is private. If the host is already a literal IP
+ * address, it is validated directly without performing DNS lookups.
+ */
+export async function assertResolvedHostSafe(host: string): Promise<void> {
+  const bare = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+
+  // Literal IPv4
+  if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(bare)) {
+    if (isPrivateIpv4(bare)) {
+      throw new UrlSafetyError(`Host resolves to a private address: ${bare}`);
+    }
+    return;
+  }
+
+  // Literal IPv6
+  if (bare.includes(':')) {
+    if (isPrivateIpv6(bare)) {
+      throw new UrlSafetyError(`Host resolves to a private address: ${bare}`);
+    }
+    return;
+  }
+
+  const results = await dns.promises.lookup(host, { all: true });
+  for (const { address, family } of results) {
+    const isPrivate = family === 6 ? isPrivateIpv6(address) : isPrivateIpv4(address);
+    if (isPrivate) {
+      throw new UrlSafetyError(`Host resolves to a private address: ${host} -> ${address}`);
+    }
+  }
+}

--- a/packages/mcp-web-fetch/src/url-safety.ts
+++ b/packages/mcp-web-fetch/src/url-safety.ts
@@ -1,5 +1,3 @@
-import dns from 'node:dns';
-
 export class UrlSafetyError extends Error {
   constructor(message: string) {
     super(message);
@@ -157,34 +155,10 @@ export function parseAndValidateUrl(
 }
 
 /**
- * Resolves the given hostname via DNS and throws UrlSafetyError if any
- * resolved address is private. If the host is already a literal IP
- * address, it is validated directly without performing DNS lookups.
+ * Returns true if the given resolved connection address (IPv4 or IPv6,
+ * without brackets) is private, loopback, link-local, or otherwise
+ * unsafe to connect to.
  */
-export async function assertResolvedHostSafe(host: string): Promise<void> {
-  const bare = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
-
-  // Literal IPv4
-  if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(bare)) {
-    if (isPrivateIpv4(bare)) {
-      throw new UrlSafetyError(`Host resolves to a private address: ${bare}`);
-    }
-    return;
-  }
-
-  // Literal IPv6
-  if (bare.includes(':')) {
-    if (isPrivateIpv6(bare)) {
-      throw new UrlSafetyError(`Host resolves to a private address: ${bare}`);
-    }
-    return;
-  }
-
-  const results = await dns.promises.lookup(host, { all: true });
-  for (const { address, family } of results) {
-    const isPrivate = family === 6 ? isPrivateIpv6(address) : isPrivateIpv4(address);
-    if (isPrivate) {
-      throw new UrlSafetyError(`Host resolves to a private address: ${host} -> ${address}`);
-    }
-  }
+export function isConnectionAddressBlocked(address: string): boolean {
+  return isPrivateIpv4(address) || isPrivateIpv6(address);
 }

--- a/packages/mcp-web-fetch/src/url-safety.ts
+++ b/packages/mcp-web-fetch/src/url-safety.ts
@@ -1,3 +1,5 @@
+import { isIP } from 'node:net';
+
 export class UrlSafetyError extends Error {
   constructor(message: string) {
     super(message);
@@ -41,34 +43,110 @@ export function isPrivateIpv4(ip: string): boolean {
 }
 
 /**
+ * Parses an IPv6 address string into its 8 16-bit hextets.
+ *
+ * Strips a zone id (e.g. "%eth0") and surrounding brackets, expands the
+ * "::" zero-run shorthand, and converts an embedded dotted-quad IPv4
+ * tail (e.g. "::ffff:127.0.0.1") into two trailing hextets.
+ *
+ * Returns null if `addr` is not a valid IPv6 address per `net.isIP`, or
+ * if it is otherwise malformed.
+ */
+export function expandIpv6(addr: string): number[] | null {
+  let normalized = addr.trim().toLowerCase();
+
+  // Strip surrounding brackets, e.g. "[::1]"
+  if (normalized.startsWith('[') && normalized.endsWith(']')) {
+    normalized = normalized.slice(1, -1);
+  }
+
+  // Strip zone id, e.g. "fe80::1%eth0"
+  const zoneIndex = normalized.indexOf('%');
+  if (zoneIndex !== -1) {
+    normalized = normalized.slice(0, zoneIndex);
+  }
+
+  if (isIP(normalized) !== 6) return null;
+
+  // If the address ends with a dotted-quad IPv4 tail (e.g.
+  // "::ffff:127.0.0.1"), convert it into two hex groups first.
+  const lastColon = normalized.lastIndexOf(':');
+  const tail = normalized.slice(lastColon + 1);
+  if (tail.includes('.')) {
+    const octets = tail.split('.');
+    if (octets.length !== 4) return null;
+    const nums: number[] = [];
+    for (const o of octets) {
+      if (!/^\d{1,3}$/.test(o)) return null;
+      const n = Number(o);
+      if (n < 0 || n > 255) return null;
+      nums.push(n);
+    }
+    const hi = ((nums[0] << 8) | nums[1]).toString(16);
+    const lo = ((nums[2] << 8) | nums[3]).toString(16);
+    normalized = `${normalized.slice(0, lastColon + 1)}${hi}:${lo}`;
+  }
+
+  const parts = normalized.split('::');
+  if (parts.length > 2) return null;
+
+  const head = parts[0].length > 0 ? parts[0].split(':') : [];
+  const tailGroups = parts.length === 2 && parts[1].length > 0 ? parts[1].split(':') : [];
+
+  let groups: string[];
+  if (parts.length === 2) {
+    const missing = 8 - (head.length + tailGroups.length);
+    if (missing < 0) return null;
+    groups = [...head, ...Array(missing).fill('0'), ...tailGroups];
+  } else {
+    groups = head;
+  }
+
+  if (groups.length !== 8) return null;
+
+  const hextets: number[] = [];
+  for (const g of groups) {
+    if (!/^[0-9a-f]{1,4}$/.test(g)) return null;
+    hextets.push(parseInt(g, 16));
+  }
+
+  return hextets;
+}
+
+/**
  * Returns true if the given IPv6 address is loopback, unique-local,
- * link-local, unspecified, or an IPv4-mapped address whose embedded
- * IPv4 address is private.
+ * link-local, unspecified, IPv4-mapped/IPv4-compatible with a private
+ * embedded IPv4 address, or otherwise reserved for local use.
  */
 export function isPrivateIpv6(ip: string): boolean {
-  const normalized = ip.toLowerCase().trim();
+  const h = expandIpv6(ip);
+  if (!h) return false;
 
-  // Unspecified
-  if (normalized === '::') return true;
-  // Loopback
-  if (normalized === '::1') return true;
+  const isZero = (n: number) => n === 0;
 
-  // IPv4-mapped: ::ffff:x.x.x.x
-  const v4MappedMatch = normalized.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
-  if (v4MappedMatch) {
-    return isPrivateIpv4(v4MappedMatch[1]);
+  // Unspecified ::
+  if (h.every(isZero)) return true;
+
+  // Loopback ::1
+  if (h.slice(0, 7).every(isZero) && h[7] === 1) return true;
+
+  // IPv4-mapped ::ffff:a.b.c.d
+  if (h.slice(0, 5).every(isZero) && h[5] === 0xffff) {
+    const v4 = `${h[6] >> 8}.${h[6] & 0xff}.${h[7] >> 8}.${h[7] & 0xff}`;
+    return isPrivateIpv4(v4);
   }
 
-  // fc00::/7 (Unique Local Address) -> first 7 bits are 1111 110x
-  // i.e. first hex group's value, when masked, falls in 0xfc00-0xfdff
-  const firstGroup = normalized.split(':')[0];
-  if (/^[0-9a-f]{1,4}$/.test(firstGroup)) {
-    const value = parseInt(firstGroup, 16);
-    // fc00::/7 => top 7 bits of first 16-bit group are 1111110
-    if ((value & 0xfe00) === 0xfc00) return true;
-    // fe80::/10 (link-local) => top 10 bits are 1111111010
-    if ((value & 0xffc0) === 0xfe80) return true;
+  // IPv4-compatible (deprecated) ::a.b.c.d
+  if (h.slice(0, 6).every(isZero)) {
+    const v4 = `${h[6] >> 8}.${h[6] & 0xff}.${h[7] >> 8}.${h[7] & 0xff}`;
+    return isPrivateIpv4(v4);
   }
+
+  // fc00::/7 (Unique Local Address) -> top 7 bits are 1111110
+  if ((h[0] & 0xfe00) === 0xfc00) return true;
+
+  // fe80::/10 (link-local) -> top 10 bits are 1111111010
+  if ((h[0] & 0xffc0) === 0xfe80) return true;
 
   return false;
 }

--- a/packages/mcp-web-fetch/tsconfig.json
+++ b/packages/mcp-web-fetch/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/mcp-web-fetch/vitest.config.ts
+++ b/packages/mcp-web-fetch/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: ['dist/**', 'node_modules/**'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,6 +341,18 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/mcp-web-fetch:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
+
   packages/runtime-node:
     dependencies:
       '@frontagent/core':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,10 @@ importers:
         version: 6.0.3
 
   packages/mcp-web-fetch:
+    dependencies:
+      undici:
+        specifier: ^6.21.0
+        version: 6.26.0
     devDependencies:
       '@types/node':
         specifier: ^25.9.1


### PR DESCRIPTION
## What & why

Step 2 of 3 for #357 (agent web-fetch capability, learned from CLAUDE-FABLE-5 `web_fetch`). Adds a new workspace package `@frontagent/mcp-web-fetch` providing a `web_fetch` MCP tool — fetch a URL and return cleaned, readable text (HTML→text) for looking up library/framework docs, API references, and error resolutions during planning/execution.

This is delivered as an **incremental, small-step PR**: the package is added and fully tested but **not yet wired** into the agent's MCP client registries. Wiring + planner-prompt note is the next PR.

Part of #357.

## Design — mirrors `@frontagent/mcp-filesense`

- Zero runtime deps; ports its logic from the standalone `ceilf6/websense` repo (same pattern as mcp-filesense porting the filesense engine rather than depending on the npm package).
- `*Schema` + `handle*Tool` dispatch shape; `tools.security.test.ts` like filesense's path-containment test.
- **SSRF-hardened** (the security core): `url-safety.ts` rejects private/loopback/link-local/CGNAT and cloud-metadata (169.254.169.254) hosts, rejects non-http(s) and embedded credentials, and does a DNS-resolution check (`assertResolvedHostSafe`) to defend against DNS-rebinding. The engine re-validates safety on every redirect hop, with an AbortController timeout and a byte cap.

## web_fetch tool

`web_fetch(url, format?, timeoutMs?, maxBytes?)` → `{ url, finalUrl, status, contentType, title, text, bytes, truncated }`. Unsafe URLs are rejected **before any network access** (synchronous url-safety check), which the security test relies on (no network in tests).

## Verification

- `pnpm --filter @frontagent/mcp-web-fetch build` — tsc clean
- `pnpm --filter @frontagent/mcp-web-fetch test` — 25 tests pass (url-safety, html-to-text, tools.security)
- `pnpm --filter @frontagent/mcp-web-fetch typecheck` — clean
- root `biome check` — clean; `quality:precommit` hook green (lint/typecheck/test/test:workflows 32/32)

## GitNexus Impact Summary

- **Risk level**: LOW
- **Critical skeleton changes**: None — purely additive new package; nothing imports it yet (unwired). No existing symbol, contract, or assembly path modified.
- **GitNexus impact**: `detect_changes(all)` → 0 changed symbols, 0 affected processes, risk low (only new files + `pnpm-lock.yaml`). No `impact()` target since no existing symbol is edited.
- **Verification**: package build/test/typecheck/biome clean; full precommit gates green (above).

## Security note

The `tools.security.test.ts` asserts that loopback (`127.0.0.1`), `localhost`, cloud-metadata (`169.254.169.254`), `file://`, `ftp://`, and credential-bearing URLs are all rejected without performing any network I/O.