### PR TITLE
fix(tests): accept vars-based Repo Guard runner in workflow rules

### DIFF
--- a/scripts/tests/workflow-rules.test.mjs
+++ b/scripts/tests/workflow-rules.test.mjs
@@ -526,7 +526,10 @@ test('Claude Harness workflow has a single portable entrypoint', () => {
 test('repo guard remains advisory and training-camp workflows are absent', () => {
   const repoGuard = readFileSync('.github/workflows/repo-guard.yml', 'utf8');
 
-  assert.match(repoGuard, /runs-on:\s+ubuntu-latest/u);
+  assert.match(
+    repoGuard,
+    /runs-on:\s+(?:ubuntu-latest|\$\{\{\s*vars\.REPO_GUARD_RUNNER\s*\|\|\s*'ubuntu-latest'\s*\}\})/u,
+  );
   assert.doesNotMatch(repoGuard, /repo-guard-intranet/u);
   assert.doesNotMatch(repoGuard, /auto-merge|确认合并|认领|score:/u);
   assert.throws(() => readFileSync('.github/workflows/pr-auto-merge.yml', 'utf8'));


### PR DESCRIPTION
## Linked Issue Or Context

- Fixes #397

## Summary

- 4053c61 switched `repo-guard.yml` to `runs-on: ${{ vars.REPO_GUARD_RUNNER || 'ubuntu-latest' }}` without updating the workflow-rules assertion, so `pnpm test:workflows` fails (33/34) on a clean develop checkout and the pre-commit/pre-push hooks reject every commit and push repo-wide.
- The assertion now accepts either the plain `ubuntu-latest` runner or the vars expression **with the ubuntu-latest fallback**, preserving the test's intent (portable, advisory Repo Guard).

## Impact Scope

- `scripts/tests/workflow-rules.test.mjs` — one assertion in the 'repo guard remains advisory' test. No production code touched.

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: none
- GitNexus impact: N/A — test-only change outside indexed source; verified by direct test run.
- Verification: `pnpm test:workflows` 34/34.

## Verification

- `pnpm test:workflows`: 34 pass / 0 fail (was 33/1 on clean develop).
- Full `quality:precommit` + pre-push gates ran green via the git hooks on commit and push of this branch — first fully green hook run since 4053c61.
- Unblocks CI for open PRs including #398.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run. (Not a critical skeleton change.)
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results. (N/A.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)