### PR TITLE
fix(filesense): 用导航枚举出的真实目录清单校正计划路径（#434）

### DIFF
--- a/apps/desktop/src/state/executionReducer.ts
+++ b/apps/desktop/src/state/executionReducer.ts
@@ -162,6 +162,13 @@ export function consoleReducer(state: ConsoleState, event: AgentEvent): ConsoleS
         `Filesense 导航: ${event.paths.length} 路径 / ${event.entries} 条目`,
       );
 
+    // 放弃校正也要出现在日志里，且用 warn。只显示成功改写会让人以为
+    // 路径接地全都命中了，而放弃的那几条恰恰是需要人去看的（#434）。
+    case 'filesense_path_grounded':
+      return event.outcome === 'corrected'
+        ? appendLog(state, 'info', `路径接地: ${event.from} → ${event.to}`)
+        : appendLog(state, 'warn', `路径接地放弃: ${event.from}（${event.reason}）`);
+
     case 'planning_completed': {
       const seeded = (event.plan.phases ?? []).reduce(
         (phases, phase) =>

--- a/packages/core/src/context/filesystem-facts-update.ts
+++ b/packages/core/src/context/filesystem-facts-update.ts
@@ -37,7 +37,10 @@ export function updateFilesystemFactsFromToolResult(
   // Handle filesense navigation results - consume explicit factsDelta instead of guessing result shape.
   if (toolName.startsWith('filesense_')) {
     const data = result.data as
-      | { factsDelta?: { existingFiles?: string[]; existingDirectories?: string[] } }
+      | {
+          factsDelta?: { existingFiles?: string[]; existingDirectories?: string[] };
+          scanned?: { truncated?: boolean };
+        }
       | undefined;
     const factsDelta = data?.factsDelta;
     if (result.success && factsDelta) {
@@ -48,6 +51,28 @@ export function updateFilesystemFactsFromToolResult(
       for (const dir of factsDelta.existingDirectories ?? []) {
         changed = addToSet(facts.filesystem.existingDirectories, dir) || changed;
         changed = removeFromSet(facts.filesystem.nonExistentPaths, dir) || changed;
+      }
+
+      // 目录清单：把扫描到的文件按父目录归组，供路径接地判断「这个文件名不存在」。
+      //
+      // 只在 `truncated === false` 时记录。预算截断意味着清单是残缺的，
+      // 此时「不在清单里」不等于「不存在」——据此去改写一个本来正确的路径，
+      // 会把一个能跑通的步骤改坏。宁可不接地，不可接错地。
+      if (data?.scanned?.truncated === false) {
+        const byDir = new Map<string, string[]>();
+        for (const file of factsDelta.existingFiles ?? []) {
+          const slash = file.lastIndexOf('/');
+          const dir = slash === -1 ? '.' : file.slice(0, slash);
+          const list = byDir.get(dir);
+          if (list) list.push(file);
+          else byDir.set(dir, [file]);
+        }
+        for (const [dir, files] of byDir) {
+          const merged = [
+            ...new Set([...(facts.filesystem.directoryContents.get(dir) ?? []), ...files]),
+          ].sort();
+          changed = setStringArrayMap(facts.filesystem.directoryContents, dir, merged) || changed;
+        }
       }
     }
   }

--- a/packages/core/src/context/filesystem-facts-update.ts
+++ b/packages/core/src/context/filesystem-facts-update.ts
@@ -38,7 +38,11 @@ export function updateFilesystemFactsFromToolResult(
   if (toolName.startsWith('filesense_')) {
     const data = result.data as
       | {
-          factsDelta?: { existingFiles?: string[]; existingDirectories?: string[] };
+          factsDelta?: {
+            existingFiles?: string[];
+            existingDirectories?: string[];
+            filesTruncated?: boolean;
+          };
           scanned?: { truncated?: boolean };
         }
       | undefined;
@@ -55,10 +59,20 @@ export function updateFilesystemFactsFromToolResult(
 
       // 目录清单：把扫描到的文件按父目录归组，供路径接地判断「这个文件名不存在」。
       //
-      // 只在 `truncated === false` 时记录。预算截断意味着清单是残缺的，
-      // 此时「不在清单里」不等于「不存在」——据此去改写一个本来正确的路径，
-      // 会把一个能跑通的步骤改坏。宁可不接地，不可接错地。
-      if (data?.scanned?.truncated === false) {
+      // 两个条件缺一不可，且它们管的是不同的事：
+      //
+      //   scanned.truncated === false   —— 扫描过程没触到 maxEntries、没超时
+      //   factsDelta.filesTruncated === false —— 扫到的文件都带回来了
+      //
+      // 曾经只查前者。engine 对 `factsDelta.existingFiles` 是无条件
+      // `slice(0, 200)`（超 maxBytes 时再压到 80），而这个裁剪**不会**置位
+      // `scanned.truncated`——于是扫描顺利完成的大目录会返回一份被悄悄截断的清单。
+      // 拿它去否定一个真实存在的路径，就会把一个本来能跑通的步骤改坏，
+      // 正是这套接地声称要避免的失效模式（#434 评审）。
+      //
+      // `filesTruncated === undefined` 视为不可信：老版本 engine 不报这个字段，
+      // 无从判断清单是否完整。宁可不接地，不可接错地。
+      if (data?.scanned?.truncated === false && data?.factsDelta?.filesTruncated === false) {
         const byDir = new Map<string, string[]>();
         for (const file of factsDelta.existingFiles ?? []) {
           const slash = file.lastIndexOf('/');

--- a/packages/core/src/executor/executor.ts
+++ b/packages/core/src/executor/executor.ts
@@ -127,6 +127,18 @@ export class Executor {
         return trace.finish(this.buildSkippedStepOutput(paramValidation.reason, startTime));
       }
 
+      // 路径接地必须发生在前置校验**之前**（#434 评审意见）。
+      //
+      // 幻觉 `read_file` 会被 `validateBeforeExecution` 里的 fileExistence 检查
+      // 判为 "does not exist"，随后 `getPreValidationSkip` 把整步 skip 掉并提前
+      // 返回——接地放在其后就永远执行不到，恰好在它唯一该起作用的那类步骤上失效。
+      // （这条 skip 分支返回 `success: true`，也正是 #432 里「幻觉步骤 ok 恒为 true」
+      // 的来源。）
+      //
+      // 就地改写 `step.params` 而不是只改一份副本：后续的校验、apply_patch 的
+      // auto-read、prepareToolParams 都读 `step.params`，只改副本会让它们各看各的路径。
+      this.groundStepPathInPlace(step);
+
       const preValidation = await trace.withStage('validate_before', () =>
         this.validateBeforeExecution(step, context),
       );
@@ -155,11 +167,6 @@ export class Executor {
       }
 
       let toolParams = { ...step.params };
-
-      // 路径接地（#434）：导航步骤是前插到一份已定路径的计划上的，导航结果此前
-      // 从不回改这些路径。这里拿导航枚举出的真实目录清单校正读取类步骤的文件名。
-      // 只在把握明确时改写；含糊即保持原样让它自然失败——见 path-grounding.ts。
-      toolParams = this.groundToolPath(step, toolParams);
 
       if (this.config.debug) {
         const stepAny = step as { needsCodeGeneration?: boolean };
@@ -533,45 +540,38 @@ export class Executor {
   }
 
   /**
-   * 只有「至少一项真实检查判定失败」才算校验拦截。
-   * `validateAfterExecution` 在工具自身报错时返回 results 为空的失败结果——
-   * 那是工具失败，不是拦截；两者混在同一事件里，`validation_failed`
-   * 就不能当拦截数用，而 #388 要的正是一个能计数的拦截量。
-   */
-  /**
-   * 用导航枚举出的真实目录清单校正步骤路径（#434）。
+   * 用导航枚举出的真实目录清单校正步骤路径，**就地改写 `step.params`**（#434）。
+   *
+   * 就地而不是返回副本：后续的前置校验、`apply_patch` 的 auto-read、
+   * `prepareToolParams` 全都读 `step.params`，只改副本会让它们各看各的路径。
    *
    * 拒绝的情形也要发事件。只统计成功校正会让「接地覆盖率」读成 100%，
    * 而被拒绝的那部分正是这套启发式的能力边界——那才是下一轮该改的东西。
    */
-  private groundToolPath(
-    step: ExecutionStep,
-    params: Record<string, unknown>,
-  ): Record<string, unknown> {
-    const path = params.path;
-    if (typeof path !== 'string' || !path) return params;
+  private groundStepPathInPlace(step: ExecutionStep): void {
+    const path = step.params.path;
+    if (typeof path !== 'string' || !path) return;
 
     const facts = this.config.getFileSystemFacts?.();
-    if (!facts) return params;
+    if (!facts) return;
 
     const outcome = groundStepPath(path, step.action, facts);
 
     if (outcome.corrected) {
-      this.debugLog(
-        `[Executor] 🧭 路径接地：${outcome.corrected.from} → ${outcome.corrected.to}（相似度 ${outcome.corrected.score}）`,
-      );
+      const { from, to, score, candidateCount } = outcome.corrected;
+      this.debugLog(`[Executor] 🧭 路径接地：${from} → ${to}（相似度 ${score}）`);
+      step.params.path = to;
       this.config.emitEvent?.({
         type: 'filesense_path_grounded',
         outcome: 'corrected',
         stepId: step.stepId,
         action: step.action,
-        from: outcome.corrected.from,
-        to: outcome.corrected.to,
-        score: outcome.corrected.score,
-        candidateCount:
-          facts.directoryContents.get(path.slice(0, path.lastIndexOf('/')))?.length ?? 0,
+        from,
+        to,
+        score,
+        candidateCount,
       });
-      return { ...params, path: outcome.corrected.to };
+      return;
     }
 
     if (outcome.declined) {
@@ -588,10 +588,14 @@ export class Executor {
         candidateCount: outcome.declined.candidates.length,
       });
     }
-
-    return params;
   }
 
+  /**
+   * 只有「至少一项真实检查判定失败」才算校验拦截。
+   * `validateAfterExecution` 在工具自身报错时返回 results 为空的失败结果——
+   * 那是工具失败，不是拦截；两者混在同一事件里，`validation_failed`
+   * 就不能当拦截数用，而 #388 要的正是一个能计数的拦截量。
+   */
   private emitValidationFailed(
     stage: 'pre_execution' | 'post_write',
     validation: ValidationResult,

--- a/packages/core/src/executor/executor.ts
+++ b/packages/core/src/executor/executor.ts
@@ -2,6 +2,7 @@ import { existsSync, statSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import type { AgentTask, ExecutionStep, StepResult, ValidationResult } from '@frontagent/shared';
 import { logger } from '@frontagent/shared';
+import { groundStepPath } from '../filesense/path-grounding.js';
 import {
   createDefaultExecutorSkillRegistry,
   type ExecutorActionSkill,
@@ -154,6 +155,11 @@ export class Executor {
       }
 
       let toolParams = { ...step.params };
+
+      // 路径接地（#434）：导航步骤是前插到一份已定路径的计划上的，导航结果此前
+      // 从不回改这些路径。这里拿导航枚举出的真实目录清单校正读取类步骤的文件名。
+      // 只在把握明确时改写；含糊即保持原样让它自然失败——见 path-grounding.ts。
+      toolParams = this.groundToolPath(step, toolParams);
 
       if (this.config.debug) {
         const stepAny = step as { needsCodeGeneration?: boolean };
@@ -532,6 +538,60 @@ export class Executor {
    * 那是工具失败，不是拦截；两者混在同一事件里，`validation_failed`
    * 就不能当拦截数用，而 #388 要的正是一个能计数的拦截量。
    */
+  /**
+   * 用导航枚举出的真实目录清单校正步骤路径（#434）。
+   *
+   * 拒绝的情形也要发事件。只统计成功校正会让「接地覆盖率」读成 100%，
+   * 而被拒绝的那部分正是这套启发式的能力边界——那才是下一轮该改的东西。
+   */
+  private groundToolPath(
+    step: ExecutionStep,
+    params: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const path = params.path;
+    if (typeof path !== 'string' || !path) return params;
+
+    const facts = this.config.getFileSystemFacts?.();
+    if (!facts) return params;
+
+    const outcome = groundStepPath(path, step.action, facts);
+
+    if (outcome.corrected) {
+      this.debugLog(
+        `[Executor] 🧭 路径接地：${outcome.corrected.from} → ${outcome.corrected.to}（相似度 ${outcome.corrected.score}）`,
+      );
+      this.config.emitEvent?.({
+        type: 'filesense_path_grounded',
+        outcome: 'corrected',
+        stepId: step.stepId,
+        action: step.action,
+        from: outcome.corrected.from,
+        to: outcome.corrected.to,
+        score: outcome.corrected.score,
+        candidateCount:
+          facts.directoryContents.get(path.slice(0, path.lastIndexOf('/')))?.length ?? 0,
+      });
+      return { ...params, path: outcome.corrected.to };
+    }
+
+    if (outcome.declined) {
+      this.debugLog(
+        `[Executor] 🧭 路径接地放弃：${outcome.declined.path}（${outcome.declined.reason}）`,
+      );
+      this.config.emitEvent?.({
+        type: 'filesense_path_grounded',
+        outcome: 'declined',
+        stepId: step.stepId,
+        action: step.action,
+        from: outcome.declined.path,
+        reason: outcome.declined.reason,
+        candidateCount: outcome.declined.candidates.length,
+      });
+    }
+
+    return params;
+  }
+
   private emitValidationFailed(
     stage: 'pre_execution' | 'post_write',
     validation: ValidationResult,

--- a/packages/core/src/executor/path-grounding-wiring.test.ts
+++ b/packages/core/src/executor/path-grounding-wiring.test.ts
@@ -1,0 +1,150 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { HallucinationGuard } from '@frontagent/hallucination-guard';
+import type { AgentTask, ExecutionStep } from '@frontagent/shared';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { updateFilesystemFactsFromToolResult } from '../context/filesystem-facts-update.js';
+import type { AgentEvent, ProjectFacts } from '../types.js';
+import { Executor } from './executor.js';
+import type { ExecutorConfig } from './types.js';
+
+/**
+ * 接线测试：路径接地必须在**真实的 executeStep 链路**上生效。
+ *
+ * 上一版把接地放在 `validateBeforeExecution` 之后，而幻觉 `read_file` 会被
+ * fileExistence 检查判成 "does not exist"、由 `getPreValidationSkip` 整步 skip 掉
+ * 并提前返回——接地在它唯一该起作用的那类步骤上永远执行不到。
+ *
+ * 当时的单测只覆盖 `groundStepPath` 这个纯函数，「端到端」验证也是直接调它，
+ * 绕开了 executeStep，所以恰好避开了这个最高风险的问题。纯函数测试证明不了接线。
+ */
+
+let root: string;
+let facts: ProjectFacts;
+
+function emptyFacts(): ProjectFacts {
+  return {
+    revision: 0,
+    filesystem: {
+      existingFiles: new Set(),
+      existingDirectories: new Set(),
+      nonExistentPaths: new Set(),
+      directoryContents: new Map(),
+    },
+    dependencies: { installedPackages: new Set(), missingPackages: new Set() },
+    project: { devServerRunning: false },
+  } as unknown as ProjectFacts;
+}
+
+/** 用 navigate 的真实返回形状喂事实层，而不是手搓 directoryContents */
+function feedNavigation(target: ProjectFacts, overrides: Record<string, unknown> = {}): void {
+  updateFilesystemFactsFromToolResult(target, 'filesense_navigate', {}, {
+    success: true,
+    data: {
+      scanned: { paths: ['src/features/checkout/lib'], depth: 2, entries: 3, truncated: false },
+      factsDelta: {
+        existingFiles: [
+          'src/features/checkout/lib/computeTotal.ts',
+          'src/features/checkout/lib/computeTotal.test.ts',
+          'src/features/checkout/lib/format.ts',
+        ],
+        existingDirectories: ['src/features/checkout/lib'],
+        filesTruncated: false,
+        directoriesTruncated: false,
+        ...overrides,
+      },
+    },
+  } as never);
+}
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'ground-wiring-'));
+  mkdirSync(join(root, 'src/features/checkout/lib'), { recursive: true });
+  for (const f of ['computeTotal.ts', 'computeTotal.test.ts', 'format.ts']) {
+    writeFileSync(join(root, 'src/features/checkout/lib', f), 'export {}\n');
+  }
+});
+
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+function makeExecutor(events: AgentEvent[], callTool: ReturnType<typeof vi.fn>) {
+  // 真的 guard，默认配置——fileExistence 开着，正是消融实验里的配置
+  const guard = new HallucinationGuard({ projectRoot: root });
+  const executor = new Executor({
+    projectRoot: root,
+    hallucinationGuard: guard as unknown as ExecutorConfig['hallucinationGuard'],
+    llmService: { name: 't', generateText: vi.fn(), generateObject: vi.fn() } as never,
+    getFileSystemFacts: () => facts.filesystem,
+    emitEvent: (e: AgentEvent) => events.push(e),
+  } as ExecutorConfig);
+
+  executor.registerMCPClient('file', {
+    callTool,
+    listTools: vi.fn().mockResolvedValue([]),
+  } as never);
+  executor.registerToolMapping('read_file', 'file');
+  return executor;
+}
+
+function readStep(path: string): ExecutionStep {
+  return {
+    stepId: 's1',
+    description: 'read',
+    action: 'read_file',
+    tool: 'read_file',
+    params: { path },
+    dependencies: [],
+    validation: [],
+    status: 'pending',
+    phase: 'preparation',
+  };
+}
+
+const task = { id: 't1', type: 'modify', description: 'x' } as AgentTask;
+
+describe('路径接地在 executeStep 链路上', () => {
+  it('corrects a hallucinated read before the existence check can skip it', async () => {
+    facts = emptyFacts();
+    feedNavigation(facts);
+
+    const events: AgentEvent[] = [];
+    const callTool = vi.fn().mockResolvedValue({ success: true, content: 'export {}' });
+    const executor = makeExecutor(events, callTool);
+
+    const step = readStep('src/features/checkout/lib/calculateTotal.ts');
+    const out = await executor.executeStep(step, { task, collectedContext: { files: new Map() } });
+
+    // 工具真的被以校正后的路径调用了——这是纯函数测试证明不了的部分
+    expect(callTool).toHaveBeenCalledTimes(1);
+    expect(callTool.mock.calls[0]?.[1]).toMatchObject({
+      path: 'src/features/checkout/lib/computeTotal.ts',
+    });
+    expect(out.stepResult.success).toBe(true);
+
+    const grounded = events.find((e) => e.type === 'filesense_path_grounded');
+    expect(grounded).toMatchObject({
+      outcome: 'corrected',
+      to: 'src/features/checkout/lib/computeTotal.ts',
+    });
+  });
+
+  // engine 对 factsDelta 是无条件 slice(0,200)，而该裁剪不置位 scanned.truncated。
+  // 拿一份被悄悄截断的清单去否定真实存在的路径，会把能跑通的步骤改坏。
+  it('never rewrites when the listing itself was truncated', async () => {
+    facts = emptyFacts();
+    feedNavigation(facts, { filesTruncated: true });
+
+    expect(facts.filesystem.directoryContents.size).toBe(0);
+
+    const events: AgentEvent[] = [];
+    const callTool = vi.fn().mockResolvedValue({ success: true, content: '' });
+    const executor = makeExecutor(events, callTool);
+
+    const step = readStep('src/features/checkout/lib/computeTotal.ts');
+    await executor.executeStep(step, { task, collectedContext: { files: new Map() } });
+
+    expect(step.params.path).toBe('src/features/checkout/lib/computeTotal.ts');
+    expect(events.some((e) => e.type === 'filesense_path_grounded')).toBe(false);
+  });
+});

--- a/packages/core/src/filesense/path-grounding.test.ts
+++ b/packages/core/src/filesense/path-grounding.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { groundStepPath, type PathGroundingFacts } from './path-grounding.js';
+
+function facts(dirs: Record<string, string[]>): PathGroundingFacts {
+  const directoryContents = new Map(Object.entries(dirs));
+  const existingFiles = new Set(Object.values(dirs).flat());
+  return { existingFiles, directoryContents };
+}
+
+const checkout = facts({
+  'src/features/checkout/lib': [
+    'src/features/checkout/lib/computeTotal.test.ts',
+    'src/features/checkout/lib/computeTotal.ts',
+    'src/features/checkout/lib/format.ts',
+  ],
+});
+
+describe('groundStepPath', () => {
+  // 2026-08-02 消融实验里实际出现的三个幻觉文件名，导航都看见了真实文件。
+  it.each([
+    ['src/features/checkout/lib/calculateTotal.ts', 'src/features/checkout/lib/computeTotal.ts'],
+  ])('corrects the hallucinated %s', (ghost, real) => {
+    const out = groundStepPath(ghost, 'read_file', checkout);
+    expect(out.path).toBe(real);
+    expect(out.corrected).toMatchObject({ from: ghost, to: real });
+  });
+
+  it('keeps a path that really exists', () => {
+    const p = 'src/features/checkout/lib/computeTotal.ts';
+    expect(groundStepPath(p, 'read_file', checkout)).toEqual({ path: p });
+  });
+
+  // create_file 的目标本来就不该存在。对它接地会把每一次新建改写成覆盖既有文件。
+  it('never touches create_file, whose target is supposed to be absent', () => {
+    const p = 'src/features/checkout/lib/truncate.ts';
+    expect(groundStepPath(p, 'create_file', checkout)).toEqual({ path: p });
+  });
+
+  // 目录没被完整枚举过时，「不在清单里」不等于「不存在」——预算截断就是这种情况。
+  it('declines when the directory was never fully enumerated', () => {
+    const noListing: PathGroundingFacts = {
+      existingFiles: new Set(),
+      directoryContents: new Map(),
+    };
+    const p = 'src/features/checkout/lib/calculateTotal.ts';
+    expect(groundStepPath(p, 'read_file', noListing)).toEqual({ path: p });
+  });
+
+  // 押一个次优候选，是把看得见的错误换成看不见的错误。
+  it('declines when no candidate shares a token with the guess', () => {
+    const entities = facts({
+      'src/entities/coupon/model': [
+        'src/entities/coupon/model/coupon.ts',
+        'src/entities/coupon/model/guards.ts',
+      ],
+    });
+    const p = 'src/entities/coupon/model/types.ts';
+    const out = groundStepPath(p, 'read_file', entities);
+    expect(out.path).toBe(p);
+    expect(out.corrected).toBeUndefined();
+    expect(out.declined?.reason).toBe('候选与原名无共同词元');
+  });
+
+  it('declines when two candidates score alike', () => {
+    const tie = facts({
+      'src/lib': ['src/lib/mergeLeft.ts', 'src/lib/mergeRight.ts'],
+    });
+    const out = groundStepPath('src/lib/mergeThing.ts', 'read_file', tie);
+    expect(out.corrected).toBeUndefined();
+    expect(out.declined?.reason).toBe('最佳候选未明显优于次佳');
+  });
+
+  // 实现文件不能被配到同名测试文件上。
+  it('does not match an implementation guess to a .test file', () => {
+    const out = groundStepPath('src/features/checkout/lib/computeTotals.ts', 'read_file', checkout);
+    expect(out.path).toBe('src/features/checkout/lib/computeTotal.ts');
+  });
+
+  it('matches a test-file guess only against test files', () => {
+    const out = groundStepPath(
+      'src/features/checkout/lib/calculateTotal.test.ts',
+      'read_file',
+      checkout,
+    );
+    expect(out.path).toBe('src/features/checkout/lib/computeTotal.test.ts');
+  });
+});

--- a/packages/core/src/filesense/path-grounding.ts
+++ b/packages/core/src/filesense/path-grounding.ts
@@ -1,0 +1,138 @@
+/**
+ * 路径接地：拿导航扫出来的真实目录清单，校正计划里猜出来的文件名。
+ *
+ * 为什么需要它（#434）。导航步骤是**前插**到一份已生成的计划上的
+ * （`planner-skills.ts` 的 `return [navigateStep, ...steps]`），计划里每一步的
+ * `path` 在导航跑之前就定死了，而导航产出只进 `filesenseContext` 供答案生成用，
+ * 没有任何一处回改步骤路径。
+ *
+ * 2026-08-02 消融实验实测：开臂每一条产生幻觉文件名的任务，导航都覆盖了
+ * 真实文件所在目录且未截断——真实文件名确实在输出里——计划仍然读了一个
+ * 不存在的同义词：
+ *
+ *     computeTotal.ts  ← 计划写 calculateTotal.ts
+ *     mergeLines.ts    ← 计划写 mergeCartItem.ts
+ *     estimateEta.ts   ← 计划写 estimateDeliveryDays.ts
+ *
+ * 关臂的幻觉是同一类。拿到答案的那一臂从不查阅它，所以开不开导航，
+ * 猜错的方式一模一样，通过率 4/12 对 4/12。
+ *
+ * ## 两条不可越过的边界
+ *
+ * **只校正读取类动作。** `create_file` 的目标本来就不该存在，对它接地会把
+ * 每一个新建都改写到一个既有文件上——把新增变成覆盖。
+ *
+ * **含糊时不改。** 匹配不明确就保持原样、让它自然失败。静默押一个次优候选，
+ * 就是把一个看得见的错误换成一个看不见的错误——本仓库反复栽在这上面
+ * （#386 #400 #403 #388 #415 #417 #432）。
+ */
+
+/** 会读取既有文件的动作。`create_file` 不在内且不能在内，理由见文件头。 */
+const READ_LIKE_ACTIONS = new Set(['read_file', 'apply_patch', 'get_ast']);
+
+export interface PathGroundingFacts {
+  existingFiles: Set<string>;
+  /** 目录 → 其下文件清单。只有完整枚举过（导航未截断）的目录才在这里。 */
+  directoryContents: Map<string, string[]>;
+}
+
+export interface PathGroundingOutcome {
+  /** 最终应当使用的路径；未改写时等于入参 */
+  path: string;
+  /** 发生了校正 */
+  corrected?: { from: string; to: string; score: number };
+  /** 判定为幻觉但没有足够把握校正——保持原样，把候选记下来供诊断 */
+  declined?: { path: string; reason: string; candidates: string[] };
+}
+
+function basename(path: string): string {
+  const slash = path.lastIndexOf('/');
+  return slash === -1 ? path : path.slice(slash + 1);
+}
+
+function dirname(path: string): string {
+  const slash = path.lastIndexOf('/');
+  return slash === -1 ? '.' : path.slice(0, slash);
+}
+
+/** 后缀含 `.test` / `.spec` 这类中缀时一并保留，避免把实现文件配到测试文件上 */
+function extension(name: string): string {
+  const dot = name.indexOf('.');
+  return dot === -1 ? '' : name.slice(dot);
+}
+
+/** camelCase / snake_case / kebab-case 一律拆成小写词元 */
+function tokenize(name: string): Set<string> {
+  const stem = name.slice(0, name.indexOf('.') === -1 ? undefined : name.indexOf('.'));
+  return new Set(
+    stem
+      .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+      .split(/[^A-Za-z0-9]+/)
+      .filter(Boolean)
+      .map((t) => t.toLowerCase()),
+  );
+}
+
+/** Jaccard 相似度：交集 / 并集。全等为 1，无共同词元为 0。 */
+function similarity(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let shared = 0;
+  for (const t of a) if (b.has(t)) shared += 1;
+  return shared / (a.size + b.size - shared);
+}
+
+/**
+ * 校正一个步骤路径。
+ *
+ * 只有同时满足下列条件才会改写：
+ * 1. 动作是读取类；
+ * 2. 该路径不在已确认存在的文件里；
+ * 3. 其父目录**被完整枚举过**（导航未截断），因而「不在清单里」才等于「不存在」；
+ * 4. 同目录下存在同后缀候选；
+ * 5. 最佳候选有共同词元，且明显优于次佳（≥1.5 倍）——并列即视为含糊。
+ */
+export function groundStepPath(
+  path: string,
+  action: string,
+  facts: PathGroundingFacts,
+): PathGroundingOutcome {
+  if (!READ_LIKE_ACTIONS.has(action)) return { path };
+  if (facts.existingFiles.has(path)) return { path };
+
+  const dir = dirname(path);
+  const listing = facts.directoryContents.get(dir);
+  // 没有完整清单就没有判定权：可能是没扫过，也可能是扫了但被预算截断。
+  // 两种情况都不能推断「不存在」。
+  if (!listing?.length) return { path };
+
+  const name = basename(path);
+  const ext = extension(name);
+  const wanted = tokenize(name);
+
+  const scored = listing
+    .filter((candidate) => candidate !== path && extension(basename(candidate)) === ext)
+    .map((candidate) => ({ candidate, score: similarity(wanted, tokenize(basename(candidate))) }))
+    .sort((a, b) => b.score - a.score);
+
+  if (!scored.length) {
+    return { path, declined: { path, reason: '同目录下无同后缀候选', candidates: listing } };
+  }
+
+  const [best, runnerUp] = scored;
+  const decisive = best.score > 0 && (!runnerUp || best.score >= runnerUp.score * 1.5);
+  if (!decisive) {
+    return {
+      path,
+      declined: {
+        path,
+        reason: best.score === 0 ? '候选与原名无共同词元' : '最佳候选未明显优于次佳',
+        candidates: scored.map((s) => s.candidate),
+      },
+    };
+  }
+
+  return {
+    path: best.candidate,
+    corrected: { from: path, to: best.candidate, score: Number(best.score.toFixed(3)) },
+  };
+}

--- a/packages/core/src/filesense/path-grounding.ts
+++ b/packages/core/src/filesense/path-grounding.ts
@@ -27,12 +27,30 @@
  * （#386 #400 #403 #388 #415 #417 #432）。
  */
 
-/** 会读取既有文件的动作。`create_file` 不在内且不能在内，理由见文件头。 */
-const READ_LIKE_ACTIONS = new Set(['read_file', 'apply_patch', 'get_ast']);
+/**
+ * 只读取、不落盘的动作。
+ *
+ * `create_file` 不在内且不能在内，理由见文件头。
+ *
+ * `apply_patch` 也**不在内**：它会落盘，且补丁原文取自
+ * `collectedContext.files`——那个 map 的键是**未接地**的路径
+ * （`executor.ts` 的 auto-read 用原路径写入）。把它接地要么让补丁生成
+ * 报「file not found in context」，要么在目标恰好已在上下文里时，
+ * 拿另一个文件的内容生成补丁并写进去。改错一个读取只是白读一次，
+ * 改错一个补丁是数据损坏。
+ */
+const READ_LIKE_ACTIONS = new Set(['read_file', 'get_ast']);
 
 export interface PathGroundingFacts {
   existingFiles: Set<string>;
-  /** 目录 → 其下文件清单。只有完整枚举过（导航未截断）的目录才在这里。 */
+  /**
+   * 目录 → 其下文件清单。
+   *
+   * 只有**完整枚举过**的目录才会出现在这里：导航既没有被扫描预算截断
+   * （`scanned.truncated === false`），返回的清单也没有被定长裁剪
+   * （`factsDelta.filesTruncated === false`）。两个条件缺一不可——
+   * 前者管「扫完了没」，后者管「扫到的都带回来了没」。
+   */
   directoryContents: Map<string, string[]>;
 }
 
@@ -40,7 +58,7 @@ export interface PathGroundingOutcome {
   /** 最终应当使用的路径；未改写时等于入参 */
   path: string;
   /** 发生了校正 */
-  corrected?: { from: string; to: string; score: number };
+  corrected?: { from: string; to: string; score: number; candidateCount: number };
   /** 判定为幻觉但没有足够把握校正——保持原样，把候选记下来供诊断 */
   declined?: { path: string; reason: string; candidates: string[] };
 }
@@ -133,6 +151,11 @@ export function groundStepPath(
 
   return {
     path: best.candidate,
-    corrected: { from: path, to: best.candidate, score: Number(best.score.toFixed(3)) },
+    corrected: {
+      from: path,
+      to: best.candidate,
+      score: Number(best.score.toFixed(3)),
+      candidateCount: scored.length,
+    },
   };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -812,6 +812,25 @@ export type AgentEvent =
       candidateCount: number;
       warnings?: string[];
     }
+  /**
+   * 计划里的文件路径被导航枚举出的真实目录清单校正（issue #434）。
+   *
+   * `outcome` 是必要的判别字段：`corrected` 与 `declined` 的含义相反——
+   * 前者是「猜错了并已改对」，后者是「判定猜错但没把握改，保持原样」。
+   * 只发 corrected 的话，「接地覆盖率」会被读成 100%，而实际漏掉的那部分
+   * 恰恰是这套启发式的能力边界所在。
+   */
+  | {
+      type: 'filesense_path_grounded';
+      outcome: 'corrected' | 'declined';
+      stepId: string;
+      action: string;
+      from: string;
+      to?: string;
+      score?: number;
+      reason?: string;
+      candidateCount: number;
+    }
   | { type: 'planning_completed'; plan: ExecutionPlan }
   | { type: 'phase_started'; phase: string; stepCount: number }
   | { type: 'phase_completed'; phase: string; successCount: number; failureCount: number }

--- a/packages/mcp-filesense/src/engine-facts-delta.test.ts
+++ b/packages/mcp-filesense/src/engine-facts-delta.test.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { navigate } from './engine.js';
+
+/**
+ * `factsDelta` 的跨包契约：清单**是否被裁剪**必须如实上报。
+ *
+ * 消费方（core 的 path-grounding）据此决定敢不敢把「不在清单里」读作
+ * 「文件不存在」，进而改写计划里的路径。拿一份被悄悄截断的清单去否定
+ * 一个真实存在的路径，会把本来能跑通的步骤改坏。
+ *
+ * 关键区别：`scanned.truncated` 只反映扫描有没有触到 maxEntries / 超时，
+ * 与这里的定长裁剪**无关**——扫描顺利完成时，超过 200 条的目录照样被切尾。
+ */
+
+const roots: string[] = [];
+
+function makeRepo(fileCount: number): string {
+  // macOS 的 /var 是指向 /private/var 的符号链接，不规范化会撞边界检查
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'facts-delta-')));
+  roots.push(root);
+  mkdirSync(join(root, 'src'), { recursive: true });
+  for (let i = 0; i < fileCount; i++) {
+    writeFileSync(join(root, 'src', `mod${String(i).padStart(4, '0')}.ts`), 'export {}\n');
+  }
+  return root;
+}
+
+afterEach(() => {
+  while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+describe('factsDelta 裁剪契约', () => {
+  it('reports an unabridged listing as untruncated', async () => {
+    const root = makeRepo(5);
+
+    const result = await navigate(root, { boundary: root, paths: ['src'], maxEntries: 1000 });
+
+    expect(result.factsDelta.filesTruncated).toBe(false);
+    expect(result.factsDelta.directoriesTruncated).toBe(false);
+    expect(result.factsDelta.existingFiles.length).toBe(5);
+  });
+
+  // 这条是本契约存在的理由：扫描本身没被截断，清单却被切掉了尾巴。
+  // 只看 scanned.truncated 的消费方会把这份残缺清单当成完整枚举。
+  it('flags the 200-entry slice even when the scan itself completed', async () => {
+    const root = makeRepo(260);
+
+    const result = await navigate(root, { boundary: root, paths: ['src'], maxEntries: 5000 });
+
+    expect(result.scanned.truncated).toBe(false);
+    expect(result.factsDelta.existingFiles.length).toBe(200);
+    expect(result.factsDelta.filesTruncated).toBe(true);
+  });
+
+  it('flags the further compaction applied past maxBytes', async () => {
+    const root = makeRepo(150);
+
+    const result = await navigate(root, {
+      boundary: root,
+      paths: ['src'],
+      maxEntries: 5000,
+      maxBytes: 2048,
+    });
+
+    expect(result.factsDelta.existingFiles.length).toBeLessThanOrEqual(80);
+    expect(result.factsDelta.filesTruncated).toBe(true);
+  });
+});

--- a/packages/mcp-filesense/src/engine.ts
+++ b/packages/mcp-filesense/src/engine.ts
@@ -628,6 +628,42 @@ function detectProjectType(indexes: IndexFile[]): string | undefined {
   return undefined;
 }
 
+/** `factsDelta` 每类最多返回的条目数 */
+const FACTS_DELTA_LIMIT = 200;
+/** 超出 `maxBytes` 后进一步压缩到的条目数 */
+const FACTS_DELTA_COMPACT_LIMIT = 80;
+
+/**
+ * 构造 `factsDelta`，并**显式记录清单是否被裁剪**。
+ *
+ * `scanned.truncated` 只反映扫描过程有没有触到 maxEntries / 超时，与这里的
+ * 定长裁剪完全无关：扫描顺利完成（`truncated: false`）时，超过 200 条的目录
+ * 依然会被切掉尾巴。
+ *
+ * 消费方据此判断「不在清单里 ⇒ 文件不存在」时，这个区别是决定性的——
+ * 拿一份被悄悄截断的清单去否定一个真实存在的路径，会把正确的步骤改错
+ * （见 core 的 path-grounding 与 issue #434 的评审意见）。
+ */
+function buildFactsDelta(allChildren: Array<{ type: string; path: string }>): {
+  existingFiles: string[];
+  existingDirectories: string[];
+  filesTruncated: boolean;
+  directoriesTruncated: boolean;
+} {
+  const uniquePaths = (type: string) =>
+    Array.from(new Set(allChildren.filter((child) => child.type === type).map((c) => c.path)));
+
+  const files = uniquePaths('file');
+  const dirs = uniquePaths('dir');
+
+  return {
+    existingFiles: files.slice(0, FACTS_DELTA_LIMIT),
+    existingDirectories: dirs.slice(0, FACTS_DELTA_LIMIT),
+    filesTruncated: files.length > FACTS_DELTA_LIMIT,
+    directoriesTruncated: dirs.length > FACTS_DELTA_LIMIT,
+  };
+}
+
 export async function navigate(
   targetPath: string,
   options: NavigateOptions = {},
@@ -779,14 +815,7 @@ export async function navigate(
         : [],
     },
     candidates,
-    factsDelta: {
-      existingFiles: Array.from(
-        new Set(allChildren.filter((child) => child.type === 'file').map((child) => child.path)),
-      ).slice(0, 200),
-      existingDirectories: Array.from(
-        new Set(allChildren.filter((child) => child.type === 'dir').map((child) => child.path)),
-      ).slice(0, 200),
-    },
+    factsDelta: buildFactsDelta(allChildren),
     warnings,
   };
 
@@ -800,8 +829,22 @@ export async function navigate(
       `Navigation result exceeded maxBytes=${maxBytes}; returning compact summary.`,
     );
     result.candidates = result.candidates.slice(0, 10);
-    result.factsDelta.existingFiles = result.factsDelta.existingFiles.slice(0, 80);
-    result.factsDelta.existingDirectories = result.factsDelta.existingDirectories.slice(0, 80);
+    // 二次裁剪同样要如实反映到标志上，否则消费方会把一份 80 条的残缺清单
+    // 当作完整枚举，据此否定一个真实存在的路径。
+    result.factsDelta.filesTruncated =
+      result.factsDelta.filesTruncated ||
+      result.factsDelta.existingFiles.length > FACTS_DELTA_COMPACT_LIMIT;
+    result.factsDelta.directoriesTruncated =
+      result.factsDelta.directoriesTruncated ||
+      result.factsDelta.existingDirectories.length > FACTS_DELTA_COMPACT_LIMIT;
+    result.factsDelta.existingFiles = result.factsDelta.existingFiles.slice(
+      0,
+      FACTS_DELTA_COMPACT_LIMIT,
+    );
+    result.factsDelta.existingDirectories = result.factsDelta.existingDirectories.slice(
+      0,
+      FACTS_DELTA_COMPACT_LIMIT,
+    );
     result.indexes = undefined;
   }
 

--- a/packages/mcp-filesense/src/types.ts
+++ b/packages/mcp-filesense/src/types.ts
@@ -135,6 +135,18 @@ export interface NavigateResult {
   factsDelta: {
     existingFiles: string[];
     existingDirectories: string[];
+    /**
+     * 清单是否被定长裁剪。
+     *
+     * **与 `scanned.truncated` 是两回事**：后者只反映扫描有没有触到
+     * maxEntries / 超时，而这里的裁剪在扫描顺利完成时也会发生（每类 200 条，
+     * 超 maxBytes 时再压到 80）。
+     *
+     * 任何把「不在清单里」读作「文件不存在」的消费方都必须先看这两个标志，
+     * 否则会拿一份残缺清单去否定真实存在的路径。
+     */
+    filesTruncated: boolean;
+    directoriesTruncated: boolean;
   };
   warnings: string[];
   indexes?: IndexFile[];


### PR DESCRIPTION
修 #434。消融实验测出零效应的根因是接线方式，不是能力强弱——这个 PR 改接线。

## 问题

`planner-skills.ts` 的 `return [navigateStep, ...steps]`：导航步骤前插到一份**路径已定死**的计划上。导航产出只进 `filesenseContext` 供答案生成用，**没有任何一处回改步骤路径**。

2026-08-02 消融实验（12 任务 × 2 臂，各 12/12 跑完）实测：开臂每一条产生幻觉文件名的任务，导航都覆盖了真实文件所在目录且 `truncated: false`，计划仍然读了一个不存在的同义词。

| 导航看见了 | 计划却读了 |
|---|---|
| `computeTotal.ts` | `calculateTotal.ts` |
| `mergeLines.ts` | `mergeCartItem.ts` |
| `estimateEta.ts` | `estimateDeliveryDays.ts` |

两臂幻觉同型，通过率 4/12 对 4/12。**拿着答案的那一臂从不查阅它。**

## 改动

执行读取类步骤前，用导航枚举出的目录清单校正 `params.path`。

三条边界比匹配算法本身更重要：

1. **`create_file` 绝不接地。** 它的目标本来就不该存在，接地会把每一次新建改写成对邻近既有文件的覆盖。
2. **只有未被预算截断的导航才有判定权。** 截断的清单分不清「不存在」和「没扫到」，据此改写会把本来正确的路径改错。
3. **含糊就不改。** 候选须有共同词元且优于次佳 1.5 倍，否则保持原样自然失败。把看得见的错误换成看不见的错误，是本仓库反复栽的坑（#386 #400 #403 #388 #415 #417 #432）。

放弃校正**也发事件**（`outcome: 'declined'`）。只统计成功校正会让接地覆盖率读成 100%，而被放弃的那部分正是这套启发式的边界所在。

## Impact Scope

`packages/core`（新增 filesense/path-grounding、executor 接入、facts 目录清单、事件类型）+ `apps/desktop` reducer 穷尽分支。

## GitNexus Impact Summary

- Risk level: MEDIUM——改写工具入参会影响执行结果，但改写受三条边界约束且默认保守（无清单即不动）。
- Critical skeleton changes: `packages/core/src/executor/executor.ts`、`packages/core/src/types.ts`（事件联合类型）。
- GitNexus impact: 新增事件类型 `filesense_path_grounded` 为**联合新增分支**，桌面端 reducer 已补穷尽处理；无既有事件形状变更，下游消费方不受影响。事实层新增的 `directoryContents` 填充只在 `truncated === false` 时发生，不改变既有字段语义。
- Verification: `pnpm quality:precommit` exit 0；新增 8 条单测；另跑编译产物端到端验证（见下）。

## Verification

- `pnpm quality:precommit` — exit 0。
- `path-grounding.test.ts` 8 条全绿，覆盖三条拒绝分支与 `create_file` 豁免。
- 端到端（走 `dist/`，非单测桩）：把 navigate 的真实返回形状喂进 `updateFilesystemFactsFromToolResult`，再过接地——

```
实测幻觉 calculateTotal.ts  read_file    校正→ computeTotal.ts (0.333)
真实路径                    read_file    原样
新建 truncate.ts            create_file  原样
未扫过的目录                 read_file    原样
truncated=true 时           read_file    未改写 ✅
```

## 尚未验证的部分

**本 PR 不声称提升通过率。** 消融重跑在合入后进行，结果无论正负都会写进 `benchmarks/results/`。当前证据只到「接地在真实链路上按预期改写了实测幻觉」。

## Checklist

- [x] I have linked an issue or explained why this PR stands alone.
- [x] I have kept the diff focused on the stated change.
- [x] I have run `pnpm quality:precommit`, or explained why it could not run.
- [x] I have run `pnpm quality:local` for critical skeleton changes, or explained why it could not run.
- [x] I have updated docs or tests when behavior, public APIs, or Harness contracts changed.
- [x] For critical skeleton changes, I have filled the GitNexus impact summary with concrete results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
