### PR TITLE
fix(llm): make every optional plan field optional — the first fix only did params

### DIFF
--- a/packages/core/src/llm/schemas.test.ts
+++ b/packages/core/src/llm/schemas.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { GeneratedPlanSchema, PlanOutlineSchema, StepExpansionSchema } from './schemas.js';
+
+/**
+ * 这些 schema 的必填字段直接决定「LLM 规划会不会静默降级」。
+ *
+ * 模型只填相关字段：一个 create_file 步骤给 action / tool / path / 描述，
+ * 其余一概省略。任何一个它可能省略的字段只要是必填，zod 就逐条报
+ * invalid_type，`generateObject` 重试耗尽抛错，规划静默退到规则生成——
+ * 而规则生成给 create 的路径是硬编码的 `src/new-file.ts`，
+ * 净效果是「步骤全绿、任务成功、文件写错地方」（#417）。
+ *
+ * 这个缺陷已经出现过两次：第一次是 params 的 15 个字段，
+ * 修完只放开了 params，`phase` 仍必填，于是同一条链路原样重演。
+ * 下面用「模型会给的最小对象」直接过 schema，防止第三次。
+ */
+describe('plan schemas accept a minimal, realistic model output', () => {
+  const minimalStep = {
+    description: '创建工具函数',
+    action: 'create_file' as const,
+    tool: 'create_file',
+    params: { path: 'src/shared/lib/truncate.ts' },
+  };
+
+  it('GeneratedPlanSchema accepts a step without phase/reasoning/needsCodeGeneration', () => {
+    const result = GeneratedPlanSchema.safeParse({
+      summary: '新增 truncate',
+      steps: [minimalStep],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('StepExpansionSchema accepts the same minimal step', () => {
+    const result = StepExpansionSchema.safeParse({ steps: [minimalStep] });
+    expect(result.success).toBe(true);
+  });
+
+  it('PlanOutlineSchema accepts an outline without phase/risks/alternatives', () => {
+    const result = PlanOutlineSchema.safeParse({
+      summary: '新增 truncate',
+      stepOutlines: [{ description: '创建文件', action: 'create_file' as const }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('still rejects a step missing the fields that carry real meaning', () => {
+    // action / tool / description 决定这一步做什么，缺了就无法执行——
+    // 放开它们等于让 schema 不再约束任何东西。
+    expect(GeneratedPlanSchema.safeParse({ summary: 's', steps: [{}] }).success).toBe(false);
+  });
+});

--- a/packages/core/src/llm/schemas.ts
+++ b/packages/core/src/llm/schemas.ts
@@ -17,6 +17,19 @@ const ACTION_ENUM = [
 ] as const;
 
 /**
+ * 计划 schema 里所有非必需字段一律 `.optional()`。
+ *
+ * 上一轮只把 `params` 的 15 个字段放开，`phase` / `reasoning` /
+ * `needsCodeGeneration` / `risks` / `alternatives` 仍是必填——模型照样漏填，
+ * `generateObject` 照样重试耗尽抛错、照样静默退到规则生成、create 任务照样落到
+ * 硬编码的 `src/new-file.ts`（实测 `["steps",0,"phase"] Required`）。
+ * 半修等于没修：只要还有一个必填字段是模型可能省略的，整条链路就会重演。
+ *
+ * 下游对这些字段本来就有兜底（phase 有默认阶段名、needsCodeGeneration 判 falsy、
+ * risks/alternatives 只用于展示），所以放开不改变执行语义。
+ */
+
+/**
  * 工具参数。**每个字段都是可选的**——一个步骤只会用到其中一两个。
  *
  * 曾经全部必填，靠 describe 里的「不适用时填空字符串/false/0」来要求模型补齐。
@@ -56,14 +69,15 @@ export const PlanOutlineSchema = z.object({
         action: z.enum(ACTION_ENUM).describe('执行动作类型'),
         phase: z
           .string()
+          .optional()
           .describe(
             '所属阶段名称（如：阶段1-分析、阶段2-创建、阶段3-安装、阶段4-验证、阶段7-仓库管理）',
           ),
       }),
     )
     .describe('步骤概要列表 - 只需简单描述每个步骤要做什么'),
-  risks: z.array(z.string()).describe('潜在风险（可为空数组）'),
-  alternatives: z.array(z.string()).describe('备选方案（可为空数组）'),
+  risks: z.array(z.string()).optional().describe('潜在风险'),
+  alternatives: z.array(z.string()).optional().describe('备选方案'),
 });
 
 export type PlanOutline = z.infer<typeof PlanOutlineSchema>;
@@ -75,10 +89,10 @@ export const StepExpansionSchema = z.object({
         description: z.string().describe('步骤描述 - 说明要做什么'),
         action: z.enum(ACTION_ENUM).describe('执行动作'),
         tool: z.string().describe('要调用的工具'),
-        phase: z.string().describe('所属阶段名称（与Phase 1中的阶段名称保持一致）'),
+        phase: z.string().optional().describe('所属阶段名称（与Phase 1中的阶段名称保持一致）'),
         params: STEP_PARAMS_SCHEMA,
-        reasoning: z.string().describe('为什么需要这个步骤'),
-        needsCodeGeneration: z.boolean().describe('此步骤是否需要在执行时生成代码，默认false'),
+        reasoning: z.string().optional().describe('为什么需要这个步骤'),
+        needsCodeGeneration: z.boolean().optional().describe('此步骤是否需要在执行时生成代码'),
       }),
     )
     .describe('展开后的详细步骤列表'),
@@ -94,17 +108,18 @@ export const GeneratedPlanSchema = z.object({
         tool: z.string().describe('要调用的工具'),
         phase: z
           .string()
+          .optional()
           .describe(
             '所属阶段名称（如：阶段1-分析、阶段2-创建、阶段3-安装、阶段4-验证、阶段7-仓库管理）',
           ),
         params: STEP_PARAMS_SCHEMA,
-        reasoning: z.string().describe('为什么需要这个步骤'),
-        needsCodeGeneration: z.boolean().describe('此步骤是否需要在执行时生成代码，默认false'),
+        reasoning: z.string().optional().describe('为什么需要这个步骤'),
+        needsCodeGeneration: z.boolean().optional().describe('此步骤是否需要在执行时生成代码'),
       }),
     )
     .describe('执行步骤列表'),
-  risks: z.array(z.string()).describe('潜在风险（可为空数组）'),
-  alternatives: z.array(z.string()).describe('备选方案（可为空数组）'),
+  risks: z.array(z.string()).optional().describe('潜在风险'),
+  alternatives: z.array(z.string()).optional().describe('备选方案'),
 });
 
 export type GeneratedPlan = z.infer<typeof GeneratedPlanSchema>;


### PR DESCRIPTION
Follow-up to #418, which I wrongly considered complete.

#418 loosened `STEP_PARAMS_SCHEMA`'s fifteen fields. `phase`, `reasoning`, `needsCodeGeneration`, `risks` and `alternatives` stayed required, so the same chain fired on the next run:

```
generateObject retries exhausted:
  { "expected": "string", "received": "undefined", "path": ["steps", 0, "phase"] }
```

retries exhausted → silent fallback to rule-based planning → create target becomes the hardcoded `src/new-file.ts`.

## The evidence is unusually direct this time

The generated hook opens with:

```ts
import { CheckoutContext } from '../model/context';
```

A path relative to `src/features/checkout/hooks/` — exactly where the model meant the file to go. Written to `src/new-file.ts`, that import cannot resolve, and the guard reports **"Hallucination detected: Cannot resolve import"**. The model was right; the schema forced a fallback that relocated its file, and the guard then blamed the model.

## Why all of them, not just phase

Half-fixing this class equals not fixing it. One remaining required field that a model may omit re-runs the whole chain — which is precisely what happened between #418 and now. Downstream already tolerates absence: `phase` has default phase names, `needsCodeGeneration` is checked for truthiness, `risks`/`alternatives` are display-only. Execution semantics unchanged.

## Impact Scope

- `packages/core/src/llm/schemas.ts` — five fields across three schemas.
- `packages/core/src/llm/schemas.test.ts` — new; the file did not exist.

### Behaviour change

More plans validate, so more runs use LLM-generated plans rather than rule-based ones. Intended, and the same shift #418 described.

## GitNexus Impact Summary

- Risk level: MEDIUM
- Critical skeleton changes: none in `packages/core/src/agent/`; `llm/schemas.ts` is consumed only by `generateObject` calls in `plan-generation.ts`.
- GitNexus impact: required→optional strictly widens what validates, so no previously accepted plan is now rejected. `convertLLMPlanToSteps` and the executor already read these fields defensively.
- Verification: `pnpm quality:precommit` exit 0.

## Verification

- `pnpm quality:precommit` — exit 0.
- `schemas.test.ts`: the minimal object a model actually emits parses against all three plan schemas; a step missing `action`/`tool` is still rejected, so loosening did not become "constrains nothing".

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)