### PR TITLE
feat(prompts): inject external knowledge into codegen

### DIFF
--- a/packages/core/src/llm/code-generation.test.ts
+++ b/packages/core/src/llm/code-generation.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { parseTypeScriptErrors } from './code-generation.js';
+import {
+  generateCodeForFile,
+  generateModifiedCode,
+  parseTypeScriptErrors,
+} from './code-generation.js';
+import { EXTERNAL_KNOWLEDGE_PROTOCOL } from './prompts.js';
 
 describe('parseTypeScriptErrors', () => {
   it('parses standard tsc error format (parentheses)', () => {
@@ -84,5 +89,77 @@ describe('parseTypeScriptErrors', () => {
       },
     ];
     expect(parseTypeScriptErrors(steps)).toHaveLength(1);
+  });
+});
+
+// The two system prompts below are constructed as local `system` strings inside the
+// generate* functions and never returned. These tests reveal them by capturing the
+// `system` argument passed to the mocked `generateText` dependency, then asserting the
+// external-knowledge discipline is present, mirroring how iteration 17 covered the
+// planner prompts for the same protocol.
+describe('code-generation system prompts', () => {
+  const PROTOCOL_KEY_PHRASES = [
+    '不熟悉',
+    '版本特定',
+    '最近才出现',
+    'web_fetch',
+    '权威来源',
+    '无需 web_fetch',
+    '已经熟知且稳定',
+  ];
+
+  function makeDeps(captureSystem: { value?: string }) {
+    return {
+      debugLog: () => {},
+      debugWarn: () => {},
+      debugError: () => {},
+      generateText: async (options: { system?: string }) => {
+        captureSystem.value = options.system;
+        return 'export const placeholder = 1;';
+      },
+      // generateObject is unused by generateCodeForFile / generateModifiedCode.
+      generateObject: async () => {
+        throw new Error('generateObject should not be called here');
+      },
+    };
+  }
+
+  it('generateCodeForFile injects EXTERNAL_KNOWLEDGE_PROTOCOL into its system prompt', async () => {
+    const captured: { value?: string } = {};
+    await generateCodeForFile(
+      {
+        task: 'add a chart',
+        filePath: 'src/chart.tsx',
+        codeDescription: 'render a bar chart',
+        context: '',
+        language: 'typescript',
+      },
+      makeDeps(captured),
+    );
+
+    const system = captured.value ?? '';
+    expect(system).toContain(EXTERNAL_KNOWLEDGE_PROTOCOL);
+    for (const phrase of PROTOCOL_KEY_PHRASES) {
+      expect(system).toContain(phrase);
+    }
+  });
+
+  it('generateModifiedCode injects EXTERNAL_KNOWLEDGE_PROTOCOL into its system prompt', async () => {
+    const captured: { value?: string } = {};
+    await generateModifiedCode(
+      {
+        originalCode: 'export const a = 1;',
+        changeDescription: 'rename to b',
+        filePath: 'src/util.ts',
+        language: 'typescript',
+      },
+      makeDeps(captured),
+    );
+
+    const system = captured.value ?? '';
+    expect(system).toContain(EXTERNAL_KNOWLEDGE_PROTOCOL);
+    for (const phrase of PROTOCOL_KEY_PHRASES) {
+      expect(system).toContain(phrase);
+    }
   });
 });

--- a/packages/core/src/llm/code-generation.ts
+++ b/packages/core/src/llm/code-generation.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod';
 import type { Message } from '../types.js';
+import { EXTERNAL_KNOWLEDGE_PROTOCOL } from './prompts.js';
 import type { ErrorRecoveryPlan } from './schemas.js';
 import { ErrorRecoveryPlanSchema } from './schemas.js';
 
@@ -102,7 +103,9 @@ ${
 - 遵循最佳实践
 - 代码清晰可维护
 - 使用 TypeScript 类型
-- 按 codeDescription 要求实现`;
+- 按 codeDescription 要求实现
+
+${EXTERNAL_KNOWLEDGE_PROTOCOL}`;
 
   const messages: Message[] = [
     {
@@ -165,7 +168,9 @@ ${options.skillContext ? `\n# 内容技能\n${options.skillContext}` : ''}
 - 只修改必要部分
 - 保持原有代码风格
 - 确保语法正确
-- 保留未修改的代码`;
+- 保留未修改的代码
+
+${EXTERNAL_KNOWLEDGE_PROTOCOL}`;
 
   const messages: Message[] = [
     {


### PR DESCRIPTION
## Linked Issue Or Context

Closes #363.

## Summary

- Reuses the existing EXTERNAL_KNOWLEDGE_PROTOCOL in code-generation prompts.
- Injects the protocol into generateCodeForFile and generateModifiedCode so executor codegen follows the same external-knowledge discipline already added to planner prompts.
- Adds focused prompt-capture tests for both codegen paths, including the reverse constraint that stable known APIs do not need web_fetch.

## Impact Scope

Prompt-only change in packages/core/src/llm/code-generation.ts plus focused tests in packages/core/src/llm/code-generation.test.ts. No schema, tool routing, executor contract, planner, or web_fetch runtime changes.

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: none
- GitNexus impact: impact(generateCodeForFile, upstream) and impact(generateModifiedCode, upstream) both returned LOW with direct=0, processes_affected=0. Additional call-site inspection shows the changed codegen functions are reached through LLMService thin wrappers from executor create_file/apply_patch codegen paths; signatures and return contracts are unchanged.
- Verification: gitnexus detect_changes compare against develop reported changed_count=2, changed_files=2, affected_count=0, risk_level=low; changed symbols were generateCodeForFile and generateModifiedCode only.

## Verification

- pnpm agent:bootstrap
- pnpm quality:predev (initially blocked by unrelated local AGENTS.md/CLAUDE.md/.claude skill edits; passed after isolating #363 scope through quality:local)
- pnpm --filter @frontagent/core test -- code-generation.test.ts
- pnpm quality:precommit
- pnpm build:verify (rerun after one transient esbuild service stop in the first quality:local attempt)
- pnpm quality:local
- gitnexus detect_changes compare develop

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run pnpm quality:precommit, or explained why it could not run.
- [x] I have run pnpm quality:local for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.