### PR TITLE
fix(eval): actually capture exploration steps, across all their path shapes

### DIFF
--- a/benchmarks/eval/run-eval.mjs
+++ b/benchmarks/eval/run-eval.mjs
@@ -207,6 +207,26 @@ function collectEventDetail(details, event) {
   // `rollback_failed` 随 #402 才进入 AgentEvent 联合类型，在它合入前不会出现。
   // 三者一起记，才能判定「撤销成功」与「拦到了但没撤销掉」——只看 started
   // 分不出这两种，而后者意味着坏文件还在工作区里。
+  // 定位精度：通过率对「找得准不准」不敏感——两臂都能靠 list_directory /
+  // search_code 慢慢摸出来，结果一样、代价不同，而代价才是导航能力的直接体现。
+  //
+  // 路径字段因动作而异（实测）：read_file / list_directory 用 `path`，
+  // search_code 用 `filePattern`（glob 发现）或 `directory`。只认 `path`
+  // 会把 search_code 全漏掉，而那正是 #419 修好后 query 任务的主要探索手段。
+  if (event.type === 'step_completed' || event.type === 'step_failed') {
+    const action = event.step?.action;
+    const params = event.step?.params ?? {};
+    const where = params.path ?? params.directory ?? params.filePattern;
+    if (where) {
+      if (['read_file', 'list_directory', 'search_code'].includes(action)) {
+        details.explored.push({ action, path: String(where) });
+      }
+      if (['create_file', 'apply_patch'].includes(action)) {
+        details.touched.push({ action, path: String(where) });
+      }
+    }
+  }
+
   if (
     event.type === 'rollback_started' ||
     event.type === 'rollback_completed' ||
@@ -223,7 +243,13 @@ function collectEventDetail(details, event) {
 for (const task of tasks) {
   const ws = setupWorkspace(task.id);
   const events = {};
-  const eventDetails = { filesense: [], validationFailed: [], rollback: [] };
+  const eventDetails = {
+    filesense: [],
+    validationFailed: [],
+    rollback: [],
+    explored: [],
+    touched: [],
+  };
   const t0 = performance.now();
   const usageBefore = getUsageTally();
   let resultText = '';
@@ -309,10 +335,15 @@ for (const task of tasks) {
     // list_directory / search_code 慢慢摸出来，结果一样、代价不同，
     // 而代价才是导航能力的直接体现。
     exploredCount: eventDetails.explored.length,
+    // 脱靶 = 探索到了一个**具体目录**且它不在目标目录下。
+    // glob 模式（`**/*Route*.tsx`）不指向具体目录，既不算命中也不算脱靶——
+    // 把它算成脱靶会惩罚「先 glob 再收敛」这条 prompt 明确推荐的流程。
     offTargetExplored: task.targetDirs
-      ? eventDetails.explored.filter((e) => !task.targetDirs.some((d) => e.path.startsWith(d)))
-          .length
+      ? eventDetails.explored.filter(
+          (e) => !e.path.includes('*') && !task.targetDirs.some((d) => e.path.startsWith(d)),
+        ).length
       : null,
+    globExplored: eventDetails.explored.filter((e) => e.path.includes('*')).length,
     elapsedMs: Math.round(performance.now() - t0),
     llmCalls,
     llmFailures,


### PR DESCRIPTION
Follow-up to #423. The localization metric it added recorded zeroes — the capture block never landed in the file, and the event shape I wrote for it was wrong.

Measured, not assumed: `read_file` / `list_directory` carry the target under `path`; `search_code` uses `filePattern` (glob discovery) or `directory`. Keying on `path` alone dropped every `search_code` step — the main way query tasks explore now that #419 lets them plan at all.

Glob patterns count separately (`globExplored`) instead of as off-target: a pattern names no directory, and scoring `**/*Route*.tsx` as a miss would penalise the glob-then-narrow workflow the plan prompt teaches.

Verified on `deep-query-route-source`:

```
explored: 2   [search_code "*route*.ts", read_file "src/app/routes.ts"]
glob: 1
offTarget: 0   — the file read is under the declared target dir src/app
```

Two steps, one to narrow and one to read, landing on target. Before #419 this task planned no exploration at all.

## Impact Scope

`benchmarks/eval/run-eval.mjs` only. No production code.

## GitNexus Impact Summary

- Risk level: LOW
- Critical skeleton changes: none — `benchmarks/` matches no critical contract rule.
- GitNexus impact: harness-only; no `packages/**` or `apps/**` change.
- Verification: `pnpm quality:precommit` exit 0, plus the measured run above.

## Verification

- `pnpm quality:precommit` — exit 0.
- Single-task run against a real backend confirming non-zero, correctly attributed metrics.

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run — there are none.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results — none in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)