### PR TITLE
fix(executor): emit validation_failed, with a stage discriminant (#388)

### DIFF
--- a/apps/desktop/src/state/executionReducer.ts
+++ b/apps/desktop/src/state/executionReducer.ts
@@ -276,12 +276,14 @@ export function consoleReducer(state: ConsoleState, event: AgentEvent): ConsoleS
         },
       };
 
-    case 'validation_failed':
-      return appendLog(
-        state,
-        'warn',
-        `校验失败${event.result.blockedBy?.length ? `: ${event.result.blockedBy.join(', ')}` : ''}`,
-      );
+    case 'validation_failed': {
+      // 阶段决定这条日志的含义：pre_execution 是执行前结构性拦截，
+      // post_write 是内容已落盘后才判失败（文件还在）。混成一句会误导读日志的人。
+      const stageLabel = event.stage === 'post_write' ? '写盘后校验失败' : '执行前校验失败';
+      const target = event.path ? `[${event.path}] ` : '';
+      const reason = event.result.blockedBy?.length ? `: ${event.result.blockedBy.join(', ')}` : '';
+      return appendLog(state, 'warn', `${stageLabel} ${target}${reason}`.trim());
+    }
 
     case 'rollback_started':
       return appendLog(state, 'warn', `回滚开始: ${event.snapshotId}`);

