### PR TITLE
fix(agent): let query answers cite the filesense navigation result (#415)

### DIFF
--- a/packages/core/src/agent/answer-generation.test.ts
+++ b/packages/core/src/agent/answer-generation.test.ts
@@ -1,0 +1,63 @@
+import type { AgentTask, ExecutionPlan } from '@frontagent/shared';
+import { describe, expect, it, vi } from 'vitest';
+import type { ContextManager } from '../context.js';
+import { buildFinalOutput } from './answer-generation.js';
+
+type ExecutionContext = NonNullable<ReturnType<ContextManager['getContext']>>;
+
+function makeContext(
+  overrides: Partial<ExecutionContext['collectedContext']> = {},
+): ExecutionContext {
+  return {
+    collectedContext: {
+      files: new Map<string, string>(),
+      ...overrides,
+    },
+  } as unknown as ExecutionContext;
+}
+
+const queryTask = { id: 't1', type: 'query', description: '路由表在哪个文件？' } as AgentTask;
+const noSteps: ExecutionPlan['steps'] = [];
+
+/** 捕获送进 LLM 的 evidence 文本，断言它包含了该包含的东西 */
+function makeDeps() {
+  const generateText = vi.fn().mockResolvedValue('answer');
+  return {
+    deps: {
+      llmService: { generateText },
+      debugWarn: vi.fn(),
+    } as unknown as Parameters<typeof buildFinalOutput>[0],
+    generateText,
+  };
+}
+
+describe('query answer evidence', () => {
+  // filesenseContext 一路从 context-manager 传到这里，却从未被读取：
+  // navigate 扫出 15 个带评分的候选路径，回答却报告「没有任何工作区证据」。
+  // 与 #386/#400/#403/#388 同族——算了、传了、消费端不读（issue #415）。
+  it('includes the filesense navigation result as evidence', async () => {
+    const { deps, generateText } = makeDeps();
+
+    await buildFinalOutput(
+      deps,
+      queryTask,
+      noSteps,
+      makeContext({ filesenseContext: 'src/app/routes 目录：路由定义' }),
+    );
+
+    expect(generateText).toHaveBeenCalledTimes(1);
+    const prompt = JSON.stringify(generateText.mock.calls[0]?.[0]);
+    expect(prompt).toContain('src/app/routes');
+    // 必须标注成结构证据：候选路径证明「路径存在」，不等于读过该文件的内容
+    expect(prompt).toContain('结构证据');
+  });
+
+  it('omits the section entirely when navigation did not run', async () => {
+    const { deps, generateText } = makeDeps();
+
+    await buildFinalOutput(deps, queryTask, noSteps, makeContext());
+
+    const prompt = JSON.stringify(generateText.mock.calls[0]?.[0]);
+    expect(prompt).not.toContain('目录导航结果');
+  });
+});

--- a/packages/core/src/agent/answer-generation.ts
+++ b/packages/core/src/agent/answer-generation.ts
@@ -77,6 +77,21 @@ async function generateQueryAnswer(
     }
   }
 
+  // 目录导航的定位结果也是证据——只是**结构证据**，不是内容证据。
+  // 不放进来的话，navigate 扫出的候选路径对回答完全不可见：任务问「路由表在哪个
+  // 文件」，导航明明返回了带评分的候选，回答却只能说「没有工作区证据」。
+  // 排在已读文件之后：候选路径的证据强度弱于真正读到的文件内容。
+  const filesenseContext = executionContext.collectedContext.filesenseContext;
+  if (filesenseContext) {
+    evidenceParts.push(
+      '\n## 目录导航结果（结构证据）\n' +
+        '以下是按意图扫描当前工作区得到的结构信息与候选路径。' +
+        '它证明这些路径**存在**及其用途推断，但**不含文件内容**——' +
+        '引用时应说明是定位结果，不要当作读过该文件。\n' +
+        truncateForPrompt(filesenseContext, 4000),
+    );
+  }
+
   if (files.length > 0) {
     evidenceParts.push('\n## 已读取文件');
     let remainingBudget = 16000;


### PR DESCRIPTION
## Linked Issue Or Context

- Fixes #415.
- Found while running the filesense ablation from #412: every deep-fixture query task failed in **both** arms, which is the signature of an unwired consumer rather than a capability result.

## Summary

`buildEvidenceBlock` assembles the evidence a query answer is permitted to cite: agent identity, RAG matches, `search_code` hits, and files actually read. `filesenseContext` was not among them — although it is computed in `context-manager.ts:201`, included as an *execution* prompt zone at `:272`, and forwarded into the executor's collected context at `agent.ts:861`. `grep filesense` on `answer-generation.ts` returned nothing.

### Measured, before

On the 242-file feature-sliced fixture, asking which file defines the top-level route table:

```
events:                  { filesense_navigated: 1, ... }
eventDetails.filesense:  { intent: 'understand_structure', entries: 54, candidateCount: 15 }

answer: "## 无法确定 … 提供的证据中没有包含：… 当前工作区的本地文件内容"
```

Fifteen scored candidates were produced, and the answer reported having no repository evidence at all.

### Measured, after

```
answer: "目录导航结果显示了项目的目录结构（包括 src/app、src/entities 等重要目录存在），
         但该扫描结果不含文件内容，只能证明路径存在及其用途推断"
```

The answer now reasons from the navigation and correctly characterises its strength. It still cannot name the file — the plan contains no read step and the scan is depth-2 from the root. **That is a separate gap and this PR does not claim to fix it.**

## Why it is shaped this way

The section sits **below** files actually read and is labelled structural evidence. A candidate list proves a path exists and infers its purpose; it is not file content, and an answer that cites it must not imply otherwise. The prompt states this, which is what produced the appropriately hedged wording above.

## Why it matters beyond one answer

This is the fifth instance in this repo of a value that is declared, threaded through several layers, and never consumed where it is needed (#386 `enabledChecks`, #400 `hallucinationGuard.enabled`, #403 navigate `writeMode`, #388 `validation_failed`).

It also blocks measurement. A filesense ablation cannot discriminate on query tasks while this holds: both arms answer "cannot determine", so they are indistinguishable **by construction** — precisely how #386 voided the guard arm of the 2026-07-12 benchmark. I hit this on the first four tasks of the full run and stopped rather than spend hours collecting a null result that would have looked like evidence.

## Impact Scope

- `packages/core/src/agent/answer-generation.ts` — one evidence section, gated on the field being present.
- `packages/core/src/agent/answer-generation.test.ts` — the file existed but was empty; two tests added.
- Query answers only. `task.type !== 'query'` returns before this code. Execution/codegen prompts already received the navigation zone and are untouched.

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: yes — `packages/core/src/agent/`, with tests in the same package.
- GitNexus impact: additive and gated on `collectedContext.filesenseContext` being set, so behaviour is unchanged when navigation did not run (pinned by the second test). `buildFinalOutput` has one caller (`agent.ts`); its signature is unchanged. The only downstream effect is a longer evidence prompt when navigation ran, bounded by `truncateForPrompt(…, 4000)`.
- Verification: `pnpm quality:precommit` exit 0, plus the before/after comparison above on a real task.

## Verification

- `pnpm quality:precommit` — exit 0.
- Before/after run of `deep-query-route-source` against a real backend, quoted above.
- Two tests: the navigation result reaches the prompt and is labelled structural; the section is absent when navigation did not run.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)