### PR TITLE
feat(web-fetch): wire @frontagent/mcp-web-fetch into the agent registry & planner (#357)

### DIFF
--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -1,5 +1,6 @@
 import type { ExecutionStep } from '@frontagent/shared';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { Executor } from '../executor.js';
 import { createAgent } from './agent.js';
 import { generateOutput } from './answer-generation.js';
 
@@ -211,5 +212,27 @@ describe('createAgent', () => {
     const executorSnap = agent.getExecutorSkillSnapshot();
     expect(plannerSnap.taskSkills).toBeInstanceOf(Array);
     expect(executorSnap.actionSkills).toBeInstanceOf(Array);
+  });
+});
+
+describe('registerWebTools routing contract', () => {
+  it('routes web_fetch and the browser tools to the web client', () => {
+    const spy = vi.spyOn(Executor.prototype, 'registerToolMapping');
+    try {
+      const agent = createAgent({
+        projectRoot: '/test',
+        llm: { provider: 'openai', model: 'gpt-4', apiKey: 'test-key' },
+      });
+      agent.registerWebTools();
+      const webTools = spy.mock.calls
+        .filter(([, client]) => client === 'web')
+        .map(([tool]) => tool);
+      // web_fetch must route to the same 'web' client as the browser tools so
+      // the executor can dispatch it to WebMCPClient.callTool.
+      expect(webTools).toContain('web_fetch');
+      expect(webTools).toContain('browser_navigate');
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -269,6 +269,7 @@ export class FrontAgent {
       'scroll',
       'screenshot',
       'wait_for_selector',
+      'web_fetch',
     ];
     for (const tool of tools) {
       this.executor.registerToolMapping(tool, 'web');

--- a/packages/core/src/llm/plan-generation.ts
+++ b/packages/core/src/llm/plan-generation.ts
@@ -129,6 +129,7 @@ export async function generatePlanInTwoPhases(
 - **browser_navigate**: 浏览器访问URL（⚠️ 使用上下文中提供的"开发服务器端口"）
 - **browser_screenshot**: 页面截图
 - **get_page_structure**: 获取页面DOM结构
+- **web_fetch**: 抓取 URL 网页内容并清洗为纯文本（HTML→text），用于查阅库/框架文档、API 参考等外部资料
 
 ${PROGRESSIVE_EXPLORATION_PROTOCOL}
 
@@ -271,6 +272,7 @@ ${options.skillContext ?? '无已激活内容技能'}
   如果上下文中提供了端口信息，使用 http://localhost:{端口}/
 - **browser_screenshot**: params 可选 fullPage: true
 - **get_page_structure**: params 可为空对象
+- **web_fetch**: params 需要 url
 
 # 重要提示
 - create_file 和 apply_patch 必须设置 needsCodeGeneration: true
@@ -422,6 +424,7 @@ async function generatePlanSinglePhase(
 - **browser_navigate**: { url: "地址" }
 - **browser_screenshot**: { fullPage: true }
 - **get_page_structure**: {}
+- **web_fetch**: { url: "地址" }
 
 ${PROGRESSIVE_EXPLORATION_PROTOCOL}
 

--- a/packages/core/src/llm/schemas.ts
+++ b/packages/core/src/llm/schemas.ts
@@ -13,6 +13,7 @@ const ACTION_ENUM = [
   'browser_click',
   'browser_type',
   'browser_screenshot',
+  'web_fetch',
 ] as const;
 
 const STEP_PARAMS_SCHEMA = z

--- a/packages/runtime-node/package.json
+++ b/packages/runtime-node/package.json
@@ -25,6 +25,7 @@
     "@frontagent/mcp-memory": "workspace:*",
     "@frontagent/mcp-shell": "workspace:*",
     "@frontagent/mcp-web": "workspace:*",
+    "@frontagent/mcp-web-fetch": "workspace:*",
     "@frontagent/sdd": "workspace:*",
     "@frontagent/shared": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/runtime-node/src/mcp-clients.test.ts
+++ b/packages/runtime-node/src/mcp-clients.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { WebMCPClient } from './mcp-clients.js';
+
+describe('WebMCPClient web_fetch wiring', () => {
+  it('lists web_fetch as an available tool', async () => {
+    // Construction is cheap: the playwright browser is launched lazily, not in
+    // the constructor, so this stays hermetic (no browser, no network).
+    const client = new WebMCPClient();
+    const tools = await client.listTools();
+    const names = tools.map((tool) => tool.name);
+
+    expect(names).toContain('web_fetch');
+    // Sanity: the existing browser tools are still present alongside it.
+    expect(names).toContain('browser_navigate');
+  });
+
+  it('throws for an unknown web tool', async () => {
+    const client = new WebMCPClient();
+    await expect(client.callTool('definitely_not_a_tool', {})).rejects.toThrow(/Unknown web tool/);
+  });
+});

--- a/packages/runtime-node/src/mcp-clients.ts
+++ b/packages/runtime-node/src/mcp-clients.ts
@@ -21,6 +21,7 @@ import {
   type RagQueryParams,
 } from '@frontagent/mcp-memory';
 import { type BrowserManager, createBrowserManager } from '@frontagent/mcp-web';
+import { handleWebFetchTool } from '@frontagent/mcp-web-fetch';
 
 export class FileMCPClient implements MCPClient {
   private readonly snapshotManager: SnapshotManager;
@@ -143,6 +144,8 @@ export class WebMCPClient implements MCPClient {
         const { selector, timeout } = args as { selector: string; timeout?: number };
         return this.browserManager.waitForSelector(selector, timeout);
       }
+      case 'web_fetch':
+        return handleWebFetchTool(name, args);
       default:
         throw new Error(`Unknown web tool: ${name}`);
     }
@@ -159,6 +162,11 @@ export class WebMCPClient implements MCPClient {
       { name: 'browser_scroll', description: '滚动页面' },
       { name: 'browser_screenshot', description: '截取页面截图' },
       { name: 'browser_wait_for_selector', description: '等待元素出现' },
+      {
+        name: 'web_fetch',
+        description:
+          '抓取 URL 网页内容并清洗为可读文本（HTML→text），用于查阅文档/API 参考；内置 SSRF 防护',
+      },
     ];
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,6 +377,9 @@ importers:
       '@frontagent/mcp-web':
         specifier: workspace:*
         version: link:../mcp-web
+      '@frontagent/mcp-web-fetch':
+        specifier: workspace:*
+        version: link:../mcp-web-fetch
       '@frontagent/sdd':
         specifier: workspace:*
         version: link:../sdd


### PR DESCRIPTION
## Linked Issue Or Context

Closes #357. Increment 3/3 of the agent web-fetch capability (after #358 added the unwired `@frontagent/mcp-web-fetch` adapter). Learned from `CLAUDE-FABLE-5.md`'s `web_fetch` tool.

## Summary

Wires the previously-unwired `@frontagent/mcp-web-fetch` adapter so the agent can actually call the `web_fetch` tool, and surfaces it to the two-phase planner.

- **runtime-node** (`mcp-clients.ts`): register `web_fetch` in `WebMCPClient.callTool` + `listTools`, delegating to `handleWebFetchTool`. No browser launch — playwright is lazy, so `web_fetch` stays decoupled from the browser tools that share the client.
- **core/agent** (`agent.ts`): add `web_fetch` to `registerWebTools()` so the executor routes it to the `'web'` client (mirrors how `filesense_*` is routed via the `'file'` client in `registerFileTools()`).
- **core/schemas** (`schemas.ts`): add `web_fetch` to `ACTION_ENUM` so planner-emitted steps with action `web_fetch` pass `StepSchema` validation (`url` param already exists in `STEP_PARAMS_SCHEMA`). Treated like `browser_navigate`.
- **core/plan-generation** (`plan-generation.ts`): mention `web_fetch` in both `# 可用工具` prompt regions + a param hint, so the planner knows it can fetch external docs / API references.
- add `@frontagent/mcp-web-fetch` workspace dep to runtime-node.

### Why `web_fetch` is added to `ACTION_ENUM` (unlike `filesense_*`)

This increment's directive is to give the planner a prompt mention of `web_fetch`. Planner steps are zod-validated against `ACTION_ENUM` (`StepSchema.action = z.enum(ACTION_ENUM)`), so mentioning the tool in the prompt without the enum entry would invite the planner to emit a step that fails validation. Prompt-mention and enum-inclusion are therefore coupled. `filesense_*` is deliberately NOT planner-surfaced, so it stays registry-only; `web_fetch` is, so it is treated like `browser_navigate`.

### On the `cli` MCP registry (issue acceptance criterion)

#357's acceptance criteria list "registered in `runtime-node` + `cli` MCP client registries". Investigation shows `apps/cli/src/mcp-client.ts` is **dead code**: it is imported nowhere in `apps/cli/src` (the CLI commands delegate to `runFrontAgentTask` from `@frontagent/runtime-node`, which uses `runtime-node/src/mcp-clients.ts`), the package `main` is `dist/index.js`, and no test references its classes. The `@frontagent/mcp-filesense` precedent was likewise never wired into this dead CLI copy. Wiring it would add a dependency for a never-instantiated class (low-value churn). The live registry — `runtime-node` — is wired here. Deleting the dead CLI copy is noted as a possible follow-up cleanup, out of scope for this focused PR.

## Impact Scope

MVP scope only: no `web_search`, no planner when-to-search heuristics (deferred to follow-up issues). SSRF guards live in the adapter (#358) with their own security tests.

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: `packages/core/src/agent/agent.ts` (agent-core, covered by new test in `agent.test.ts`) and `packages/runtime-node/src/mcp-clients.ts` (mcp-boundary, covered by new `mcp-clients.test.ts`). Additive only — new switch `case`, `listTools` entry, `ACTION_ENUM` member, planner prompt lines, and one `registerWebTools` entry; no signature changes, nothing removed, no caller broken.
- GitNexus impact: `detect_changes` reports exactly the expected touched symbols — `registerWebTools`, `WebMCPClient.callTool`, `generatePlanInTwoPhases`/`generatePlanSinglePhase` (planner prompt builders) — and only the expected processes (`CallTool` tool dispatch + adapter SSRF chains, `GeneratePlan`). `impact ACTION_ENUM` = LOW (0 upstream); `impact WebMCPClient` = structurally HIGH but the edit is additive. No unexpected scope.
- Verification: `pnpm contract:local` passes (both critical boundaries have matching tests); `pnpm quality:precommit` passes (lint, typecheck, all unit tests, 32 workflow tests).

## Verification

- `contract:local`: passed.
- Touched-package tests: core 696 pass (incl. new `registerWebTools routing contract`), runtime-node 93 pass (incl. new hermetic `mcp-clients.test.ts`).
- biome clean on all touched files.
- Full `quality:precommit` green via pre-commit hook; pushed through the `quality:local` pre-push gate.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)