--- a/benchmarks/eval/report.mjs
+++ b/benchmarks/eval/report.mjs
@@ -74,6 +74,16 @@ console.log(`# FrontAgent 消融评测：SDD 规格约束对一次通过率的�
 3. **\`validation_failed\` 事件从未触发**
    两臂合计 ${sumEvent(arms.full, 'validation_failed') + sumEvent(arms.ablation, 'validation_failed')} 次。该事件挂在执行器不走的那条校验路径上，导致「校验是否起作用」在遥测层面不可观测。
 
+   **按阶段分解**（事件接线后才有意义）：
+
+   | 阶段 | SDD 关 | SDD 开 |
+   |---|---|---|
+   | \`pre_execution\`（执行前结构性拦截） | ${sumEvent(arms.ablation, 'validation_failed:pre_execution')} | ${sumEvent(arms.full, 'validation_failed:pre_execution')} |
+   | \`post_write\`（已落盘后判失败） | ${sumEvent(arms.ablation, 'validation_failed:post_write')} | ${sumEvent(arms.full, 'validation_failed:post_write')} |
+
+   > 全为 0 时先分清「未接线」与「零拦截」：若 JSONL 里连 \`validation_failed\` 这个裸键
+   > 都不存在，说明该轮数据产自事件接线之前，此时 0 不构成任何证据。
+
 **实证**：失败样本中出现 \`TS1127: Invalid character\`——markdown 代码围栏被原样写进 \`.tsx\` 文件并落盘，两臂皆有。这正是 \`checkSyntaxValidity\` 的目标场景，guard 在运行却未阻止其落盘，与缺陷 2 的机制一致。
 
 ## 分类通过率

--- a/benchmarks/eval/run-eval.mjs
+++ b/benchmarks/eval/run-eval.mjs
@@ -95,6 +95,12 @@ for (const task of tasks) {
       ...ARM_OPTIONS[ARM],
       onEvent: (e) => {
         events[e.type] = (events[e.type] ?? 0) + 1;
+        // 带 stage 的事件另记一份分阶段计数：`validation_failed` 的两个阶段含义
+        // 不同（post_write 时文件已经落盘了），只按 type 聚合的话，
+        // 事件加了 stage 也等于白加。
+        if (e.stage) {
+          events[`${e.type}:${e.stage}`] = (events[`${e.type}:${e.stage}`] ?? 0) + 1;
+        }
       },
     });
     resultText = result?.output ?? '';

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -215,6 +215,43 @@ describe('createAgent', () => {
   });
 });
 
+describe('executor events reach the agent event stream (#388)', () => {
+  it('wires an emitEvent outlet into the executor', () => {
+    const agent = createAgent({
+      projectRoot: '/test',
+      llm: { provider: 'openai', model: 'gpt-4', apiKey: 'test-key' },
+    });
+
+    // 公开入口 agent.execute 需要真实 LLM 才能产出计划，所以这里直接断言接线存在：
+    // 接线一旦从构造期移走，这条会先失败，不会被下面的 cast 掩盖。
+    const executor = (agent as unknown as { executor: { config: { emitEvent?: unknown } } })
+      .executor;
+    expect(typeof executor.config.emitEvent).toBe('function');
+  });
+
+  it('forwards an executor-emitted event to registered listeners', () => {
+    const agent = createAgent({
+      projectRoot: '/test',
+      llm: { provider: 'openai', model: 'gpt-4', apiKey: 'test-key' },
+    });
+    const events: Array<{ type: string }> = [];
+    agent.addEventListener((event) => events.push(event as { type: string }));
+
+    const executor = (
+      agent as unknown as {
+        executor: { config: { emitEvent: (e: unknown) => void } };
+      }
+    ).executor;
+    executor.config.emitEvent({
+      type: 'validation_failed',
+      stage: 'post_write',
+      result: { pass: false, results: [], blockedBy: ['x'] },
+    });
+
+    expect(events.map((event) => event.type)).toContain('validation_failed');
+  });
+});
+
 describe('registerWebTools routing contract', () => {
   it('routes web_fetch and the browser tools to the web client', () => {
     const spy = vi.spyOn(Executor.prototype, 'registerToolMapping');

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -115,6 +115,11 @@ export class FrontAgent {
       onSecurityDecision: (decision) => {
         this.emit({ type: 'security_decision', decision });
       },
+      // 执行器的校验事件经此汇入 agent 事件流；没有这条接线，
+      // 「校验是否拦截」在遥测层不可观测（issue #388）
+      emitEvent: (event) => {
+        this.emit(event);
+      },
       executionEngine: config.execution?.engine,
       langGraph: config.execution?.langGraph,
       maxRecoveryAttempts: config.execution?.maxRecoveryAttempts,

--- a/packages/core/src/executor/executor.test.ts
+++ b/packages/core/src/executor/executor.test.ts
@@ -528,6 +528,94 @@ describe('Executor', () => {
     });
   });
 
+  describe('validation_failed observability (#388)', () => {
+    // #388 的核心：事件有类型定义、桌面端有消费方，却在全仓没有发射点，
+    // 于是「校验是否拦截」在遥测层恒为 0——那个 0 证明的是「没接线」，
+    // 不是「没拦住」。以下三条锁住修复后的口径。
+    it('emits post_write with the failing checks when a real check fails', async () => {
+      const events: AgentEvent[] = [];
+      const executor = new Executor(
+        makeConfig({
+          hallucinationGuard: {
+            validateFilePath: vi.fn().mockResolvedValue({ pass: true, type: 'file_existence' }),
+            validateCode: vi.fn().mockResolvedValue({
+              pass: false,
+              results: [
+                {
+                  pass: false,
+                  type: 'syntax_validity',
+                  severity: 'block',
+                  message: 'Syntax errors found in src/a.ts',
+                },
+              ],
+              blockedBy: ['Syntax errors found in src/a.ts'],
+            }),
+          } as unknown as ExecutorConfig['hallucinationGuard'],
+          emitEvent: (event) => events.push(event),
+          getFileSystemFacts: () => ({
+            existingFiles: new Set<string>(),
+            existingDirectories: new Set(['src']),
+            nonExistentPaths: new Set<string>(),
+            directoryContents: new Map<string, string[]>(),
+          }),
+        }),
+      );
+      executor.registerMCPClient('files', {
+        callTool: vi.fn().mockResolvedValue({ success: true, content: 'export const a = {' }),
+        listTools: vi.fn().mockResolvedValue([]),
+      });
+      executor.registerToolMapping('create_file', 'files');
+
+      await executor.executeStep(
+        makeStep({ params: { path: 'src/a.ts', content: 'export const a = {' } }),
+        makeExecutionContext(),
+      );
+
+      expect(events).toEqual([
+        expect.objectContaining({
+          type: 'validation_failed',
+          stage: 'post_write',
+          path: 'src/a.ts',
+          stepId: 'step-1',
+        }),
+      ]);
+    });
+
+    it('stays silent when only the tool itself failed', async () => {
+      const events: AgentEvent[] = [];
+      const executor = new Executor(
+        makeConfig({
+          hallucinationGuard: {
+            validateFilePath: vi.fn().mockResolvedValue({ pass: true, type: 'file_existence' }),
+            validateCode: vi.fn().mockResolvedValue({ pass: true, results: [] }),
+          } as unknown as ExecutorConfig['hallucinationGuard'],
+          emitEvent: (event) => events.push(event),
+          getFileSystemFacts: () => ({
+            existingFiles: new Set<string>(),
+            existingDirectories: new Set(['src']),
+            nonExistentPaths: new Set<string>(),
+            directoryContents: new Map<string, string[]>(),
+          }),
+        }),
+      );
+      executor.registerMCPClient('files', {
+        // 工具自身报错（磁盘满、权限等），没有任何检查判失败
+        callTool: vi.fn().mockResolvedValue({ success: false, error: 'EACCES: permission denied' }),
+        listTools: vi.fn().mockResolvedValue([]),
+      });
+      executor.registerToolMapping('create_file', 'files');
+
+      const result = await executor.executeStep(
+        makeStep({ params: { path: 'src/a.ts', content: 'export const a = 1;' } }),
+        makeExecutionContext(),
+      );
+
+      expect(result.stepResult.success).toBe(false);
+      // 步骤失败但没有拦截：混进来的话拦截数就不能用了
+      expect(events.map((event) => event.type)).not.toContain('validation_failed');
+    });
+  });
+
   describe('executeSteps', () => {
     it('returns empty results for empty steps', async () => {
       const executor = new Executor(makeConfig());

--- a/packages/core/src/executor/executor.ts
+++ b/packages/core/src/executor/executor.ts
@@ -141,6 +141,7 @@ export class Executor {
         }
 
         const errorMsg = preValidation.blockedBy?.join('; ') || '';
+        this.emitValidationFailed('pre_execution', preValidation, step);
         return trace.finish({
           stepResult: {
             success: false,
@@ -193,6 +194,10 @@ export class Executor {
       const postValidation = await trace.withStage('validate_after', () =>
         this.validateAfterExecution(step, toolResult, toolParams),
       );
+
+      if (!postValidation.pass) {
+        this.emitValidationFailed('post_write', postValidation, step);
+      }
 
       const stepResult: StepResult = {
         success: postValidation.pass,
@@ -519,6 +524,28 @@ export class Executor {
       results,
       blockedBy: blockedBy.length > 0 ? blockedBy : undefined,
     };
+  }
+
+  /**
+   * 只有「至少一项真实检查判定失败」才算校验拦截。
+   * `validateAfterExecution` 在工具自身报错时返回 results 为空的失败结果——
+   * 那是工具失败，不是拦截；两者混在同一事件里，`validation_failed`
+   * 就不能当拦截数用，而 #388 要的正是一个能计数的拦截量。
+   */
+  private emitValidationFailed(
+    stage: 'pre_execution' | 'post_write',
+    validation: ValidationResult,
+    step: ExecutionStep,
+  ): void {
+    if (validation.results.some((result) => !result.pass)) {
+      this.config.emitEvent?.({
+        type: 'validation_failed',
+        stage,
+        result: validation,
+        path: step.params.path as string | undefined,
+        stepId: step.stepId,
+      });
+    }
   }
 
   private async validateAfterExecution(

--- a/packages/core/src/executor/types.ts
+++ b/packages/core/src/executor/types.ts
@@ -16,6 +16,12 @@ export interface MCPClient {
 }
 
 export interface ExecutorConfig {
+  /**
+   * 执行器事件出口。没有它，执行器这条校验路径上发生的一切在遥测层不可观测——
+   * 这正是 issue #388 的内容：`validation_failed` 有类型定义、有 UI 消费方，
+   * 却在全仓没有任何发射点。
+   */
+  emitEvent?: (event: import('../types.js').AgentEvent) => void;
   projectRoot: string;
   hallucinationGuard: HallucinationGuard;
   llmService: LLMService;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -790,7 +790,18 @@ export type AgentEvent =
   | { type: 'step_failed'; step: ExecutionStep; error: string }
   | { type: 'security_decision'; decision: SecurityDecision }
   | { type: 'stream_token'; token: string; stepId: string }
-  | { type: 'validation_failed'; result: ValidationResult }
+  /**
+   * 校验拦截。`stage` 是必要的判别字段——发射点的含义完全不同：
+   * `pre_execution` 是执行前的结构性拦截，`post_write` 是内容已落盘后才判失败。
+   * 不带 stage 就没法把它们分开计数，「拦截率」这个指标也就无从谈起（issue #388）。
+   */
+  | {
+      type: 'validation_failed';
+      stage: 'pre_execution' | 'post_write';
+      result: ValidationResult;
+      path?: string;
+      stepId?: string;
+    }
   | { type: 'rollback_started'; snapshotId: string }
   | { type: 'rollback_completed'; snapshotId: string }
   | { type: 'task_completed'; result: AgentExecutionResult }


### PR DESCRIPTION
## Linked Issue Or Context

- Fixes #388 (`validation_failed` event never fires — guard effectiveness is unobservable).
- **Split out of #402**, which now keeps only the write-blocking half. See "Why this is split out" below.

## Summary

`validation_failed` had a type definition (`types.ts`) and a desktop reducer case, but **no emit site anywhere in the repository**. The 2026-07-12 ablation's headline finding — "the hallucination guard recorded zero interceptions across 303 LLM calls" — could therefore not have been anything but zero. The count was accurate and meant nothing.

This PR gives the event an emit site and a discriminant. **It changes no behaviour**: no pre-write gate, no rollback trigger, nothing different reaches disk.

### Measured

A deterministic probe — zero LLM spend, identical input, through the real `runFrontAgentTask` entry point the eval harness uses:

| | `develop` | this branch |
|---|---|---|
| `validation_failed` | 0 | **1** |
| bad file on disk | yes (29 B) | **yes** (29 B) |
| `step_failed` | 1 | 1 |
| task error | `Syntax errors found in …` | `Syntax errors found in …` |

The file still lands, byte for byte, and the step still fails the same way. The original defect was "detected, but neither blocked nor reported"; this fixes the reporting half only. Blocking is #402's job.

That comparison also settles what the July number meant: the check was running and failing all along.

### `stage` is not optional decoration

`pre_execution` and `post_write` are different events. In the second, the content is **already on disk** — so summing the two does not produce an interception count, which is the quantity #388 exists to make available. The event carries `stage`, `path` and `stepId`; the harness aggregates `type:stage` alongside `type`, and `report.mjs` prints the breakdown instead of a single misleading number.

The event fires only when at least one real check failed. `validateAfterExecution` returns `results: []` when the *tool* errored (EACCES, disk full); folding those in would make the count unusable for its stated purpose.

## Why this is split out

#402 originally carried both halves. Over seven review rounds its write-blocking half accumulated substantive defects — a rollback path that could delete legitimate files, a veto predicate that rejected any string containing an apostrophe, a gate that bypassed `enabledChecks` and so reintroduced #386's mechanism. Each was caught and fixed, but the pattern is clear enough that the two halves should not share a merge decision.

This half touches no write path and is verifiable by a probe that costs nothing to run. It is also the half the filesense ablation work (#412) depends on: without an emit site, that harness's `validation_failed` payload collection is structurally empty, and an empty array reads exactly like "zero interceptions".

## Impact Scope

- `packages/core/src/executor/executor.ts` — an `emitValidationFailed` helper and two call sites at existing failure points.
- `packages/core/src/executor/types.ts` — optional `emitEvent` on `ExecutorConfig`.
- `packages/core/src/types.ts` — `validation_failed` gains `stage`, `path`, `stepId`.
- `packages/core/src/agent/agent.ts` — 3 lines wiring the outlet to `this.emit`.
- `apps/desktop/src/state/executionReducer.ts` — the log line names the stage.
- `benchmarks/eval/run-eval.mjs`, `benchmarks/eval/report.mjs` — stage-aware counting.

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: yes — `packages/core/src/executor/` and `packages/core/src/agent/`, with tests in the same package.
- GitNexus impact: `ExecutorConfig.emitEvent` is optional and additive; with no outlet configured the executor behaves exactly as before. The `AgentEvent` union gains three fields on an existing member — `apps/cli/src/ui/bridge.ts` and `apps/vscode/src/state.ts` both have `default` branches, and the desktop reducer's case is updated in this PR. No control flow is added to `executeStep`; the emit calls sit inside branches that already existed and already returned failure.
- Verification: `pnpm quality:precommit` exit 0, plus the probe comparison above.

## Verification

- `pnpm quality:precommit` — exit 0.
- Probe run against a build of this branch, table above. Reproducible without an API key.
- Three tests: a real check failure emits `post_write` with `path`/`stepId`; a tool-only failure emits nothing; and the agent forwards an executor-emitted event to its listeners.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)