### PR TITLE
fix(agent): use project package manager for dependency recovery

### DIFF
--- a/packages/core/src/agent/step-callbacks.test.ts
+++ b/packages/core/src/agent/step-callbacks.test.ts
@@ -586,6 +586,29 @@ describe('createOnPhaseComplete', () => {
     expect(errors[0].error).toBe('Missing npm dependencies: lodash');
   });
 
+  it('uses pnpm add for missing dependencies when filesense detects pnpm', async () => {
+    const files = new Map<string, string>([['src/app.ts', "import _ from 'lodash';\n"]]);
+    const { deps, onPhaseComplete } = setupPhaseComplete({ files });
+    deps.contextManager.getContext.mockReturnValue({
+      collectedContext: {
+        filesenseNavigation: {
+          summary: {
+            packageManager: 'pnpm',
+          },
+        },
+      },
+    });
+    deps.executor.callTool.mockResolvedValue({
+      success: true,
+      content: '{"dependencies":{"react":"^18.0.0"}}',
+    });
+
+    const errors = await onPhaseComplete('实现', []);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].step.params).toEqual({ command: 'pnpm add lodash' });
+  });
+
   it('runs the TypeScript check only when tsconfig.json was collected and reports parsed errors', async () => {
     const files = new Map<string, string>([['tsconfig.json', '{}']]);
     const { deps, task, onPhaseComplete } = setupPhaseComplete({ files });

--- a/packages/core/src/agent/step-callbacks.ts
+++ b/packages/core/src/agent/step-callbacks.ts
@@ -202,6 +202,24 @@ export function createOnPhaseError(
 
 // PLACEHOLDER_PHASE_COMPLETE
 
+function createMissingDependencyInstallCommand(
+  packageManager: string | undefined,
+  packages: string[],
+): string {
+  const packageList = packages.join(' ');
+
+  switch (packageManager) {
+    case 'pnpm':
+      return `pnpm add ${packageList}`;
+    case 'yarn':
+      return `yarn add ${packageList}`;
+    case 'bun':
+      return `bun add ${packageList}`;
+    default:
+      return `npm install ${packageList}`;
+  }
+}
+
 export function createOnPhaseComplete(
   deps: StepCallbackDeps,
   task: AgentTask,
@@ -267,13 +285,15 @@ export function createOnPhaseComplete(
         deps.debugLog(
           `[Agent] Found ${missingDeps.length} missing npm dependencies: ${missingDeps.join(', ')}`,
         );
+        const packageManager = deps.contextManager.getContext(task.id)?.collectedContext
+          .filesenseNavigation?.summary?.packageManager;
         errors.push({
           step: {
             stepId: 'install-missing-deps',
             description: `安装缺失的依赖: ${missingDeps.join(', ')}`,
             action: 'run_command' as const,
             tool: 'run_command',
-            params: { command: `npm install ${missingDeps.join(' ')}` },
+            params: { command: createMissingDependencyInstallCommand(packageManager, missingDeps) },
             dependencies: [],
             validation: [],
             status: 'failed' as const,


### PR DESCRIPTION
## Linked Issue Or Context

- Closes #381

## Summary

- Reuse Filesense navigation package-manager context when building the missing-dependency recovery pseudo-step.
- Emit add/install commands for pnpm/yarn/bun/npm, preserving npm fallback for unknown or generic node contexts.
- Add focused coverage for pnpm recovery command selection while retaining existing npm fallback coverage.

## Impact Scope

- Only the missing-dependency recovery pseudo-step in `packages/core/src/agent/step-callbacks.ts` changes.
- No dependency detection redesign, installs, lockfile changes, manifest changes, or planner/codegen prompt changes.

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: agent-core (`packages/core/src/agent/step-callbacks.ts`, `packages/core/src/agent/step-callbacks.test.ts`)
- GitNexus impact: impact(createOnPhaseComplete, upstream) reported LOW risk with 2 direct dependents and 1 affected process group (`executeSteps`); context(createOnPhaseComplete) confirmed incoming callers; detect_changes reported changed_count=1, affected_count=0, changed_files=2, risk_level=low, changed symbol `createOnPhaseComplete`, affected_processes=[].
- Verification: focused test, core typecheck, `pnpm quality:precommit`, and `pnpm quality:local` passed.

## Verification

- `pnpm agent:bootstrap` passed.
- `pnpm quality:predev` passed after installing dependencies from the frozen lockfile.
- TDD red check: focused test first failed with expected `npm install lodash` vs `pnpm add lodash` mismatch.
- `pnpm --filter @frontagent/core exec vitest run src/agent/step-callbacks.test.ts` passed: 28/28 tests.
- `pnpm --filter @frontagent/core typecheck` passed.
- `pnpm quality:precommit` passed.
- `pnpm quality:local` passed.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.