### PR TITLE
fix(planner): preserve web_fetch actions

### DIFF
--- a/packages/core/src/planner.test.ts
+++ b/packages/core/src/planner.test.ts
@@ -176,6 +176,36 @@ describe('Planner LLM-based plan generation', () => {
     expect(createStep).toBeDefined();
   });
 
+  it('preserves LLM-planned web_fetch actions and URL params', async () => {
+    const planner = createPlanner({ useLLM: true });
+    mockLLMGeneratePlan(planner, async () => ({
+      summary: '查阅官方文档',
+      steps: [
+        {
+          description: '抓取 API 文档',
+          action: 'web_fetch',
+          tool: 'web_fetch',
+          phase: '阶段1-分析',
+          params: defaultParams({ url: 'https://docs.example.com/api' }),
+          reasoning: '确认外部 API 行为',
+          needsCodeGeneration: false,
+        },
+      ],
+      risks: [],
+      alternatives: [],
+    }));
+
+    const result = await planner.plan(createTask({ type: 'create' }), emptyContext(), []);
+
+    const webFetchStep = result.plan!.steps.find((s) => s.action === 'web_fetch');
+    expect(result.needsMoreContext).toBe(false);
+    expect(webFetchStep).toMatchObject({
+      action: 'web_fetch',
+      tool: 'web_fetch',
+      params: expect.objectContaining({ url: 'https://docs.example.com/api' }),
+    });
+  });
+
   it('injects project instructions into the planning prompt context', async () => {
     const planner = createPlanner({ useLLM: true });
     const calls: Array<{ context: string }> = [];
@@ -341,6 +371,44 @@ describe('Planner step ordering and dependencies', () => {
     expect(readStep).toBeDefined();
     expect(searchStep).toBeDefined();
     expect(searchStep!.dependencies).not.toContain(readStep!.stepId);
+  });
+
+  it('allows web_fetch to share the read-only planning dependency policy', async () => {
+    const planner = createPlanner({ useLLM: true });
+    mockLLMGeneratePlan(planner, async () => ({
+      summary: '查阅资料并分析代码',
+      steps: [
+        {
+          description: '抓取官方文档',
+          action: 'web_fetch',
+          tool: 'web_fetch',
+          phase: '阶段1-分析',
+          params: defaultParams({ url: 'https://docs.example.com/api' }),
+          reasoning: '确认外部 API 行为',
+          needsCodeGeneration: false,
+        },
+        {
+          description: '搜索本地调用',
+          action: 'search_code',
+          tool: 'search_code',
+          phase: '阶段1-分析',
+          params: defaultParams({ query: 'createClient', maxResults: 10 }),
+          reasoning: '定位本地调用方式',
+          needsCodeGeneration: false,
+        },
+      ],
+      risks: [],
+      alternatives: [],
+    }));
+
+    const result = await planner.plan(createTask({ type: 'create' }), emptyContext(), []);
+
+    const steps = result.plan!.steps;
+    const webFetchStep = steps.find((s) => s.action === 'web_fetch');
+    const searchStep = steps.find((s) => s.action === 'search_code');
+    expect(webFetchStep).toBeDefined();
+    expect(searchStep).toBeDefined();
+    expect(searchStep!.dependencies).not.toContain(webFetchStep!.stepId);
   });
 
   it('generates correct dependencies for modify task (rule-based)', async () => {

--- a/packages/core/src/planner.ts
+++ b/packages/core/src/planner.ts
@@ -335,7 +335,7 @@ export class Planner {
   }
 
   private isReadOnlyPlanningAction(action: ExecutionStep['action']): boolean {
-    return ['read_file', 'search_code', 'list_directory', 'get_ast'].includes(action);
+    return ['read_file', 'search_code', 'list_directory', 'get_ast', 'web_fetch'].includes(action);
   }
 
   /**
@@ -355,6 +355,7 @@ export class Planner {
       browser_click: 'browser_click',
       browser_type: 'browser_type',
       browser_screenshot: 'browser_screenshot',
+      web_fetch: 'web_fetch',
     };
 
     return actionMap[action] ?? 'read_file';

--- a/packages/core/src/security.test.ts
+++ b/packages/core/src/security.test.ts
@@ -295,6 +295,17 @@ describe('SecurityManager', () => {
       expect(result.reasonCode).toBe('unknown_tool_requires_approval');
       expect(result.riskLevel).toBe('medium');
     });
+
+    it('asks for approval for web_fetch by default', () => {
+      const result = security.evaluate({
+        toolName: 'web_fetch',
+        args: { url: 'https://docs.example.com/api' },
+        projectRoot,
+      });
+      expect(result.decision).toBe('ask');
+      expect(result.reasonCode).toBe('unknown_tool_requires_approval');
+      expect(result.riskLevel).toBe('medium');
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/shared/src/types/task.ts
+++ b/packages/shared/src/types/task.ts
@@ -19,6 +19,7 @@ export type ActionType =
   | 'browser_type'
   | 'browser_screenshot'
   | 'get_page_structure'
+  | 'web_fetch'
   | 'filesense_sync_and_summarize'
   | 'filesense_query'
   | 'filesense_navigate';


### PR DESCRIPTION
LLM-planned `web_fetch` steps were silently downgraded to `read_file`; this preserves them through Planner/shared action types while keeping security approval behavior unchanged.

## Linked Issue Or Context

- Closes #379

## Summary

- Add `web_fetch` to shared `ActionType`.
- Preserve LLM-planned `web_fetch` in `Planner.mapLLMAction()`.
- Treat `web_fetch` as a read-only planning action for dependency scheduling.
- Add planner regression tests for action/URL preservation and read-only dependency policy.
- Add security regression coverage proving default `web_fetch` remains `ask` / `unknown_tool_requires_approval`.

## Impact Scope

- Planner LLM conversion only: `mapLLMAction()` now maps the already-advertised `web_fetch` action instead of falling through to `read_file`.
- Planner scheduling only: `isReadOnlyPlanningAction()` now includes `web_fetch` for consecutive read-only step dependency handling.
- Shared task contract only: `ActionType` now acknowledges `web_fetch`.
- Security boundary unchanged: `web_fetch` was not added to `READ_TOOLS`.

## GitNexus Impact Summary

- Risk level: MEDIUM
- Critical skeleton changes: `packages/core/src/planner.ts`
- GitNexus impact: `query` found the relevant `GeneratePlan → IsReadOnlyPlanningAction` and security `CallTool → Builtin` flows; pre-edit `impact(mapLLMAction, upstream)` was LOW with direct caller `convertLLMPlanToSteps` and affected process `generatePlan`; pre-edit `impact(isReadOnlyPlanningAction, upstream)` was LOW with direct caller `convertLLMPlanToSteps` and affected process `generatePlan`; `impact(convertLLMPlanToSteps, upstream)` reported HIGH because planner output flows into `generatePlan`, `planOnly`, and `execute`; staged `detect_changes` reported 4 changed files, touched symbols `Planner`, `isReadOnlyPlanningAction`, `mapLLMAction`, affected processes `GeneratePlan → MapLLMAction` and `GeneratePlan → IsReadOnlyPlanningAction`, risk `medium`.
- Verification: focused planner/security tests, `pnpm quality:precommit`, and `pnpm quality:local` passed.

## Verification

- `pnpm agent:bootstrap` passed.
- `pnpm quality:predev` passed.
- Red test confirmed planner dropped `web_fetch` before the fix.
- `pnpm --filter @frontagent/core exec vitest run src/planner.test.ts src/security.test.ts` passed: 134 tests.
- `pnpm quality:precommit` passed.
- `pnpm quality:local` passed.
- Push hook reran `pnpm quality:local` and passed.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.